### PR TITLE
feat(policy): permissive-profile warning + --fail-on-permissive CI gate

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -97,6 +97,7 @@ program
   .option('-t, --target <platform>', 'Target platform (aws | cloudflare)', 'aws')
   .option('--output-mode <mode>', 'AWS infra output mode: full | rule-group', 'full')
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
+  .option('--fail-on-permissive', 'Exit non-zero when policy.metadata.risk_level is "permissive" (gate for production CI)')
   .action((opts) => {
     const cwd = process.cwd();
     let policyPath = opts.policy;
@@ -127,6 +128,8 @@ program
     }
     console.log('[INFO] Validating policy... OK');
 
+    const permissiveFlag = opts.failOnPermissive ? ['--fail-on-permissive'] : [];
+
     if (opts.target === 'aws') {
       console.log('[INFO] Target: AWS CloudFront Functions');
       const compilePath = path.join(pkgRoot, 'scripts', 'compile.js');
@@ -134,6 +137,7 @@ program
         compilePath,
         '--policy', policyPath,
         '--out-dir', outDir,
+        ...permissiveFlag,
       ], { stdio: 'inherit', cwd });
       if (compileResult.status !== 0) process.exit(1);
       console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'viewer-request.js'));
@@ -156,6 +160,7 @@ program
         compileCfPath,
         '--policy', policyPath,
         '--out-dir', outDir,
+        ...permissiveFlag,
       ], { stdio: 'inherit', cwd });
       if (compileCfResult.status !== 0) process.exit(1);
       console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'cloudflare', 'index.ts'));

--- a/docs/profiles.ja.md
+++ b/docs/profiles.ja.md
@@ -1,0 +1,73 @@
+# セキュリティプロファイル
+
+本フレームワークは `policy/profiles/` に 3 つのビルトインプロファイルを同梱しています。それぞれが完結した `security.yml` の出発点であり、コピーしてからカスタマイズする前提です。
+
+| プロファイル | `metadata.risk_level` | 想定用途 |
+|--------------|-----------------------|----------|
+| `strict` | `strict` | 高セキュリティが必要な公開サイト、管理画面、信頼できないクライアント向け。レガシークライアントや過激なスクレイパーが壊れる可能性あり。 |
+| `balanced` | `balanced` | 一般的な Web + API トラフィックに対する推奨デフォルト。誤検知を抑えつつ現実的なブロック姿勢。 |
+| `permissive` | `permissive` | API 専用エッジや互換性重視の用途。**意図的にゆるいため、本番環境には推奨しません。** |
+
+`risk_level` フィールドは宣言的なタグです。ビルドツールはこれを読んで挙動を調整しますが、タグ自体で生成物が変わるわけではありません。実際の挙動を決めるのは policy 本体（allow_methods, limits, block ルールなど）です。
+
+---
+
+## プロファイルの選択
+
+特別な理由がない限り、まずは **`balanced`** から始めてください。本フレームワークが基準としてチューニングしている設定です。
+
+- 公開管理画面や決済フロー、高価値な標的の保護で、クライアント側調整も可能なら **`strict`** を選択してください。
+- 上流で WAF 付き API ゲートウェイなど別のフィルタ層が効いていて、互換性のために広めの入力を許容する必要がある場合のみ **`permissive`** を選んでください（例: RPC 風 API で全 HTTP メソッドを許可する）。
+
+判断に迷うなら `balanced` から出発し、丸ごと `strict` に切り替えるのではなく個別フィールドを締める方針を推奨します。
+
+---
+
+## `permissive` 警告
+
+`permissive` は意図的にゆるいため、`metadata.risk_level: permissive` が付いた policy をビルドするたびに警告を表示します:
+
+```
+[WARN] metadata.risk_level is "permissive" — this profile is intentionally loose and NOT recommended for production. See docs/profiles.md. Pass --fail-on-permissive in CI to hard-fail.
+```
+
+これは `stderr` に出るため生成物は汚しませんが、CI ログには残ります。
+
+### 本番 CI でハードフェイルする
+
+本番パイプラインでは `--fail-on-permissive` でゲートしてください。permissive タグが付いていればビルドが非 0 で終了します:
+
+```bash
+# strict / balanced は通過、permissive は失敗
+cdn-security build --fail-on-permissive
+# 直接叩く場合:
+node scripts/compile.js --policy policy/security.yml --fail-on-permissive
+```
+
+推奨運用:
+
+- **開発 / ステージング**: `cdn-security build`（警告のみ）
+- **本番リリース**: `cdn-security build --fail-on-permissive`
+
+これで permissive policy を本番 CDN に誤って投入する事故を構造的に防げます。
+
+### タグは任意
+
+このタグは任意です。`policy/base.yml` や手書き policy はデフォルトではタグ付けされておらず、警告も出ません。
+
+`policy/profiles/permissive.yml` を `policy/security.yml` の出発点としてコピーすると、`metadata.risk_level: permissive` タグも一緒に付いてきます。タグは残したままにして本番 CI ゲートで検出できるようにしてください。policy を十分に締めて permissive ではなくなったと判断したときだけ削除／変更し、その時は `balanced` か `strict` を使ってください。
+
+---
+
+## プロファイルのカスタマイズ
+
+出発点にしたいプロファイルをコピーして編集します:
+
+```bash
+cp policy/profiles/balanced.yml policy/security.yml
+$EDITOR policy/security.yml
+npm run lint:policy
+npm run build
+```
+
+オンボーディングの全体像は [quickstart.ja.md](quickstart.ja.md) を、コンパイル／デプロイのループは [policy-runtime-sync.ja.md](policy-runtime-sync.ja.md) を参照してください。

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,73 @@
+# Security Profiles
+
+This framework ships three built-in profiles in `policy/profiles/`. Each one is a complete `security.yml` starting point that you copy and then customize.
+
+| Profile | `metadata.risk_level` | Intended use |
+|---------|-----------------------|--------------|
+| `strict` | `strict` | High-security public sites, admin panels, low-trust clients. May break legacy clients or aggressive scrapers. |
+| `balanced` | `balanced` | Default recommendation for typical web + API traffic. Reasonable block posture with low false-positive rate. |
+| `permissive` | `permissive` | API-only surfaces or legacy compatibility. **Intentionally loose. NOT recommended for production.** |
+
+The `risk_level` field is declarative: the build tool reads it and adjusts its behavior accordingly. It does not change the actual compiled output on its own — what changes behavior is the rest of the policy (allow_methods, limits, block rules, etc.).
+
+---
+
+## Choosing a profile
+
+Start with **`balanced`** unless you have a specific reason not to. It is the reference configuration this framework is tuned for.
+
+- Pick **`strict`** if you are hardening a public admin UI, payments flow, or high-value target and you can coordinate with client owners to fix any resulting compatibility regressions.
+- Pick **`permissive`** only when you are running behind an upstream layer that already applies meaningful filtering (e.g. an API gateway with its own WAF) and you explicitly need to accept broader inputs for compatibility — for example, accepting all HTTP methods for an RPC-style API.
+
+When in doubt, start `balanced` and tighten individual fields rather than switching wholesale to `strict`.
+
+---
+
+## The `permissive` warning
+
+Because `permissive` is intentionally loose, the build tool prints a warning whenever it compiles a policy tagged `metadata.risk_level: permissive`:
+
+```
+[WARN] metadata.risk_level is "permissive" — this profile is intentionally loose and NOT recommended for production. See docs/profiles.md. Pass --fail-on-permissive in CI to hard-fail.
+```
+
+This is printed to `stderr` so it does not pollute generated output, but it is visible in CI logs.
+
+### Hard-failing in production CI
+
+For production pipelines, gate the build with `--fail-on-permissive`. The build will exit with a non-zero status if the policy is tagged permissive:
+
+```bash
+# Passes for strict / balanced; fails for permissive
+cdn-security build --fail-on-permissive
+# or directly:
+node scripts/compile.js --policy policy/security.yml --fail-on-permissive
+```
+
+Recommended pattern:
+
+- **Development / staging**: run `cdn-security build` (warning only)
+- **Production release**: run `cdn-security build --fail-on-permissive`
+
+This makes it impossible to accidentally ship a permissive policy to a production CDN.
+
+### Opting in to the tag
+
+The tag is optional. Base profiles (`policy/base.yml`) and hand-rolled policies are not tagged by default and will not trigger the warning.
+
+If you copy `policy/profiles/permissive.yml` as the starting point for your own `policy/security.yml`, the `metadata.risk_level: permissive` tag comes with it. Leave it in place so the production CI gate can catch accidental deploys. Remove or change it only after you have tightened the policy enough that it no longer qualifies as permissive — and then you should use `balanced` or `strict` instead.
+
+---
+
+## Customizing a profile
+
+Copy the profile you want as your starting point, then edit:
+
+```bash
+cp policy/profiles/balanced.yml policy/security.yml
+$EDITOR policy/security.yml
+npm run lint:policy
+npm run build
+```
+
+See [quickstart.md](quickstart.md) for the full onboarding flow and [policy-runtime-sync.md](policy-runtime-sync.md) for the compile / deploy loop.

--- a/policy/README.ja.md
+++ b/policy/README.ja.md
@@ -90,8 +90,21 @@ node scripts/policy-lint.js policy/base.yml
 
 ---
 
+## permissive プロファイル警告
+
+`permissive` プロファイルには `metadata.risk_level: permissive` タグが付いています。コンパイラはこのタグを検出するたびに stderr に警告を出し、`--fail-on-permissive` が付いていれば非 0 終了します。本番 CI では必ず次のようにゲートしてください:
+
+```bash
+npx cdn-security build --fail-on-permissive
+```
+
+プロファイル比較と、推奨される dev/prod ゲート運用の詳細は [docs/profiles.ja.md](../docs/profiles.ja.md) を参照してください。
+
+---
+
 ## 関連
 
+* [プロファイル](../docs/profiles.ja.md) — プロファイル選択と本番 CI の permissive ゲート。
 * [ポリシーとランタイムの同期](../docs/policy-runtime-sync.ja.md) — ポリシーとランタイムの同期方法。
 * [アーキテクチャ](../docs/architecture.ja.md) — ポリシー駆動の設計。
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -93,8 +93,21 @@ issue with the use case.
 
 ---
 
+## Permissive profile warning
+
+The `permissive` profile is tagged `metadata.risk_level: permissive`. Whenever the compiler sees that tag it prints a warning to stderr and, if `--fail-on-permissive` is passed, exits non-zero. Gate production CI with:
+
+```bash
+npx cdn-security build --fail-on-permissive
+```
+
+See [docs/profiles.md](../docs/profiles.md) for the full profile comparison and the recommended dev/prod gate pattern.
+
+---
+
 ## Related
 
+* [Profiles](../docs/profiles.md) — how to choose a profile and gate permissive in production CI.
 * [Policy and runtime sync](../docs/policy-runtime-sync.md) — how to keep policy and runtimes in sync.
 * [Architecture](../docs/architecture.md) — policy-driven design.
 

--- a/policy/profiles/balanced.yml
+++ b/policy/profiles/balanced.yml
@@ -4,6 +4,10 @@
 version: 1
 project: example-cdn-security
 
+metadata:
+  risk_level: balanced
+  description: "Default profile: balanced security vs compatibility for typical web/API traffic."
+
 defaults:
   mode: "enforce"          # enforce | monitor (monitor needs logging/metrics)
   response:

--- a/policy/profiles/permissive.yml
+++ b/policy/profiles/permissive.yml
@@ -5,6 +5,10 @@
 version: 1
 project: example-cdn-security
 
+metadata:
+  risk_level: permissive
+  description: "Permissive profile: intentionally loose. NOT recommended for production — build prints a warning and can be hard-failed with --fail-on-permissive."
+
 defaults:
   mode: "enforce"
   response:

--- a/policy/profiles/strict.yml
+++ b/policy/profiles/strict.yml
@@ -5,6 +5,10 @@
 version: 1
 project: example-cdn-security
 
+metadata:
+  risk_level: strict
+  description: "Maximum edge hardening; intended for surfaces with tight client control."
+
 defaults:
   mode: "enforce"
   response:

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -7,6 +7,18 @@
   "properties": {
     "version": { "type": "integer", "const": 1 },
     "project": { "type": "string" },
+    "metadata": {
+      "description": "Optional profile / policy metadata. `risk_level` hints the intended security posture — `permissive` triggers a build-time warning so operators do not accidentally ship a loose policy to production.",
+      "type": "object",
+      "properties": {
+        "risk_level": {
+          "description": "Intended posture: strict, balanced, or permissive. Build warns on permissive and can be hard-failed with --fail-on-permissive.",
+          "enum": ["strict", "balanced", "permissive"]
+        },
+        "description": { "type": "string" },
+        "owner": { "type": "string" }
+      }
+    },
     "defaults": {
       "type": "object",
       "properties": {

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -12,6 +12,8 @@ const {
   regexesLiteralCode,
   validateAuthGates,
   hasAllowPlaceholderFlag,
+  hasFailOnPermissiveFlag,
+  warnIfPermissive,
 } = require('./lib/compile-core');
 
 const repoRoot = path.join(__dirname, '..');
@@ -24,9 +26,11 @@ for (let i = 0; i < argv.length; i++) {
   if (argv[i] === '--policy' && argv[i + 1]) { policyPath = argv[++i]; continue; }
   if (argv[i] === '--out-dir' && argv[i + 1]) { outDir = argv[++i]; continue; }
   if (argv[i] === '--allow-placeholder-token') { continue; }
+  if (argv[i] === '--fail-on-permissive') { continue; }
   if (!argv[i].startsWith('--')) { policyPath = argv[i]; }
 }
 const allowPlaceholderToken = hasAllowPlaceholderFlag(argv);
+const failOnPermissive = hasFailOnPermissiveFlag(argv);
 
 let policy;
 try {
@@ -38,6 +42,11 @@ try {
     process.exit(1);
   }
   console.error('Error: failed to parse policy YAML:', e.message);
+  process.exit(1);
+}
+
+const permissive = warnIfPermissive(policy, { failOnPermissive });
+if (permissive.failed) {
   process.exit(1);
 }
 

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -12,6 +12,8 @@ const {
   validateAuthGates,
   build,
   PLACEHOLDER_TOKEN,
+  hasFailOnPermissiveFlag,
+  warnIfPermissive,
 } = require('./lib/compile-core');
 
 function test(name, fn) {
@@ -542,6 +544,51 @@ test('build clamps clock_skew_sec to 0..600', () => {
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+});
+
+test('hasFailOnPermissiveFlag detects the flag', () => {
+  assert.strictEqual(hasFailOnPermissiveFlag(['--fail-on-permissive']), true);
+  assert.strictEqual(hasFailOnPermissiveFlag(['--policy', 'x', '--fail-on-permissive']), true);
+  assert.strictEqual(hasFailOnPermissiveFlag(['--policy', 'x']), false);
+  assert.strictEqual(hasFailOnPermissiveFlag([]), false);
+  assert.strictEqual(hasFailOnPermissiveFlag(undefined), false);
+  assert.strictEqual(hasFailOnPermissiveFlag(null), false);
+});
+
+test('warnIfPermissive returns no-op when metadata.risk_level is not permissive', () => {
+  const captured = [];
+  const logger = { error: (msg) => captured.push(msg) };
+  const r1 = warnIfPermissive({}, { logger });
+  const r2 = warnIfPermissive({ metadata: { risk_level: 'strict' } }, { logger });
+  const r3 = warnIfPermissive({ metadata: { risk_level: 'balanced' } }, { logger });
+  const r4 = warnIfPermissive(null, { logger });
+  assert.deepStrictEqual(r1, { warned: false, failed: false });
+  assert.deepStrictEqual(r2, { warned: false, failed: false });
+  assert.deepStrictEqual(r3, { warned: false, failed: false });
+  assert.deepStrictEqual(r4, { warned: false, failed: false });
+  assert.strictEqual(captured.length, 0);
+});
+
+test('warnIfPermissive warns but does not fail when failOnPermissive is false', () => {
+  const captured = [];
+  const logger = { error: (msg) => captured.push(msg) };
+  const result = warnIfPermissive({ metadata: { risk_level: 'permissive' } }, { logger });
+  assert.deepStrictEqual(result, { warned: true, failed: false });
+  assert.strictEqual(captured.length, 1);
+  assert.match(captured[0], /metadata\.risk_level is "permissive"/);
+  assert.match(captured[0], /--fail-on-permissive/);
+});
+
+test('warnIfPermissive fails when failOnPermissive is true', () => {
+  const captured = [];
+  const logger = { error: (msg) => captured.push(msg) };
+  const result = warnIfPermissive(
+    { metadata: { risk_level: 'permissive' } },
+    { logger, failOnPermissive: true },
+  );
+  assert.deepStrictEqual(result, { warned: true, failed: true });
+  assert.strictEqual(captured.length, 2);
+  assert.match(captured[1], /refusing to build a permissive policy/);
 });
 
 if (process.exitCode) {

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -293,6 +293,28 @@ function hasAllowPlaceholderFlag(argv) {
   return Array.isArray(argv) && argv.includes('--allow-placeholder-token');
 }
 
+function hasFailOnPermissiveFlag(argv) {
+  return Array.isArray(argv) && argv.includes('--fail-on-permissive');
+}
+
+function warnIfPermissive(policy, options = {}) {
+  const failOnPermissive = options.failOnPermissive === true;
+  const logger = options.logger || console;
+  const risk = policy && policy.metadata && policy.metadata.risk_level;
+  if (risk !== 'permissive') {
+    return { warned: false, failed: false };
+  }
+  const msg =
+    '[WARN] metadata.risk_level is "permissive" — this profile is intentionally loose and NOT recommended for production. ' +
+    'See docs/profiles.md. Pass --fail-on-permissive in CI to hard-fail.';
+  logger.error(msg);
+  if (failOnPermissive) {
+    logger.error('[ERROR] --fail-on-permissive set; refusing to build a permissive policy.');
+    return { warned: true, failed: true };
+  }
+  return { warned: true, failed: false };
+}
+
 function build(policy, options = {}) {
   const rootDir = options.rootDir || repoRoot;
   const outDir = options.outDir || path.join(rootDir, 'dist');
@@ -460,6 +482,7 @@ function build(policy, options = {}) {
 function main(argv = process.argv.slice(2)) {
   const { policyPath, outDir } = parseArgs(argv, repoRoot);
   const allowPlaceholderToken = hasAllowPlaceholderFlag(argv);
+  const failOnPermissive = hasFailOnPermissiveFlag(argv);
   let policy;
 
   try {
@@ -470,6 +493,12 @@ function main(argv = process.argv.slice(2)) {
       process.exit(1);
     }
     console.error('Error: failed to parse policy YAML:', e.message);
+    process.exit(1);
+  }
+
+  // Surface permissive-profile warning before wasting build time.
+  const permissive = warnIfPermissive(policy, { failOnPermissive });
+  if (permissive.failed) {
     process.exit(1);
   }
 
@@ -503,6 +532,8 @@ module.exports = {
   regexesLiteralCode,
   getAuthGates,
   hasAllowPlaceholderFlag,
+  hasFailOnPermissiveFlag,
+  warnIfPermissive,
   build,
   main,
   PLACEHOLDER_TOKEN,


### PR DESCRIPTION
## Summary

- Adds `metadata.risk_level` (strict | balanced | permissive) to the policy schema and tags the three built-in profiles accordingly (`policy/base.yml` intentionally stays untagged for backward compatibility).
- Compiler now prints a `[WARN]` to stderr whenever it sees `metadata.risk_level: permissive`.
- New CLI flag `cdn-security build --fail-on-permissive` makes the build exit non-zero when the policy is tagged permissive. Same flag is plumbed into `scripts/compile.js` and `scripts/compile-cloudflare.js`.
- Docs (`docs/profiles.md` + `docs/profiles.ja.md`) document the gate and the recommended dev/prod split; `policy/README.{md,ja.md}` link to them and summarize the warning.
- Unit tests added for `hasFailOnPermissiveFlag` and `warnIfPermissive` (positive / negative / failOnPermissive branches).

Closes #26.

## Motivation

The `permissive` profile is intentionally loose (broader methods, higher limits, no UA-missing block, relaxed UA denylist). Before this PR nothing stopped a team from committing a permissive policy and shipping it to a production CDN. Now the build layer surfaces the risk and production CI can hard-fail on it.

## Test plan

- [x] `npm run lint:policy` against `base.yml` and all three profiles — PASS
- [x] `EDGE_ADMIN_TOKEN=... npm run build` — PASS
- [x] `npm run test:unit` — PASS (31 tests, includes 4 new tests for the warning helpers)
- [x] `npm run test:runtime` — PASS (46 AWS + 4 Cloudflare)
- [x] `npm run test:drift` — PASS (no drift; warning goes to stderr, exit=0 for all three profiles)
- [x] `npm run test:security-baseline` — PASS
- [x] `npm pack --dry-run` — PASS (27 files)
- [x] Manual CLI verification:
  - `cdn-security build --policy policy/profiles/permissive.yml` — prints warning, exit=0
  - `cdn-security build --policy policy/profiles/permissive.yml --fail-on-permissive` — prints warning + error, exit=1
  - same for `--target cloudflare` — exit=1
  - `cdn-security build --policy policy/profiles/{strict,balanced}.yml --fail-on-permissive` — exit=0