### PR TITLE
docs: add language switcher between README.md and README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,7 @@
 # CDN セキュリティフレームワーク
 
+> **言語:** [English](./README.md) · 日本語
+
 ## 概要
 
 **CDN Security Framework** は、CloudFront / CloudFront Functions / Lambda@Edge / Cloudflare Workers など、

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # README.md
 
+> **Languages:** English · [日本語](./README.ja.md)
+
 ## CDN Security Framework
 
 [![CI](https://github.com/albert-einshutoin/cdn-security-framework/actions/workflows/policy-lint.yml/badge.svg)](https://github.com/albert-einshutoin/cdn-security-framework/actions/workflows/policy-lint.yml)


### PR DESCRIPTION
## Summary
Adds a top-of-file language switcher so readers can jump between the English and Japanese README in one click.

- `README.md`: `> **Languages:** English · [日本語](./README.ja.md)`
- `README.ja.md`: `> **言語:** [English](./README.md) · 日本語`

## Test plan
- [x] Visual check: link renders and navigates between the two files
- [x] No code or policy changes