### PR TITLE
security: edge-auth マーカースプーフィング防止 / path_patterns.contains 大文字正規化 / tokenHeaderName 小文字化

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -16,6 +16,9 @@
 - CloudFront Functions / Cloudflare Workers の `static_token` および `basic_auth` 照合を constant-time 比較に置き換え、タイミング攻撃耐性を確保。
 - レガシーの `CFG.adminGate` 二重評価経路を削除。認証は `CFG.authGates` に一本化。
 - `policy-lint` は `policy/schema.json` を ajv で強制するようになり、従来のクロスフィールド検証（JWT / 署名付き URL など）と併用する。
+- **edge-auth マーカーのスプーフィング対策**: AWS CloudFront Functions ハンドラおよび Cloudflare Workers ハンドラの双方で、クライアントから送られてきた `x-edge-authenticated` ヘッダをリクエスト入口 / オリジン転送前に必ず剥ぎ取るようにした。従来はクライアントが未認証リクエストにこのヘッダを付与するだけで、下流が認証済みと誤認する余地があった。
+- **`path_patterns.contains` の大文字小文字正規化**: `contains` エントリをビルド時に小文字化するようにした。ランタイム側は URI を `toLowerCase()` してから `includes()` で比較するため、ポリシーに `%2E%2E` のような大文字エントリを書いても絶対にマッチしない silent downgrade が発生していた。regex 拒否と同種の silent-downgrade を両形式で塞ぐ。
+- **`auth_gate.header` の小文字化**: CloudFront Functions ではヘッダキーが小文字でしか見えないため、生成コードの `tokenHeaderName` を強制的に小文字化する。ポリシーで `header: X-Edge-Token` と書かれていた場合、従来は `req.headers[...]` のルックアップが常に undefined となり、正規リクエストまで拒否される不具合があった。
 
 ### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CloudFront Functions and Cloudflare Workers now compare `static_token` / `basic_auth` credentials with a constant-time equality helper to mitigate timing side-channels.
 - Removed the legacy `CFG.adminGate` double-evaluation path. Auth is driven exclusively by `CFG.authGates`.
 - `policy-lint` now validates policies against `policy/schema.json` via ajv, in addition to the existing cross-field auth-gate checks.
+- **Edge-auth marker spoofing**: both the AWS CloudFront Functions handler and the Cloudflare Workers handler now strip any client-supplied `x-edge-authenticated` header at request entry / before forwarding to origin. Previously a client could set this header on an unauthenticated request and trick downstream code into trusting it.
+- **`path_patterns.contains` case-normalization**: `contains` entries are lowercased at compile time. The runtime lowercases the URI before calling `includes()`, so uppercase policy entries like `%2E%2E` used to silently never match. This is the same silent-downgrade class as the regex reject; now both forms are normalized.
+- **`auth_gate.header` case-normalization**: CloudFront Functions expose header keys in lowercase only, so the compiled `tokenHeaderName` is forced to lowercase. Policies that set `header: X-Edge-Token` previously caused every authenticated lookup to return `undefined` and reject valid requests.
 
 ### Added
 

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -50,12 +50,13 @@ test('parsePathPatterns returns defaults when unset or empty', () => {
   assert.deepStrictEqual(parsePathPatterns([]), { contains: DEFAULT_CONTAINS.slice(), regexSources: [] });
 });
 
-test('parsePathPatterns expands known legacy regex entries as contains', () => {
+test('parsePathPatterns expands known legacy regex entries as contains (lowercased)', () => {
   const { contains, regexSources } = parsePathPatterns(['(?i)\\.{2}/', '(?i)%2e%2e']);
   assert.ok(contains.includes('/../'));
   assert.ok(contains.includes('..'));
   assert.ok(contains.includes('%2e%2e'));
-  assert.ok(contains.includes('%2E%2E'));
+  // Runtime lowercases the URI before `includes()`, so we only need the lower form.
+  assert.ok(contains.every((c) => c === c.toLowerCase()));
   assert.deepStrictEqual(regexSources, []);
 });
 
@@ -103,6 +104,15 @@ test('parsePathPatterns rejects regex-like entries under object-form contains', 
   );
 });
 
+test('parsePathPatterns lowercases contains entries so uppercase policy survives runtime toLowerCase', () => {
+  const fromObject = parsePathPatterns({ contains: ['%2E%2E', '/INTERNAL/'], regex: [] });
+  assert.deepStrictEqual(fromObject.contains, ['%2e%2e', '/internal/']);
+
+  const fromLegacy = parsePathPatterns(['/INTERNAL/', '(?i)\\.{2}/']);
+  assert.ok(fromLegacy.contains.includes('/internal/'), 'plain upper entry normalized');
+  assert.ok(fromLegacy.contains.every((c) => c === c.toLowerCase()), 'mapped entries normalized');
+});
+
 test('regexesLiteralCode emits real RegExp literals with flags', () => {
   assert.strictEqual(regexesLiteralCode([]), '[]');
   const code = regexesLiteralCode(['(?i)\\.git/', '\\.env$']);
@@ -135,6 +145,24 @@ test('getAuthGates resolves static_token env', () => {
       token: 'secret-token',
       tokenIsPlaceholder: false,
     });
+  });
+});
+
+test('getAuthGates forces tokenHeaderName to lowercase for CFF compatibility', () => {
+  withEnv('CUSTOM_EDGE_TOKEN', 'secret-token', () => {
+    const policy = {
+      routes: [{
+        name: 'admin',
+        match: { path_prefixes: ['/admin'] },
+        auth_gate: {
+          type: 'static_token',
+          header: 'X-Edge-Token',
+          token_env: 'CUSTOM_EDGE_TOKEN',
+        },
+      }],
+    };
+    const gates = getAuthGates(policy);
+    assert.strictEqual(gates[0].tokenHeaderName, 'x-edge-token');
   });
 });
 

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -7,7 +7,7 @@ const DEFAULT_CONTAINS = ['/../', '%2e%2e', '%2f..', '..%2f', '%5c'];
 
 const LEGACY_KNOWN_MAP = {
   '(?i)\\.{2}/': { contains: ['/../', '..'] },
-  '(?i)%2e%2e': { contains: ['%2e%2e', '%2E%2E'] },
+  '(?i)%2e%2e': { contains: ['%2e%2e'] },
 };
 
 function parseArgs(argv, rootDir = repoRoot) {
@@ -85,7 +85,9 @@ function parsePathPatterns(pathPatterns) {
       if (!s) continue;
       const mapped = LEGACY_KNOWN_MAP[s];
       if (mapped) {
-        if (mapped.contains) mapped.contains.forEach((m) => contains.add(m));
+        // Runtime lowercases the URI before `includes()`, so contains entries
+        // must also be lowercase or they never match.
+        if (mapped.contains) mapped.contains.forEach((m) => contains.add(m.toLowerCase()));
         if (mapped.regex) mapped.regex.forEach((m) => regexSources.push(m));
         continue;
       }
@@ -96,7 +98,7 @@ function parsePathPatterns(pathPatterns) {
           'literal substrings under `path_patterns.contains: [...]`.',
         );
       }
-      contains.add(s);
+      contains.add(s.toLowerCase());
     }
     if (contains.size === 0 && regexSources.length === 0) {
       return { contains: DEFAULT_CONTAINS.slice(), regexSources: [] };
@@ -121,7 +123,9 @@ function parsePathPatterns(pathPatterns) {
           'or escape the metacharacters if you genuinely want a literal substring.',
         );
       }
-      contains.push(s);
+      // Runtime lowercases the URI before `includes()`, so contains entries
+      // must also be lowercase or they never match. Normalize at build time.
+      contains.push(s.toLowerCase());
     }
     // Validate each regex compiles successfully at build time.
     for (const src of regexSources) {
@@ -232,7 +236,11 @@ function getAuthGates(policy, options = {}) {
     };
 
     if (authType === 'static_token') {
-      const header = gate.header || 'x-edge-token';
+      // CloudFront Functions only expose header keys in lowercase form, so
+      // force the configured name to lowercase to avoid a silent mismatch
+      // (e.g. policy says `X-Edge-Token`, runtime lookup `req.headers[...]`
+      // returns undefined and every authenticated call fails).
+      const header = (gate.header || 'x-edge-token').toLowerCase();
       const tokenEnv = gate.token_env || 'EDGE_ADMIN_TOKEN';
       const resolved = env[tokenEnv];
       const token = resolved != null && resolved !== ''

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -106,6 +106,40 @@ for (const [name, event, expected] of cases) {
 
 console.log('--- viewer-request: ' + (cases.length - viewerFailed) + '/' + cases.length + ' passed ---');
 
+// x-edge-authenticated spoofing defense: the handler MUST strip any
+// client-supplied value before the origin sees it. If the caller does not
+// also supply a valid token the request must still fail auth.
+(function runEdgeAuthSpoofingTests() {
+  const spoofEvent = buildEvent('GET', '/admin', {
+    'user-agent': 'Mozilla',
+    'x-edge-authenticated': '1',
+  });
+  const result = handler(spoofEvent);
+  const blocked = result && result.statusCode === 401;
+  if (!blocked) {
+    console.error('FAIL: spoofed x-edge-authenticated on /admin should still 401, got', result && result.statusCode);
+    viewerFailed++;
+  } else {
+    console.log('OK: spoofed x-edge-authenticated on /admin still blocked (401)');
+  }
+
+  const passEvent = buildEvent('GET', '/not-protected', {
+    'user-agent': 'Mozilla',
+    'x-edge-authenticated': 'totally-fake',
+  });
+  const passResult = handler(passEvent);
+  const headerStripped = passResult
+    && passResult.uri !== undefined
+    && passResult.headers
+    && !passResult.headers['x-edge-authenticated'];
+  if (!headerStripped) {
+    console.error('FAIL: x-edge-authenticated leaked through on non-protected path', passResult && passResult.headers);
+    viewerFailed++;
+  } else {
+    console.log('OK: x-edge-authenticated stripped from incoming request');
+  }
+})();
+
 // =========================================================================
 // Section 1b: viewer-request.js monitor mode tests
 // =========================================================================

--- a/templates/aws/viewer-request.js
+++ b/templates/aws/viewer-request.js
@@ -222,7 +222,14 @@
   function handler(event) {
     const req = event.request;
 
-    // 0) CORS preflight handling
+    // 0a) Strip any client-supplied edge-auth marker. Only the edge itself is
+    //     allowed to set this; trusting an incoming value would let a client
+    //     spoof authenticated state to the origin.
+    if (req.headers) {
+      delete req.headers['x-edge-authenticated'];
+    }
+
+    // 0b) CORS preflight handling
     const preflight = handleCorsPreflight(req);
     if (preflight) return preflight;
 

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -349,6 +349,10 @@ export default {
     }
 
     const forwardHeaders = new Headers(request.headers);
+    // Strip any client-supplied edge-auth marker before forwarding to origin.
+    // Only the edge is allowed to assert this; trusting an incoming value
+    // would let a client spoof authenticated state.
+    forwardHeaders.delete('x-edge-authenticated');
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';
       if (secret) {

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -14,7 +14,7 @@ const CFG = {
   maxHeaderSize: 0,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -378,6 +378,10 @@ export default {
     }
 
     const forwardHeaders = new Headers(request.headers);
+    // Strip any client-supplied edge-auth marker before forwarding to origin.
+    // Only the edge is allowed to assert this; trusting an incoming value
+    // would let a client spoof authenticated state.
+    forwardHeaders.delete('x-edge-authenticated');
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';
       if (secret) {

--- a/tests/golden/base/edge/viewer-request.js
+++ b/tests/golden/base/edge/viewer-request.js
@@ -26,7 +26,7 @@ const CFG = {
   maxUriLength: 2048,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -236,7 +236,14 @@ const CFG = {
   function handler(event) {
     const req = event.request;
 
-    // 0) CORS preflight handling
+    // 0a) Strip any client-supplied edge-auth marker. Only the edge itself is
+    //     allowed to set this; trusting an incoming value would let a client
+    //     spoof authenticated state to the origin.
+    if (req.headers) {
+      delete req.headers['x-edge-authenticated'];
+    }
+
+    // 0b) CORS preflight handling
     const preflight = handleCorsPreflight(req);
     if (preflight) return preflight;
 

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -14,7 +14,7 @@ const CFG = {
   maxHeaderSize: 0,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -378,6 +378,10 @@ export default {
     }
 
     const forwardHeaders = new Headers(request.headers);
+    // Strip any client-supplied edge-auth marker before forwarding to origin.
+    // Only the edge is allowed to assert this; trusting an incoming value
+    // would let a client spoof authenticated state.
+    forwardHeaders.delete('x-edge-authenticated');
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';
       if (secret) {

--- a/tests/golden/profiles/balanced/edge/viewer-request.js
+++ b/tests/golden/profiles/balanced/edge/viewer-request.js
@@ -26,7 +26,7 @@ const CFG = {
   maxUriLength: 2048,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -236,7 +236,14 @@ const CFG = {
   function handler(event) {
     const req = event.request;
 
-    // 0) CORS preflight handling
+    // 0a) Strip any client-supplied edge-auth marker. Only the edge itself is
+    //     allowed to set this; trusting an incoming value would let a client
+    //     spoof authenticated state to the origin.
+    if (req.headers) {
+      delete req.headers['x-edge-authenticated'];
+    }
+
+    // 0b) CORS preflight handling
     const preflight = handleCorsPreflight(req);
     if (preflight) return preflight;
 

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -14,7 +14,7 @@ const CFG = {
   maxHeaderSize: 0,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -378,6 +378,10 @@ export default {
     }
 
     const forwardHeaders = new Headers(request.headers);
+    // Strip any client-supplied edge-auth marker before forwarding to origin.
+    // Only the edge is allowed to assert this; trusting an incoming value
+    // would let a client spoof authenticated state.
+    forwardHeaders.delete('x-edge-authenticated');
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';
       if (secret) {

--- a/tests/golden/profiles/permissive/edge/viewer-request.js
+++ b/tests/golden/profiles/permissive/edge/viewer-request.js
@@ -26,7 +26,7 @@ const CFG = {
   maxUriLength: 4096,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e"],
   blockPathRegexes: [],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -236,7 +236,14 @@ const CFG = {
   function handler(event) {
     const req = event.request;
 
-    // 0) CORS preflight handling
+    // 0a) Strip any client-supplied edge-auth marker. Only the edge itself is
+    //     allowed to set this; trusting an incoming value would let a client
+    //     spoof authenticated state to the origin.
+    if (req.headers) {
+      delete req.headers['x-edge-authenticated'];
+    }
+
+    // 0b) CORS preflight handling
     const preflight = handleCorsPreflight(req);
     if (preflight) return preflight;
 

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -14,7 +14,7 @@ const CFG = {
   maxHeaderSize: 0,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests","zgrab","nmap","curl","wget","scanner"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e","%2e%2e"],
   blockPathRegexes: [/%2f\.\.\//i, /\.\.%2f/i, /\\\.\.\\/i],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -378,6 +378,10 @@ export default {
     }
 
     const forwardHeaders = new Headers(request.headers);
+    // Strip any client-supplied edge-auth marker before forwarding to origin.
+    // Only the edge is allowed to assert this; trusting an incoming value
+    // would let a client spoof authenticated state.
+    forwardHeaders.delete('x-edge-authenticated');
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';
       if (secret) {

--- a/tests/golden/profiles/strict/edge/viewer-request.js
+++ b/tests/golden/profiles/strict/edge/viewer-request.js
@@ -26,7 +26,7 @@ const CFG = {
   maxUriLength: 1024,
   dropQueryKeys: new Set(["utm_source","utm_medium","utm_campaign","utm_term","utm_content","gclid","fbclid"]),
   uaDenyContains: ["sqlmap","nikto","acunetix","masscan","python-requests","zgrab","nmap","curl","wget","scanner"],
-  blockPathContains: ["/../","..","%2e%2e","%2E%2E"],
+  blockPathContains: ["/../","..","%2e%2e","%2e%2e"],
   blockPathRegexes: [/%2f\.\.\//i, /\.\.%2f/i, /\\\.\.\\/i],
   normalizePath: { collapseSlashes: false, removeDotSegments: false },
   requiredHeaders: ["user-agent"],
@@ -236,7 +236,14 @@ const CFG = {
   function handler(event) {
     const req = event.request;
 
-    // 0) CORS preflight handling
+    // 0a) Strip any client-supplied edge-auth marker. Only the edge itself is
+    //     allowed to set this; trusting an incoming value would let a client
+    //     spoof authenticated state to the origin.
+    if (req.headers) {
+      delete req.headers['x-edge-authenticated'];
+    }
+
+    // 0b) CORS preflight handling
     const preflight = handleCorsPreflight(req);
     if (preflight) return preflight;
 


### PR DESCRIPTION
## Summary

PR #1 (Codex P2) で `path_patterns` の silent downgrade を塞いだ流れで、同じクラスの落とし穴がテンプレート / compile-core に他にも残っていたため、3 件まとめて修正。

### 1. `x-edge-authenticated` クライアントスプーフィング (HIGH)
- **問題**: CFF は認証成功時に `req.headers["x-edge-authenticated"] = "1"` を付けてオリジンへ渡すが、入口で入力側の同ヘッダを剥いでいなかった。クライアントが自分で `x-edge-authenticated: 1` を付与するだけで、認証ゲートを通っていないのに origin 側で「edge 認証済み」と誤認する余地があった。Cloudflare Workers も同様に素通しで forward していた。
- **修正**: AWS CFF ハンドラ冒頭で `delete req.headers['x-edge-authenticated']`、CF Workers では origin 転送前に `forwardHeaders.delete('x-edge-authenticated')`。

### 2. `path_patterns.contains` の大文字エントリが silent にマッチしない (MEDIUM)
- **問題**: ランタイムは URI を `toLowerCase()` してから `includes()` で比較する。ポリシーに `%2E%2E` のような大文字エントリを書いても絶対マッチしない。P2 と同種の silent downgrade。
- **修正**: `parsePathPatterns` で legacy 配列 / object 形 / `LEGACY_KNOWN_MAP` 経由すべてを build 時に小文字化。`LEGACY_KNOWN_MAP` の `%2E%2E` 重複も削除。

### 3. `auth_gate.header` が大文字指定のとき CFF で一切ヒットしない (MEDIUM)
- **問題**: CloudFront Functions はヘッダキーを小文字でしか返さない。policy で `header: X-Edge-Token` と書かれていると `req.headers['X-Edge-Token']` が常に undefined となり、正当なリクエストまで 401 になる。
- **修正**: `getAuthGates` 内で `tokenHeaderName` を `.toLowerCase()` する。

## Test plan

- [x] `node scripts/compile-unit-tests.js` — 20 tests pass (contains 小文字化 / header 小文字化 / legacy map 小文字化 追加)
- [x] `npm run test:runtime` — `x-edge-authenticated` スプーフィング 2 ケース追加 (`/admin` でスプーフ → 401 維持、非保護パスでも入力ヘッダ削除)
- [x] `npm run lint:policy` — 全プロファイル通過
- [x] `npm run test:drift` — 全 golden 再生成、drift ゼロ
- [x] `node scripts/infra-unit-tests.js` — 通過
- [x] CHANGELOG / CHANGELOG.ja 更新
- [ ] CI: Node 20 で全ジョブ green
- [ ] reviewer: `x-edge-authenticated` の strip タイミング (CFF: handler 冒頭 / CF: 転送直前) が適切かレビュー