### PR TITLE
feat(security): JWKS SSRF hardening + request-smuggling header strip

### DIFF
--- a/docs/threat-model.ja.md
+++ b/docs/threat-model.ja.md
@@ -95,6 +95,32 @@ Edge / WAF / Origin のどのレイヤーが担当するかを明確にします
 
 ---
 
+### 9. JWKS SSRF（JWT ゲート経由のサーバーサイドリクエストフォージェリ）
+
+| 脅威 | Edge の責務 | WAF / Origin |
+|------|-------------|--------------|
+| クラウドメタデータ（`169.254.169.254`）、ループバック、RFC1918、リンクローカルを指す悪意ある／誤った `jwks_url` | ビルド時に拒否、ランタイムで再検証 | — |
+| JWKS ホストから内部エンドポイントへの攻撃者制御リダイレクト | 3xx レスポンスを拒否（Workers: `redirect: 'error'`、Lambda@Edge: 明示的な 3xx 拒否） | — |
+| ポリシーに明示的な allowlist がある場合、範囲外の IdP ホスト | ビルド時に `firewall.jwks.allowed_hosts` で拒否 | — |
+
+**フレームワーク**:
+- ビルド時バリデータ（`validateJwksUrl`）が `https://` 必須、userinfo / loopback / RFC1918 / リンクローカル / IPv4-mapped IPv6 を拒否し、任意で `firewall.jwks.allowed_hosts` メンバーシップを強制。
+- ランタイムの `fetchJwks` が URL を再チェックし、3xx レスポンスを拒否。
+- 運用推奨: 本番環境では `firewall.jwks.allowed_hosts` を必ず設定し IdP ホスト名を固定する。
+
+---
+
+### 10. HTTP Request Smuggling / Desync
+
+| 脅威 | Edge の責務 | WAF / Origin |
+|------|-------------|--------------|
+| クライアント由来の `Transfer-Encoding: chunked` による CloudFront/Worker ↔ Origin フレーミングのデシンク（CL.TE / TE.CL / H2.TE） | Origin 転送前に hop-by-hop ヘッダーを除去 | — |
+| クライアント由来の `Connection`、`Upgrade`、`TE`、`Keep-Alive`、`Proxy-*`、`Trailer` | Origin 転送前に除去 | — |
+
+**フレームワーク**: AWS origin-request Lambda と Cloudflare Worker の両方で、転送前に `transfer-encoding`、`connection`、`keep-alive`、`te`、`upgrade`、`proxy-connection`、`proxy-authenticate`、`proxy-authorization`、`trailer` を削除。CDN 自身がリクエストを再フレーム化するため、これらのヘッダーに正当なビューワー意図は存在しない。
+
+---
+
 ## 本フレームワークが対象としないもの
 
 * **高度な Bot 挙動**（WAF / Bot Management）。

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -94,6 +94,32 @@ This document organizes threats that this Edge Security Framework is designed to
 
 ---
 
+### 9. JWKS SSRF (Server-Side Request Forgery via JWT gates)
+
+| Threat | Edge responsibility | WAF / Origin |
+|--------|---------------------|---------------|
+| Malicious or accidental `jwks_url` pointing at cloud metadata (`169.254.169.254`), loopback, RFC1918, or link-local ranges | Reject at build time and re-validate at runtime | — |
+| Attacker-controlled redirect from JWKS host to internal endpoint | Refuse 3xx responses (`redirect: 'error'` in Workers / explicit 3xx rejection in Lambda@Edge) | — |
+| Out-of-scope IdP host when policy has an explicit allowlist | Reject at build time via `firewall.jwks.allowed_hosts` | — |
+
+**Framework**:
+- Build-time validator (`validateJwksUrl`) enforces `https://`, rejects userinfo, loopback, RFC1918, link-local, IPv4-mapped IPv6, and optional `firewall.jwks.allowed_hosts` membership.
+- Runtime `fetchJwks` re-checks the URL and refuses any 3xx response.
+- Recommended operator practice: always set `firewall.jwks.allowed_hosts` in production to pin the exact IdP hostname(s).
+
+---
+
+### 10. HTTP Request Smuggling / Desync
+
+| Threat | Edge responsibility | WAF / Origin |
+|--------|---------------------|---------------|
+| Client-supplied `Transfer-Encoding: chunked` desynchronizing CloudFront/Worker ↔ origin framing (CL.TE / TE.CL / H2.TE) | Strip hop-by-hop headers before origin forward | — |
+| Client-supplied `Connection`, `Upgrade`, `TE`, `Keep-Alive`, `Proxy-*`, `Trailer` | Strip before origin forward | — |
+
+**Framework**: The AWS origin-request Lambda and Cloudflare Worker both delete `transfer-encoding`, `connection`, `keep-alive`, `te`, `upgrade`, `proxy-connection`, `proxy-authenticate`, `proxy-authorization`, and `trailer` from the forwarded request. The CDN re-frames the request, so none of these carry legitimate viewer intent.
+
+---
+
 ## What This Framework Does Not Mitigate
 
 * **Advanced bot behavior** (WAF / Bot Management).

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -222,6 +222,18 @@
             "allowlist": { "type": "array", "items": { "type": "string" } },
             "blocklist": { "type": "array", "items": { "type": "string" } }
           }
+        },
+        "jwks": {
+          "description": "JWKS outbound-fetch guardrails. When `allowed_hosts` is set, the build refuses any JWT gate whose `jwks_url` hostname is not on the list, preventing SSRF into internal metadata endpoints. Regardless of this setting, the compiler also rejects non-HTTPS URLs and URLs that resolve to loopback, private, or link-local literals.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowed_hosts": {
+              "description": "Exact-match hostname allowlist for any `routes[].auth_gate.jwks_url`. Comparison is case-insensitive. Wildcards are not supported — list each IdP host explicitly.",
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
         }
       }
     },

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -10,6 +10,7 @@ const {
   regexesLiteralCode,
   getAuthGates,
   validateAuthGates,
+  validateJwksUrl,
   build,
   PLACEHOLDER_TOKEN,
   hasFailOnPermissiveFlag,
@@ -589,6 +590,107 @@ test('warnIfPermissive fails when failOnPermissive is true', () => {
   assert.deepStrictEqual(result, { warned: true, failed: true });
   assert.strictEqual(captured.length, 2);
   assert.match(captured[1], /refusing to build a permissive policy/);
+});
+
+test('validateJwksUrl accepts well-formed public https URLs', () => {
+  assert.deepStrictEqual(
+    validateJwksUrl('https://idp.example.com/.well-known/jwks.json').ok,
+    true,
+  );
+  assert.deepStrictEqual(
+    validateJwksUrl('https://login.microsoftonline.com/common/discovery/v2.0/keys').ok,
+    true,
+  );
+});
+
+test('validateJwksUrl rejects non-https schemes', () => {
+  assert.strictEqual(validateJwksUrl('http://idp.example.com/jwks.json').ok, false);
+  assert.strictEqual(validateJwksUrl('file:///etc/passwd').ok, false);
+  assert.strictEqual(validateJwksUrl('ftp://example.com/jwks.json').ok, false);
+});
+
+test('validateJwksUrl rejects URLs with userinfo', () => {
+  const r = validateJwksUrl('https://user:pass@idp.example.com/jwks.json');
+  assert.strictEqual(r.ok, false);
+  assert.match(r.reason, /userinfo/);
+});
+
+test('validateJwksUrl rejects loopback / private / link-local hostnames', () => {
+  const cases = [
+    'https://localhost/jwks.json',
+    'https://127.0.0.1/jwks.json',
+    'https://127.5.5.5/jwks.json',
+    'https://10.0.0.1/jwks.json',
+    'https://10.255.255.254/jwks.json',
+    'https://192.168.1.1/jwks.json',
+    'https://172.16.0.1/jwks.json',
+    'https://172.31.255.255/jwks.json',
+    'https://169.254.169.254/latest/meta-data/',
+    'https://0.0.0.0/jwks.json',
+    'https://[::1]/jwks.json',
+    'https://[fe80::1]/jwks.json',
+    'https://[fc00::1]/jwks.json',
+    'https://[::ffff:127.0.0.1]/jwks.json',
+  ];
+  for (const url of cases) {
+    const r = validateJwksUrl(url);
+    assert.strictEqual(r.ok, false, `should reject ${url}`);
+  }
+});
+
+test('validateJwksUrl enforces allowed_hosts when provided', () => {
+  const allow = ['idp.example.com', 'Auth.Example.Com'];
+  assert.strictEqual(validateJwksUrl('https://idp.example.com/jwks.json', allow).ok, true);
+  assert.strictEqual(validateJwksUrl('https://auth.example.com/jwks.json', allow).ok, true);
+  const r = validateJwksUrl('https://evil.example.com/jwks.json', allow);
+  assert.strictEqual(r.ok, false);
+  assert.match(r.reason, /firewall\.jwks\.allowed_hosts/);
+});
+
+test('validateAuthGates rejects jwks_url in private/loopback ranges', () => {
+  const policy = {
+    routes: [
+      {
+        name: 'metadata-ssrf',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://169.254.169.254/latest/' },
+      },
+    ],
+  };
+  assert.throws(
+    () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
+    (err) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e) => /metadata-ssrf/.test(e) && /private\/loopback/.test(e)),
+  );
+});
+
+test('validateAuthGates rejects jwks_url outside firewall.jwks.allowed_hosts', () => {
+  const policy = {
+    firewall: { jwks: { allowed_hosts: ['idp.example.com'] } },
+    routes: [
+      {
+        name: 'wrong-idp',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://attacker.example/jwks.json' },
+      },
+    ],
+  };
+  assert.throws(
+    () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
+    (err) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e) => /wrong-idp/.test(e) && /allowed_hosts/.test(e)),
+  );
+});
+
+test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', () => {
+  const policy = {
+    firewall: { jwks: { allowed_hosts: ['IDP.Example.COM'] } },
+    routes: [
+      {
+        name: 'good-idp',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+      },
+    ],
+  };
+  validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
 });
 
 if (process.exitCode) {

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -150,6 +150,91 @@ function regexesLiteralCode(regexSources) {
   return '[' + literals.join(', ') + ']';
 }
 
+// Reject JWKS URLs that point at loopback, private, link-local, or other
+// internal address ranges. An attacker who can influence the JWKS URL at
+// build time (via a policy PR) or at runtime (via a regression that lets a
+// client seed the cache) could otherwise force the edge to fetch cloud
+// metadata endpoints (169.254.169.254) or internal services.
+const JWKS_DISALLOWED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'broadcasthost',
+]);
+
+function isPrivateIPv4Literal(hostname) {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+  if (!m) return false;
+  const octets = m.slice(1, 5).map(Number);
+  if (octets.some((o) => o < 0 || o > 255)) return false;
+  const [a, b] = octets;
+  if (a === 10) return true;                             // 10.0.0.0/8
+  if (a === 127) return true;                            // loopback
+  if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;               // 192.168.0.0/16
+  if (a === 169 && b === 254) return true;               // link-local / metadata
+  if (a === 100 && b >= 64 && b <= 127) return true;     // CGN 100.64.0.0/10
+  if (a === 0) return true;                              // 0.0.0.0/8
+  if (a >= 224) return true;                             // multicast / reserved
+  return false;
+}
+
+function isPrivateIPv6Literal(hostname) {
+  const h = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1).toLowerCase()
+    : hostname.toLowerCase();
+  if (!h.includes(':')) return false;
+  if (h === '::' || h === '::1') return true;
+  if (h.startsWith('fe80:') || h.startsWith('fe80::')) return true;   // link-local
+  if (h.startsWith('fc') || h.startsWith('fd')) return true;          // ULA fc00::/7
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d). Node's WHATWG URL normalizes the
+  // trailing IPv4 to hex (e.g. ::ffff:127.0.0.1 → ::ffff:7f00:1), so we
+  // reject the entire `::ffff:` family. Legitimate public IdPs never serve
+  // JWKS behind an IPv4-mapped literal — they use a real v4 or v6 address.
+  if (h.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function validateJwksUrl(rawUrl, allowedHosts) {
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return { ok: false, reason: 'jwks_url is empty' };
+  }
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: `jwks_url is not a valid URL: ${rawUrl}` };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: `jwks_url must use https:// (got ${parsed.protocol})` };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, reason: 'jwks_url must not contain userinfo (user:pass@host)' };
+  }
+  const hostname = (parsed.hostname || '').toLowerCase();
+  if (!hostname) {
+    return { ok: false, reason: 'jwks_url has empty hostname' };
+  }
+  if (JWKS_DISALLOWED_HOSTNAMES.has(hostname)) {
+    return { ok: false, reason: `jwks_url hostname "${hostname}" is a loopback alias` };
+  }
+  if (isPrivateIPv4Literal(hostname) || isPrivateIPv6Literal(parsed.hostname)) {
+    return { ok: false, reason: `jwks_url hostname "${hostname}" resolves to a private/loopback/link-local range` };
+  }
+  if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
+    const normalized = allowedHosts
+      .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
+      .filter(Boolean);
+    if (!normalized.includes(hostname)) {
+      return {
+        ok: false,
+        reason: `jwks_url hostname "${hostname}" is not in firewall.jwks.allowed_hosts (${normalized.join(', ')})`,
+      };
+    }
+  }
+  return { ok: true, hostname };
+}
+
 function validateAuthGates(policy, options = {}) {
   const exitOnError = options.exitOnError !== false;
   const logger = options.logger || console;
@@ -157,6 +242,7 @@ function validateAuthGates(policy, options = {}) {
   const allowPlaceholderToken = options.allowPlaceholderToken === true;
   const routes = policy.routes || [];
   const errors = [];
+  const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
 
   for (const route of routes) {
     const gate = route.auth_gate;
@@ -168,6 +254,12 @@ function validateAuthGates(policy, options = {}) {
       const alg = gate.algorithm || 'RS256';
       if (alg === 'RS256' && !gate.jwks_url) {
         errors.push(`Route "${name}": JWT+RS256 requires "jwks_url"`);
+      }
+      if (gate.jwks_url) {
+        const v = validateJwksUrl(gate.jwks_url, jwksAllowedHosts);
+        if (!v.ok) {
+          errors.push(`Route "${name}": ${v.reason}`);
+        }
       }
       if (alg === 'HS256' && !gate.secret_env) {
         errors.push(`Route "${name}": JWT+HS256 requires "secret_env"`);
@@ -534,6 +626,7 @@ module.exports = {
   hasAllowPlaceholderFlag,
   hasFailOnPermissiveFlag,
   warnIfPermissive,
+  validateJwksUrl,
   build,
   main,
   PLACEHOLDER_TOKEN,

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -54,8 +54,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -63,6 +88,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -388,6 +426,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -81,15 +81,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -398,6 +425,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)


### PR DESCRIPTION
## Summary

Harden outbound JWKS fetches against SSRF and strip hop-by-hop headers before forwarding to origin to defend against HTTP request smuggling.

- **JWKS SSRF (#5, #40)** — `validateJwksUrl()` rejects any `jwks_url` that is not HTTPS, or points at loopback / RFC1918 / link-local / IPv4-mapped / cloud-metadata ranges. New optional `firewall.jwks.allowed_hosts` pins IdP hostnames.
- **Runtime re-validation** — AWS Lambda@Edge and Cloudflare Worker both re-check the URL on every fetch and refuse 3xx responses to block redirect-based SSRF.
- **Request smuggling (#7)** — Both runtimes now strip `transfer-encoding`, `connection`, `keep-alive`, `te`, `upgrade`, `proxy-connection`, `proxy-authenticate`, `proxy-authorization`, and `trailer` from the forwarded request.
- **Docs** — `docs/threat-model.{md,ja.md}` gains sections 9 (JWKS SSRF) and 10 (Request Smuggling / Desync).
- **Tests** — 8 new unit tests for the URL validator + integration tests; golden fixtures regenerated for all profiles.

## Test plan

- [x] `npm run lint:policy` (base + 3 profiles)
- [x] `npm run build` + `node scripts/compile-cloudflare.js`
- [x] `npm run test:unit` (all new SSRF tests pass)
- [x] `npm run test:runtime` (46/46)
- [x] `npm run test:drift` (base + 3 profiles)
- [x] `npm run test:security-baseline`

Closes #5
Closes #7
Closes #40