### PR TITLE
feat(security): signed-URL exact_path + nonce replay hardening

### DIFF
--- a/docs/signed-urls.ja.md
+++ b/docs/signed-urls.ja.md
@@ -1,0 +1,102 @@
+# 署名付き URL のハードニング
+
+## 目的
+
+`signed_url` 認証ゲートは HMAC-SHA256 署名で URL と期限を束ねて、保護リソースへの一時的アクセスを与える。追加の制約がなければ、同じプレフィックス配下の別パスで再利用されたり、有効期限まで何度もリプレイされたりする余地が残る。本ドキュメントでは、フレームワーク側の 2 つの緩和策を整理する。
+
+- **`exact_path`** — 署名を 1 つのパスだけに束ねる（既定はゲートプレフィックス配下のパス全体にマッチ）。
+- **`nonce_param`** — HMAC 入力にリクエスト毎のノンスを組み込み、エッジ → オリジンへワンタイム識別子を転送する。
+
+## 脅威モデル
+
+| 攻撃 | 緩和策 |
+|---|---|
+| 同じ署名鍵とプレフィックスを共有する `/download/a.pdf` の署名 URL が、兄弟パス `/download/b.pdf` に再利用される | `exact_path: true` |
+| 漏洩・ブラウザ戻るなどで 1 本の署名 URL が複数クライアントから使われる | `nonce_param` + オリジン側の単回利用ストア（エッジ単体ではワンタイム化できない） |
+| 署名 URL のノンスを書き換えて他ユーザのセッションを乗っ取る | ノンスは HMAC 入力 (`uri + exp + '|' + nonce`) に含まれるため、書き換えると署名が壊れて失敗 |
+
+## ポリシー設定
+
+```yaml
+routes:
+  - name: one-time-download
+    match:
+      path_prefixes: ["/download/"]
+    auth_gate:
+      type: signed_url
+      algorithm: HMAC-SHA256
+      secret_env: URL_SIGNING_SECRET
+      expires_param: exp
+      signature_param: sig
+      exact_path: true        # 署名を 1 パスに束ねる
+      nonce_param: nonce      # URL ごとのノンスをオリジンへ X-Signed-URL-Nonce で転送
+```
+
+- `exact_path` の既定は `false`（従来のプレフィックス一致）。
+- `nonce_param` の既定は `""`（ノンスなし。署名対象は `uri + exp` のみ）。
+- `exact_path` と `nonce_param` は独立しており、片方だけでも有効。
+
+## 署名ルール
+
+HMAC 入力は以下の通り。
+
+```
+signData = uri + exp + ( nonce ? '|' + nonce : '' )
+signature = HMAC-SHA256-Hex(secret, signData)
+```
+
+`nonce_param` が設定されているときだけノンスを連結する。ノンス無しで発行済みの既存 URL は従来どおり通過する。
+
+### ノンス書式
+
+エッジランタイムはノンスの書式を厳格に検証し、単回利用ストアや下流ログへの任意文字列注入を防ぐ。
+
+- 長さ: 16〜256 文字
+- 使用可能文字: `A-Z a-z 0-9 . _ ~ -`（URL セーフ unreserved 文字）
+
+書式不正は署名検証前に `403 Malformed nonce` で拒否する。
+
+## オリジン側での単回利用の強制
+
+エッジは署名を検証し、設定があればノンスを `X-Signed-URL-Nonce` ヘッダとしてオリジンへ転送する。エッジは単回利用を保証できない（CloudFront Functions / Worker の呼び出しはステートレス）。オリジン側で原子的な単回利用を実装する必要がある。
+
+```ts
+// オリジンエンドポイントの擬似コード
+const nonce = req.headers['x-signed-url-nonce'];
+if (!nonce) return reject(403, 'Nonce required');
+
+// 署名 URL の有効期限より長い TTL で Redis SET NX
+const acquired = await redis.set(`nonce:${nonce}`, '1', 'EX', 3600, 'NX');
+if (!acquired) return reject(409, 'URL already used');
+```
+
+TTL は署名 URL の最大有効期限以上を指定する。
+
+## 書き込み系パスでノンスが未設定な場合の警告
+
+`signed_url` ゲートが書き込み系の匂いを含むプレフィックス (`/api/`, `/write`, `/admin`, `/upload`, `/delete`) を保護しているのに `nonce_param` が未設定のとき、コンパイラは非致死の警告を出す。
+
+```
+[WARN] Route "admin-upload" uses signed_url on a write-like path ("/admin/upload") without nonce_param.
+       Signed URLs can be replayed on write endpoints. Set nonce_param and enforce single-use at origin.
+```
+
+対応策は `nonce_param` を設定するか、JWT や静的トークンなど別の認証ゲートへ切り替えること。
+
+## ランタイム挙動のまとめ
+
+| 入力 | エッジのレスポンス |
+|---|---|
+| 署名 OK + ノンス OK + パス一致 | 200（通過、`X-Signed-URL-Nonce` をオリジンへ転送） |
+| 署名 OK、ノンス未設定（ポリシーも未設定） | 200（通過） |
+| `nonce_param` 設定ありでノンス欠落 | 403 Missing nonce |
+| ノンスの長さ/文字種が不正 | 403 Malformed nonce |
+| 署名不一致（ノンス改ざん含む） | 403 Invalid signature |
+| `exact_path: true` でゲートプレフィックスとパスが異なる | ゲート非適用 → 通常ルーティング |
+| 期限切れ（`exp < now`） | 403 URL expired |
+
+## 関連ドキュメント
+
+- 脅威モデル: `docs/threat-model.ja.md` §5（Auth Gate）
+- ポリシースキーマ: `policy/schema.json` — `routes[].auth_gate`
+- ランタイム参照実装: `runtimes/aws/origin-request.js`, `runtimes/cloudflare/index.ts`

--- a/docs/signed-urls.md
+++ b/docs/signed-urls.md
@@ -1,0 +1,102 @@
+# Signed URL Hardening
+
+## Purpose
+
+The `signed_url` auth gate grants time-bounded access to a protected resource by binding a URL to an HMAC-SHA256 signature. Without additional constraints, a signed URL can be replayed against sibling paths under the same prefix, or re-used repeatedly until it expires. This document covers two framework-level mitigations:
+
+- **`exact_path`** — scope the signature to a single path (default behaviour matches any path under the gate prefix).
+- **`nonce_param`** — bind a per-URL nonce into the HMAC input so the edge can forward a single-use identifier to the origin.
+
+## Threat Model
+
+| Attack | Mitigation |
+|---|---|
+| Signed URL for `/download/a.pdf` reused against `/download/b.pdf` when both share the same signing secret and prefix | `exact_path: true` |
+| Single signed URL replayed by multiple clients (leaked URL, browser back button) | `nonce_param` + origin-side single-use store (edge cannot enforce single-use alone) |
+| Signed URL tampered by flipping the nonce value to collide with another user's session | Nonce is included in the HMAC input (`uri + exp + '|' + nonce`), so any change to the nonce invalidates the signature |
+
+## Policy Configuration
+
+```yaml
+routes:
+  - name: one-time-download
+    match:
+      path_prefixes: ["/download/"]
+    auth_gate:
+      type: signed_url
+      algorithm: HMAC-SHA256
+      secret_env: URL_SIGNING_SECRET
+      expires_param: exp
+      signature_param: sig
+      exact_path: true        # signature is bound to a single URI path
+      nonce_param: nonce      # per-URL nonce forwarded to origin as X-Signed-URL-Nonce
+```
+
+- `exact_path` defaults to `false` (backwards-compatible prefix match).
+- `nonce_param` defaults to `""` (no nonce; signature covers `uri + exp` only).
+- `exact_path` and `nonce_param` are independent and may be used separately.
+
+## Signing Rules
+
+The HMAC input is constructed as:
+
+```
+signData = uri + exp + ( nonce ? '|' + nonce : '' )
+signature = HMAC-SHA256-Hex(secret, signData)
+```
+
+The nonce is appended only when `nonce_param` is configured. Existing URLs signed without a nonce continue to work unchanged.
+
+### Nonce Format
+
+The edge runtime enforces a strict nonce format to prevent injection of arbitrary data into downstream logs or single-use stores:
+
+- Length: 16–256 characters
+- Charset: `A-Z a-z 0-9 . _ ~ -` (URL-safe unreserved characters)
+
+Malformed nonces are rejected with `403 Malformed nonce` before signature verification runs.
+
+## Origin-Side Single-Use Enforcement
+
+The edge runtime verifies the signature and (if configured) forwards the nonce as `X-Signed-URL-Nonce`. The edge cannot enforce single-use on its own — each CloudFront Function / Worker invocation is stateless. The origin MUST implement atomic single-use:
+
+```ts
+// Pseudocode for an origin endpoint
+const nonce = req.headers['x-signed-url-nonce'];
+if (!nonce) return reject(403, 'Nonce required');
+
+// Redis SET NX with TTL longer than signed URL expiry
+const acquired = await redis.set(`nonce:${nonce}`, '1', 'EX', 3600, 'NX');
+if (!acquired) return reject(409, 'URL already used');
+```
+
+Choose a TTL at least equal to the maximum signed URL lifetime.
+
+## Warning: Write-like Paths Without Nonce
+
+The compiler emits a non-fatal warning when a `signed_url` gate protects a path prefix containing write-like hints (`/api/`, `/write`, `/admin`, `/upload`, `/delete`) without `nonce_param` set:
+
+```
+[WARN] Route "admin-upload" uses signed_url on a write-like path ("/admin/upload") without nonce_param.
+       Signed URLs can be replayed on write endpoints. Set nonce_param and enforce single-use at origin.
+```
+
+Address by either adding `nonce_param` or moving the route to a different auth gate (JWT, static token).
+
+## Runtime Behaviour Summary
+
+| Input | Edge response |
+|---|---|
+| Valid signature + valid nonce + path matches | 200 (passes through, `X-Signed-URL-Nonce` forwarded) |
+| Valid signature, no nonce configured | 200 (passes through) |
+| Missing nonce when `nonce_param` set | 403 Missing nonce |
+| Malformed nonce (length/charset) | 403 Malformed nonce |
+| Signature mismatch (nonce tampered) | 403 Invalid signature |
+| `exact_path: true` and URI differs from prefix | Gate does not match → normal routing |
+| Expired (`exp < now`) | 403 URL expired |
+
+## Cross-Reference
+
+- Threat model: `docs/threat-model.md` §5 (Auth Gate)
+- Policy schema: `policy/schema.json` — `routes[].auth_gate`
+- Runtime reference: `runtimes/aws/origin-request.js`, `runtimes/cloudflare/index.ts`

--- a/docs/threat-model.ja.md
+++ b/docs/threat-model.ja.md
@@ -95,6 +95,32 @@ Edge / WAF / Origin のどのレイヤーが担当するかを明確にします
 
 ---
 
+### 9. JWKS SSRF（JWT ゲート経由のサーバーサイドリクエストフォージェリ）
+
+| 脅威 | Edge の責務 | WAF / Origin |
+|------|-------------|--------------|
+| クラウドメタデータ（`169.254.169.254`）、ループバック、RFC1918、リンクローカルを指す悪意ある／誤った `jwks_url` | ビルド時に拒否、ランタイムで再検証 | — |
+| JWKS ホストから内部エンドポイントへの攻撃者制御リダイレクト | 3xx レスポンスを拒否（Workers: `redirect: 'error'`、Lambda@Edge: 明示的な 3xx 拒否） | — |
+| ポリシーに明示的な allowlist がある場合、範囲外の IdP ホスト | ビルド時に `firewall.jwks.allowed_hosts` で拒否 | — |
+
+**フレームワーク**:
+- ビルド時バリデータ（`validateJwksUrl`）が `https://` 必須、userinfo / loopback / RFC1918 / リンクローカル / IPv4-mapped IPv6 を拒否し、任意で `firewall.jwks.allowed_hosts` メンバーシップを強制。
+- ランタイムの `fetchJwks` が URL を再チェックし、3xx レスポンスを拒否。
+- 運用推奨: 本番環境では `firewall.jwks.allowed_hosts` を必ず設定し IdP ホスト名を固定する。
+
+---
+
+### 10. HTTP Request Smuggling / Desync
+
+| 脅威 | Edge の責務 | WAF / Origin |
+|------|-------------|--------------|
+| クライアント由来の `Transfer-Encoding: chunked` による CloudFront/Worker ↔ Origin フレーミングのデシンク（CL.TE / TE.CL / H2.TE） | Origin 転送前に hop-by-hop ヘッダーを除去 | — |
+| クライアント由来の `Connection`、`Upgrade`、`TE`、`Keep-Alive`、`Proxy-*`、`Trailer` | Origin 転送前に除去 | — |
+
+**フレームワーク**: AWS origin-request Lambda と Cloudflare Worker の両方で、転送前に `transfer-encoding`、`connection`、`keep-alive`、`te`、`upgrade`、`proxy-connection`、`proxy-authenticate`、`proxy-authorization`、`trailer` を削除。CDN 自身がリクエストを再フレーム化するため、これらのヘッダーに正当なビューワー意図は存在しない。
+
+---
+
 ## 本フレームワークが対象としないもの
 
 * **高度な Bot 挙動**（WAF / Bot Management）。

--- a/docs/threat-model.ja.md
+++ b/docs/threat-model.ja.md
@@ -119,6 +119,17 @@ Edge / WAF / Origin のどのレイヤーが担当するかを明確にします
 
 **フレームワーク**: AWS origin-request Lambda と Cloudflare Worker の両方で、転送前に `transfer-encoding`、`connection`、`keep-alive`、`te`、`upgrade`、`proxy-connection`、`proxy-authenticate`、`proxy-authorization`、`trailer` を削除。CDN 自身がリクエストを再フレーム化するため、これらのヘッダーに正当なビューワー意図は存在しない。
 
+### 11. 署名付き URL のリプレイ
+
+| 脅威 | Edge の責務 | WAF / Origin |
+|------|-------------|--------------|
+| `/download/a.pdf` の署名 URL が兄弟パス `/download/b.pdf` に再利用される | `exact_path: true` で 1 パスに束ねる | — |
+| 1 本の署名 URL が TTL 内で繰り返し使われる | `nonce_param` で HMAC 入力にノンスを束ね、エッジが `X-Signed-URL-Nonce` を転送 | オリジンで単回利用を強制（例: Redis `SET NX`） |
+| ノンスを書き換えて他セッションと衝突させる | ノンスは HMAC 入力 (`uri + exp + '|' + nonce`) に含まれ、改ざんで署名が失敗 | — |
+| 書き込み系（POST/PUT/DELETE）を長寿命の署名 URL で保護 | `signed_url` が書き込み系プレフィックスに適用され、`nonce_param` 未設定のときはビルド時に警告 | — |
+
+**フレームワーク**: 署名ルール、ノンス書式（16〜256 文字、URL セーフ unreserved）、オリジン側のパターンは `docs/signed-urls.ja.md` を参照。エッジは署名とノンス束縛を検証するが、単回利用はエッジ関数がステートレスであるためオリジン側との協調が必須。
+
 ---
 
 ## 本フレームワークが対象としないもの

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -94,6 +94,32 @@ This document organizes threats that this Edge Security Framework is designed to
 
 ---
 
+### 9. JWKS SSRF (Server-Side Request Forgery via JWT gates)
+
+| Threat | Edge responsibility | WAF / Origin |
+|--------|---------------------|---------------|
+| Malicious or accidental `jwks_url` pointing at cloud metadata (`169.254.169.254`), loopback, RFC1918, or link-local ranges | Reject at build time and re-validate at runtime | — |
+| Attacker-controlled redirect from JWKS host to internal endpoint | Refuse 3xx responses (`redirect: 'error'` in Workers / explicit 3xx rejection in Lambda@Edge) | — |
+| Out-of-scope IdP host when policy has an explicit allowlist | Reject at build time via `firewall.jwks.allowed_hosts` | — |
+
+**Framework**:
+- Build-time validator (`validateJwksUrl`) enforces `https://`, rejects userinfo, loopback, RFC1918, link-local, IPv4-mapped IPv6, and optional `firewall.jwks.allowed_hosts` membership.
+- Runtime `fetchJwks` re-checks the URL and refuses any 3xx response.
+- Recommended operator practice: always set `firewall.jwks.allowed_hosts` in production to pin the exact IdP hostname(s).
+
+---
+
+### 10. HTTP Request Smuggling / Desync
+
+| Threat | Edge responsibility | WAF / Origin |
+|--------|---------------------|---------------|
+| Client-supplied `Transfer-Encoding: chunked` desynchronizing CloudFront/Worker ↔ origin framing (CL.TE / TE.CL / H2.TE) | Strip hop-by-hop headers before origin forward | — |
+| Client-supplied `Connection`, `Upgrade`, `TE`, `Keep-Alive`, `Proxy-*`, `Trailer` | Strip before origin forward | — |
+
+**Framework**: The AWS origin-request Lambda and Cloudflare Worker both delete `transfer-encoding`, `connection`, `keep-alive`, `te`, `upgrade`, `proxy-connection`, `proxy-authenticate`, `proxy-authorization`, and `trailer` from the forwarded request. The CDN re-frames the request, so none of these carry legitimate viewer intent.
+
+---
+
 ## What This Framework Does Not Mitigate
 
 * **Advanced bot behavior** (WAF / Bot Management).

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -118,6 +118,17 @@ This document organizes threats that this Edge Security Framework is designed to
 
 **Framework**: The AWS origin-request Lambda and Cloudflare Worker both delete `transfer-encoding`, `connection`, `keep-alive`, `te`, `upgrade`, `proxy-connection`, `proxy-authenticate`, `proxy-authorization`, and `trailer` from the forwarded request. The CDN re-frames the request, so none of these carry legitimate viewer intent.
 
+### 11. Signed URL Replay
+
+| Threat | Edge responsibility | WAF / Origin |
+|--------|---------------------|---------------|
+| Signed URL for `/download/a.pdf` reused against sibling path `/download/b.pdf` | `exact_path: true` binds signature to a single URI | — |
+| Single signed URL replayed repeatedly within its TTL | `nonce_param` binds per-URL nonce into HMAC + edge forwards `X-Signed-URL-Nonce` | Origin enforces single-use (e.g., Redis `SET NX`) |
+| Nonce tampered to collide with another session | Nonce included in HMAC input (`uri + exp + '|' + nonce`); tampering invalidates signature | — |
+| Write endpoint (POST/PUT/DELETE) protected by long-lived signed URL | Compile-time warning when `signed_url` gate hits write-like prefix without `nonce_param` | — |
+
+**Framework**: See `docs/signed-urls.md` for signing rules, nonce format (16–256 chars, URL-safe unreserved), and origin-side enforcement pattern. Edge enforces signature + nonce binding; single-use still requires origin cooperation because edge functions are stateless per invocation.
+
 ---
 
 ## What This Framework Does Not Mitigate

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -222,6 +222,18 @@
             "allowlist": { "type": "array", "items": { "type": "string" } },
             "blocklist": { "type": "array", "items": { "type": "string" } }
           }
+        },
+        "jwks": {
+          "description": "JWKS outbound-fetch guardrails. When `allowed_hosts` is set, the build refuses any JWT gate whose `jwks_url` hostname is not on the list, preventing SSRF into internal metadata endpoints. Regardless of this setting, the compiler also rejects non-HTTPS URLs and URLs that resolve to loopback, private, or link-local literals.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowed_hosts": {
+              "description": "Exact-match hostname allowlist for any `routes[].auth_gate.jwks_url`. Comparison is case-insensitive. Wildcards are not supported — list each IdP host explicitly.",
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
         }
       }
     },

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -147,7 +147,15 @@
                 "maximum": 86400
               },
               "expires_param": { "type": "string" },
-              "signature_param": { "type": "string" }
+              "signature_param": { "type": "string" },
+              "exact_path": {
+                "description": "If true, signed-URL gates require the request URI to exactly match a protected prefix. If false (default, back-compat), any URI under the prefix is acceptable — which lets an attacker replay a signature issued for one sibling path against another. Archetypes for sensitive downloads should always set `true`.",
+                "type": "boolean"
+              },
+              "nonce_param": {
+                "description": "Optional query-parameter name carrying a per-URL nonce (e.g. `nonce`). When set, the edge forwards the nonce to origin as `X-Signed-URL-Nonce` so origin can enforce single-use (SET NX in Redis / KV). The edge alone cannot enforce replay protection — origin cooperation is required. See docs/signed-urls.md.",
+                "type": "string"
+              }
             }
           },
           "response": { "type": "object", "properties": { "cache_control": { "type": "string" } } },

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -14,6 +14,7 @@ const {
   hasAllowPlaceholderFlag,
   hasFailOnPermissiveFlag,
   warnIfPermissive,
+  warnSignedUrlReplay,
 } = require('./lib/compile-core');
 
 const repoRoot = path.join(__dirname, '..');
@@ -49,6 +50,9 @@ const permissive = warnIfPermissive(policy, { failOnPermissive });
 if (permissive.failed) {
   process.exit(1);
 }
+
+// Non-fatal advisory: signed_url protecting write-like paths without nonce_param.
+warnSignedUrlReplay(policy);
 
 // Cloudflare Workers reads env at runtime for static_token/basic_auth, so build
 // does not require the actual token value. Only structural gate fields matter.
@@ -107,6 +111,10 @@ function getWorkerAuthGates() {
       gateConfig.secret_env = gate.secret_env || 'URL_SIGNING_SECRET';
       gateConfig.expires_param = gate.expires_param || 'exp';
       gateConfig.signature_param = gate.signature_param || 'sig';
+      gateConfig.exact_path = gate.exact_path === true;
+      gateConfig.nonce_param = typeof gate.nonce_param === 'string' && gate.nonce_param.trim()
+        ? gate.nonce_param.trim()
+        : '';
     }
 
     gates.push(gateConfig);

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -10,6 +10,7 @@ const {
   regexesLiteralCode,
   getAuthGates,
   validateAuthGates,
+  validateJwksUrl,
   build,
   PLACEHOLDER_TOKEN,
   hasFailOnPermissiveFlag,
@@ -589,6 +590,107 @@ test('warnIfPermissive fails when failOnPermissive is true', () => {
   assert.deepStrictEqual(result, { warned: true, failed: true });
   assert.strictEqual(captured.length, 2);
   assert.match(captured[1], /refusing to build a permissive policy/);
+});
+
+test('validateJwksUrl accepts well-formed public https URLs', () => {
+  assert.deepStrictEqual(
+    validateJwksUrl('https://idp.example.com/.well-known/jwks.json').ok,
+    true,
+  );
+  assert.deepStrictEqual(
+    validateJwksUrl('https://login.microsoftonline.com/common/discovery/v2.0/keys').ok,
+    true,
+  );
+});
+
+test('validateJwksUrl rejects non-https schemes', () => {
+  assert.strictEqual(validateJwksUrl('http://idp.example.com/jwks.json').ok, false);
+  assert.strictEqual(validateJwksUrl('file:///etc/passwd').ok, false);
+  assert.strictEqual(validateJwksUrl('ftp://example.com/jwks.json').ok, false);
+});
+
+test('validateJwksUrl rejects URLs with userinfo', () => {
+  const r = validateJwksUrl('https://user:pass@idp.example.com/jwks.json');
+  assert.strictEqual(r.ok, false);
+  assert.match(r.reason, /userinfo/);
+});
+
+test('validateJwksUrl rejects loopback / private / link-local hostnames', () => {
+  const cases = [
+    'https://localhost/jwks.json',
+    'https://127.0.0.1/jwks.json',
+    'https://127.5.5.5/jwks.json',
+    'https://10.0.0.1/jwks.json',
+    'https://10.255.255.254/jwks.json',
+    'https://192.168.1.1/jwks.json',
+    'https://172.16.0.1/jwks.json',
+    'https://172.31.255.255/jwks.json',
+    'https://169.254.169.254/latest/meta-data/',
+    'https://0.0.0.0/jwks.json',
+    'https://[::1]/jwks.json',
+    'https://[fe80::1]/jwks.json',
+    'https://[fc00::1]/jwks.json',
+    'https://[::ffff:127.0.0.1]/jwks.json',
+  ];
+  for (const url of cases) {
+    const r = validateJwksUrl(url);
+    assert.strictEqual(r.ok, false, `should reject ${url}`);
+  }
+});
+
+test('validateJwksUrl enforces allowed_hosts when provided', () => {
+  const allow = ['idp.example.com', 'Auth.Example.Com'];
+  assert.strictEqual(validateJwksUrl('https://idp.example.com/jwks.json', allow).ok, true);
+  assert.strictEqual(validateJwksUrl('https://auth.example.com/jwks.json', allow).ok, true);
+  const r = validateJwksUrl('https://evil.example.com/jwks.json', allow);
+  assert.strictEqual(r.ok, false);
+  assert.match(r.reason, /firewall\.jwks\.allowed_hosts/);
+});
+
+test('validateAuthGates rejects jwks_url in private/loopback ranges', () => {
+  const policy = {
+    routes: [
+      {
+        name: 'metadata-ssrf',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://169.254.169.254/latest/' },
+      },
+    ],
+  };
+  assert.throws(
+    () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
+    (err) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e) => /metadata-ssrf/.test(e) && /private\/loopback/.test(e)),
+  );
+});
+
+test('validateAuthGates rejects jwks_url outside firewall.jwks.allowed_hosts', () => {
+  const policy = {
+    firewall: { jwks: { allowed_hosts: ['idp.example.com'] } },
+    routes: [
+      {
+        name: 'wrong-idp',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://attacker.example/jwks.json' },
+      },
+    ],
+  };
+  assert.throws(
+    () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
+    (err) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e) => /wrong-idp/.test(e) && /allowed_hosts/.test(e)),
+  );
+});
+
+test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', () => {
+  const policy = {
+    firewall: { jwks: { allowed_hosts: ['IDP.Example.COM'] } },
+    routes: [
+      {
+        name: 'good-idp',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+      },
+    ],
+  };
+  validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
 });
 
 if (process.exitCode) {

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -15,6 +15,7 @@ const {
   PLACEHOLDER_TOKEN,
   hasFailOnPermissiveFlag,
   warnIfPermissive,
+  warnSignedUrlReplay,
 } = require('./lib/compile-core');
 
 function test(name, fn) {
@@ -691,6 +692,112 @@ test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', (
     ],
   };
   validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
+});
+
+test('warnSignedUrlReplay flags write-like signed_url gates missing nonce_param', () => {
+  const captured = [];
+  const logger = { error: (m) => captured.push(m) };
+  const policy = {
+    routes: [
+      {
+        name: 'write-download',
+        match: { path_prefixes: ['/api/download'] },
+        auth_gate: { type: 'signed_url', secret_env: 'URL_SIGNING_SECRET' },
+      },
+    ],
+  };
+  const r = warnSignedUrlReplay(policy, { logger });
+  assert.strictEqual(r.warned, true);
+  assert.strictEqual(r.warnings.length, 1);
+  assert.match(captured[0], /write-download/);
+  assert.match(captured[0], /nonce_param/);
+});
+
+test('warnSignedUrlReplay stays silent for read-only paths', () => {
+  const captured = [];
+  const logger = { error: (m) => captured.push(m) };
+  const policy = {
+    routes: [
+      {
+        name: 'cdn-assets',
+        match: { path_prefixes: ['/assets'] },
+        auth_gate: { type: 'signed_url', secret_env: 'URL_SIGNING_SECRET' },
+      },
+    ],
+  };
+  const r = warnSignedUrlReplay(policy, { logger });
+  assert.strictEqual(r.warned, false);
+  assert.strictEqual(captured.length, 0);
+});
+
+test('warnSignedUrlReplay stays silent when nonce_param is set', () => {
+  const captured = [];
+  const logger = { error: (m) => captured.push(m) };
+  const policy = {
+    routes: [
+      {
+        name: 'write-download',
+        match: { path_prefixes: ['/api/download'] },
+        auth_gate: { type: 'signed_url', secret_env: 'URL_SIGNING_SECRET', nonce_param: 'nonce' },
+      },
+    ],
+  };
+  const r = warnSignedUrlReplay(policy, { logger });
+  assert.strictEqual(r.warned, false);
+  assert.strictEqual(captured.length, 0);
+});
+
+test('build emits signed_url gate with exact_path and nonce_param fields', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-signed-'));
+  try {
+    const policy = {
+      version: 1,
+      request: { allow_methods: ['GET'] },
+      response_headers: {},
+      routes: [
+        {
+          name: 'one-time',
+          match: { path_prefixes: ['/api/download/report.pdf'] },
+          auth_gate: {
+            type: 'signed_url',
+            secret_env: 'URL_SIGNING_SECRET',
+            exact_path: true,
+            nonce_param: 'nonce',
+          },
+        },
+      ],
+    };
+    build(policy, { outDir: tmpDir, allowPlaceholderToken: true });
+    const origin = fs.readFileSync(path.join(tmpDir, 'edge', 'origin-request.js'), 'utf8');
+    assert.match(origin, /"exact_path":true/);
+    assert.match(origin, /"nonce_param":"nonce"/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('build defaults exact_path=false and nonce_param="" when unspecified', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-signed-def-'));
+  try {
+    const policy = {
+      version: 1,
+      request: { allow_methods: ['GET'] },
+      response_headers: {},
+      routes: [
+        {
+          name: 'legacy',
+          match: { path_prefixes: ['/assets'] },
+          auth_gate: { type: 'signed_url', secret_env: 'URL_SIGNING_SECRET' },
+        },
+      ],
+    };
+    build(policy, { outDir: tmpDir, allowPlaceholderToken: true });
+    const origin = fs.readFileSync(path.join(tmpDir, 'edge', 'origin-request.js'), 'utf8');
+    assert.match(origin, /"exact_path":false/);
+    assert.match(origin, /"nonce_param":""/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 if (process.exitCode) {

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -150,6 +150,91 @@ function regexesLiteralCode(regexSources) {
   return '[' + literals.join(', ') + ']';
 }
 
+// Reject JWKS URLs that point at loopback, private, link-local, or other
+// internal address ranges. An attacker who can influence the JWKS URL at
+// build time (via a policy PR) or at runtime (via a regression that lets a
+// client seed the cache) could otherwise force the edge to fetch cloud
+// metadata endpoints (169.254.169.254) or internal services.
+const JWKS_DISALLOWED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'broadcasthost',
+]);
+
+function isPrivateIPv4Literal(hostname) {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+  if (!m) return false;
+  const octets = m.slice(1, 5).map(Number);
+  if (octets.some((o) => o < 0 || o > 255)) return false;
+  const [a, b] = octets;
+  if (a === 10) return true;                             // 10.0.0.0/8
+  if (a === 127) return true;                            // loopback
+  if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;               // 192.168.0.0/16
+  if (a === 169 && b === 254) return true;               // link-local / metadata
+  if (a === 100 && b >= 64 && b <= 127) return true;     // CGN 100.64.0.0/10
+  if (a === 0) return true;                              // 0.0.0.0/8
+  if (a >= 224) return true;                             // multicast / reserved
+  return false;
+}
+
+function isPrivateIPv6Literal(hostname) {
+  const h = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1).toLowerCase()
+    : hostname.toLowerCase();
+  if (!h.includes(':')) return false;
+  if (h === '::' || h === '::1') return true;
+  if (h.startsWith('fe80:') || h.startsWith('fe80::')) return true;   // link-local
+  if (h.startsWith('fc') || h.startsWith('fd')) return true;          // ULA fc00::/7
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d). Node's WHATWG URL normalizes the
+  // trailing IPv4 to hex (e.g. ::ffff:127.0.0.1 → ::ffff:7f00:1), so we
+  // reject the entire `::ffff:` family. Legitimate public IdPs never serve
+  // JWKS behind an IPv4-mapped literal — they use a real v4 or v6 address.
+  if (h.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function validateJwksUrl(rawUrl, allowedHosts) {
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return { ok: false, reason: 'jwks_url is empty' };
+  }
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: `jwks_url is not a valid URL: ${rawUrl}` };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: `jwks_url must use https:// (got ${parsed.protocol})` };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, reason: 'jwks_url must not contain userinfo (user:pass@host)' };
+  }
+  const hostname = (parsed.hostname || '').toLowerCase();
+  if (!hostname) {
+    return { ok: false, reason: 'jwks_url has empty hostname' };
+  }
+  if (JWKS_DISALLOWED_HOSTNAMES.has(hostname)) {
+    return { ok: false, reason: `jwks_url hostname "${hostname}" is a loopback alias` };
+  }
+  if (isPrivateIPv4Literal(hostname) || isPrivateIPv6Literal(parsed.hostname)) {
+    return { ok: false, reason: `jwks_url hostname "${hostname}" resolves to a private/loopback/link-local range` };
+  }
+  if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
+    const normalized = allowedHosts
+      .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
+      .filter(Boolean);
+    if (!normalized.includes(hostname)) {
+      return {
+        ok: false,
+        reason: `jwks_url hostname "${hostname}" is not in firewall.jwks.allowed_hosts (${normalized.join(', ')})`,
+      };
+    }
+  }
+  return { ok: true, hostname };
+}
+
 function validateAuthGates(policy, options = {}) {
   const exitOnError = options.exitOnError !== false;
   const logger = options.logger || console;
@@ -157,6 +242,7 @@ function validateAuthGates(policy, options = {}) {
   const allowPlaceholderToken = options.allowPlaceholderToken === true;
   const routes = policy.routes || [];
   const errors = [];
+  const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
 
   for (const route of routes) {
     const gate = route.auth_gate;
@@ -168,6 +254,12 @@ function validateAuthGates(policy, options = {}) {
       const alg = gate.algorithm || 'RS256';
       if (alg === 'RS256' && !gate.jwks_url) {
         errors.push(`Route "${name}": JWT+RS256 requires "jwks_url"`);
+      }
+      if (gate.jwks_url) {
+        const v = validateJwksUrl(gate.jwks_url, jwksAllowedHosts);
+        if (!v.ok) {
+          errors.push(`Route "${name}": ${v.reason}`);
+        }
       }
       if (alg === 'HS256' && !gate.secret_env) {
         errors.push(`Route "${name}": JWT+HS256 requires "secret_env"`);
@@ -534,6 +626,7 @@ module.exports = {
   hasAllowPlaceholderFlag,
   hasFailOnPermissiveFlag,
   warnIfPermissive,
+  validateJwksUrl,
   build,
   main,
   PLACEHOLDER_TOKEN,

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -389,6 +389,37 @@ function hasFailOnPermissiveFlag(argv) {
   return Array.isArray(argv) && argv.includes('--fail-on-permissive');
 }
 
+// Heuristic: paths that usually mutate state and therefore deserve replay
+// protection rather than just an expiry window. Matching is permissive (any
+// prefix that contains one of these substrings) because write patterns vary
+// by application convention.
+const SIGNED_URL_WRITE_PATH_HINTS = ['/api/', '/write', '/admin', '/upload', '/delete'];
+
+function warnSignedUrlReplay(policy, options = {}) {
+  const logger = options.logger || console;
+  const routes = policy.routes || [];
+  const warnings = [];
+  for (const route of routes) {
+    const gate = route.auth_gate;
+    if (!gate || gate.type !== 'signed_url') continue;
+    if (gate.nonce_param && typeof gate.nonce_param === 'string' && gate.nonce_param.trim()) continue;
+    const match = route.match || {};
+    const prefixes = match.path_prefixes || [];
+    const writeLike = prefixes.find((p) =>
+      SIGNED_URL_WRITE_PATH_HINTS.some((hint) => p.toLowerCase().includes(hint)),
+    );
+    if (writeLike) {
+      warnings.push(
+        `Route "${route.name || 'unnamed'}": signed_url protects ${JSON.stringify(writeLike)} but has no "nonce_param". ` +
+          'URLs are replayable within the expiry window — add nonce_param and enforce single-use at origin. See docs/signed-urls.md.',
+      );
+    }
+  }
+  if (warnings.length === 0) return { warned: false, warnings };
+  for (const w of warnings) logger.error('[WARN] ' + w);
+  return { warned: true, warnings };
+}
+
 function warnIfPermissive(policy, options = {}) {
   const failOnPermissive = options.failOnPermissive === true;
   const logger = options.logger || console;
@@ -545,6 +576,10 @@ function build(policy, options = {}) {
       secret_env: gate.secret_env || 'URL_SIGNING_SECRET',
       expires_param: gate.expires_param || 'exp',
       signature_param: gate.signature_param || 'sig',
+      exact_path: gate.exact_path === true,
+      nonce_param: typeof gate.nonce_param === 'string' && gate.nonce_param.trim()
+        ? gate.nonce_param.trim()
+        : '',
     };
   });
 
@@ -594,6 +629,9 @@ function main(argv = process.argv.slice(2)) {
     process.exit(1);
   }
 
+  // Non-fatal advisory: signed_url protecting write-like paths without nonce_param.
+  warnSignedUrlReplay(policy);
+
   validateAuthGates(policy, { allowPlaceholderToken });
 
   try {
@@ -626,6 +664,7 @@ module.exports = {
   hasAllowPlaceholderFlag,
   hasFailOnPermissiveFlag,
   warnIfPermissive,
+  warnSignedUrlReplay,
   validateJwksUrl,
   build,
   main,

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -406,6 +406,14 @@ function createSignedUrlParams(uri, expiresSec, secret) {
   return 'exp=' + expiresSec + '&sig=' + sig;
 }
 
+function createSignedUrlWithNonce(uri, expiresSec, secret, nonce) {
+  const signData = uri + String(expiresSec) + '|' + nonce;
+  const sig = crypto.createHmac('sha256', secret)
+    .update(signData)
+    .digest('base64url');
+  return 'exp=' + expiresSec + '&nonce=' + nonce + '&sig=' + sig;
+}
+
 async function runOriginRequestTests() {
   const testSecret = HS256_SECRET;
   process.env.JWT_TEST_SECRET = testSecret;
@@ -433,7 +441,19 @@ async function runOriginRequestTests() {
     '    algorithm: "HMAC-SHA256",',
     '    secret_env: "URL_SIGNING_SECRET",',
     '    expires_param: "exp",',
-    '    signature_param: "sig"',
+    '    signature_param: "sig",',
+    '    exact_path: false,',
+    '    nonce_param: ""',
+    '  }, {',
+    '    name: "one-time-download",',
+    '    protectedPrefixes: ["/download/report.pdf"],',
+    '    type: "signed_url",',
+    '    algorithm: "HMAC-SHA256",',
+    '    secret_env: "URL_SIGNING_SECRET",',
+    '    expires_param: "exp",',
+    '    signature_param: "sig",',
+    '    exact_path: true,',
+    '    nonce_param: "nonce"',
     '  }],',
     '  originAuth: null',
     '};',
@@ -600,6 +620,28 @@ async function runOriginRequestTests() {
     ['origin: GET /other/file not protected by signed URL',
       buildLambdaEdgeEvent('/other/file', {}, ''),
       'allow'],
+
+    // --- exact_path: reject sibling-path replay ---
+    ['origin: exact_path rejects sibling path with valid signature for /download/report.pdf',
+      buildLambdaEdgeEvent('/download/leaked.pdf', {},
+        createSignedUrlWithNonce('/download/report.pdf', nowSec + 3600, SIGNED_URL_SECRET, 'nonce-0123456789abcdef')),
+      'allow'],
+
+    // --- nonce_param required: accept when present, reject when missing ---
+    ['origin: exact_path + nonce accepts well-formed one-time URL',
+      buildLambdaEdgeEvent('/download/report.pdf', {},
+        createSignedUrlWithNonce('/download/report.pdf', nowSec + 3600, SIGNED_URL_SECRET, 'nonce-0123456789abcdef')),
+      'allow'],
+
+    ['origin: exact_path + nonce rejects when nonce missing',
+      buildLambdaEdgeEvent('/download/report.pdf', {},
+        createSignedUrlParams('/download/report.pdf', nowSec + 3600, SIGNED_URL_SECRET)),
+      '403'],
+
+    ['origin: exact_path + nonce rejects short/invalid nonce',
+      buildLambdaEdgeEvent('/download/report.pdf', {},
+        createSignedUrlWithNonce('/download/report.pdf', nowSec + 3600, SIGNED_URL_SECRET, 'short')),
+      '403'],
   ];
 
   let originFailed = 0;
@@ -621,8 +663,52 @@ async function runOriginRequestTests() {
     console.log('OK: origin strips client-supplied x-forwarded-for');
   }
 
-  console.log('--- origin-request (enforce): ' + (originCases.length + 1 - originFailed) + '/' + (originCases.length + 1) + ' passed ---');
-  return { failed: originFailed, total: originCases.length + 1 };
+  // Hop-by-hop / smuggling header stripping (defense-in-depth).
+  const smugEvent = buildLambdaEdgeEvent('/other/file', {
+    'transfer-encoding': 'chunked',
+    'connection': 'close',
+    'upgrade': 'websocket',
+    'te': 'trailers',
+    'keep-alive': 'timeout=5',
+    'proxy-connection': 'keep-alive',
+    'trailer': 'Expires',
+  });
+  const smugResult = await originHandler(smugEvent);
+  const smugStripped = smugResult && smugResult.uri !== undefined
+    && !smugResult.headers['transfer-encoding']
+    && !smugResult.headers['connection']
+    && !smugResult.headers['upgrade']
+    && !smugResult.headers['te']
+    && !smugResult.headers['keep-alive']
+    && !smugResult.headers['proxy-connection']
+    && !smugResult.headers['trailer'];
+  if (!smugStripped) {
+    console.error('FAIL: origin should strip hop-by-hop / smuggling headers, headers=',
+      smugResult && smugResult.headers);
+    originFailed++;
+  } else {
+    console.log('OK: origin strips hop-by-hop smuggling headers');
+  }
+
+  // Nonce forwarding: successful signed_url verification must set
+  // X-Signed-URL-Nonce on the forwarded request.
+  const nonceVal = 'nonce-0123456789abcdef';
+  const nonceEvent = buildLambdaEdgeEvent('/download/report.pdf', {},
+    createSignedUrlWithNonce('/download/report.pdf', nowSec + 3600, SIGNED_URL_SECRET, nonceVal));
+  const nonceResult = await originHandler(nonceEvent);
+  const nonceHeader = nonceResult && nonceResult.headers && nonceResult.headers['x-signed-url-nonce'];
+  const nonceOk = Array.isArray(nonceHeader) && nonceHeader[0] && nonceHeader[0].value === nonceVal;
+  if (!nonceOk) {
+    console.error('FAIL: origin should forward X-Signed-URL-Nonce, got=',
+      nonceResult && nonceResult.headers && nonceResult.headers['x-signed-url-nonce']);
+    originFailed++;
+  } else {
+    console.log('OK: origin forwards X-Signed-URL-Nonce header to origin');
+  }
+
+  const extraAsserts = 3;
+  console.log('--- origin-request (enforce): ' + (originCases.length + extraAsserts - originFailed) + '/' + (originCases.length + extraAsserts) + ' passed ---');
+  return { failed: originFailed, total: originCases.length + extraAsserts };
 }
 
 // Monitor mode tests: blocking checks should pass through

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -300,15 +300,30 @@ function verifySignedUrl(uri, querystring, gate) {
   const params = new URLSearchParams(querystring);
   const exp = params.get(gate.expires_param);
   const sig = params.get(gate.signature_param);
-  
+
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
   if (Date.now() > parseInt(exp) * 1000) return { valid: false, error: 'URL expired' };
-  
-  // Compute expected signature: HMAC-SHA256(uri + exp, secret)
+
+  let nonce = null;
+  if (gate.nonce_param) {
+    nonce = params.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    // Reject empty / overly long nonces before hitting origin. 16..256 chars
+    // matches a typical ULID/UUID/base64(16B) envelope; anything outside that
+    // is almost certainly crafted noise.
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
+  // Compute expected signature: HMAC-SHA256(uri + exp [+ nonce], secret)
   const secret = process.env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'Secret not configured' };
-  
-  const signData = uri + exp;
+
+  // When a nonce is part of the scheme, include it in the signed material so
+  // tampering with it invalidates the signature (origin still enforces single-
+  // use separately).
+  const signData = uri + exp + (nonce ? ('|' + nonce) : '');
   const expectedSig = crypto.createHmac('sha256', secret)
     .update(signData)
     .digest('base64url');
@@ -319,7 +334,7 @@ function verifySignedUrl(uri, querystring, gate) {
   const isValid = expectedBuf.length === providedBuf.length &&
     crypto.timingSafeEqual(expectedBuf, providedBuf);
 
-  return { valid: isValid };
+  return { valid: isValid, nonce };
 }
 
 // Check JWT auth gates
@@ -368,19 +383,33 @@ async function checkJwtGates(request) {
 function checkSignedUrlGates(request) {
   const uri = request.uri || '/';
   const qs = request.querystring || '';
-  
+
   for (const gate of CFG.signedUrlGates) {
-    const isProtected = gate.protectedPrefixes.some(
-      p => uri === p || uri.startsWith(p + '/')
-    );
+    // exact_path: signature is bound to the exact URI. Without it, a signed
+    // URL for /assets/ can be replayed against /assets/other-file if an
+    // operator accidentally signs a prefix. exact_path rejects any request
+    // whose URI is not one of the protected paths verbatim.
+    const isProtected = gate.exact_path
+      ? gate.protectedPrefixes.some((p) => uri === p)
+      : gate.protectedPrefixes.some((p) => uri === p || uri.startsWith(p + '/'));
     if (!isProtected) continue;
-    
+
     const result = verifySignedUrl(uri, qs, gate);
     if (!result.valid) {
       return resp(403, result.error || 'Invalid signature');
     }
+
+    // Forward the nonce to origin so it can enforce single-use (SET NX in
+    // Redis / conditional write in DynamoDB). The edge alone cannot enforce
+    // replay protection statelessly — origin cooperation is required.
+    if (gate.nonce_param && result.nonce && request.headers) {
+      request.headers['x-signed-url-nonce'] = [{
+        key: 'X-Signed-URL-Nonce',
+        value: result.nonce,
+      }];
+    }
   }
-  
+
   return null;
 }
 

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -54,8 +54,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -63,6 +88,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -388,6 +426,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -199,7 +199,7 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
   return { valid: false, error: 'Unsupported JWT algorithm' };
 }
 
-async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string }> {
+async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string; nonce?: string | null }> {
   const exp = url.searchParams.get(gate.expires_param || 'exp');
   const sig = url.searchParams.get(gate.signature_param || 'sig');
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
@@ -209,12 +209,22 @@ async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ v
     return { valid: false, error: 'URL expired' };
   }
 
+  let nonce: string | null = null;
+  if (gate.nonce_param) {
+    nonce = url.searchParams.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
   const secret = env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'URL signing secret not configured' };
 
-  const expected = await hmacSha256Base64Url(secret, `${url.pathname}${exp}`);
+  const signData = `${url.pathname}${exp}` + (nonce ? `|${nonce}` : '');
+  const expected = await hmacSha256Base64Url(secret, signData);
   if (!timingSafeEqual(expected, sig)) return { valid: false, error: 'Invalid signature' };
-  return { valid: true };
+  return { valid: true, nonce };
 }
 
 function isHostAllowed(hostHeader: string): boolean {
@@ -343,8 +353,16 @@ export default {
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);
 
+    // Nonce to forward to origin after a successful signed_url verification.
+    // Collected here and attached when we build the origin-facing Request.
+    let signedUrlNonce: string | null = null;
     for (const gate of CFG.authGates) {
-      const isProtected = gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
+      // signed_url gates may opt into exact_path matching to prevent a signature
+      // for /assets/ from being replayed against /assets/other-file.
+      const useExact = gate.type === 'signed_url' && gate.exact_path === true;
+      const isProtected = useExact
+        ? gate.protectedPrefixes.some((p: string) => url.pathname === p)
+        : gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
       if (!isProtected) continue;
 
       if (gate.type === 'static_token') {
@@ -412,6 +430,9 @@ export default {
           if (r) return r;
           continue;
         }
+        if (gate.nonce_param && verified.nonce) {
+          signedUrlNonce = verified.nonce;
+        }
       }
     }
 
@@ -440,6 +461,12 @@ export default {
         const headerName = CFG.originAuth.header || 'X-Origin-Verify';
         forwardHeaders.set(headerName, secret);
       }
+    }
+    // Forward signed-URL nonce so origin can enforce single-use. The edge
+    // cannot enforce replay protection statelessly — origin must reject
+    // re-use (SET NX in KV/Redis).
+    if (signedUrlNonce) {
+      forwardHeaders.set('X-Signed-URL-Nonce', signedUrlNonce);
     }
 
     const res = await fetch(new Request(url.toString(), {

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -81,15 +81,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -398,6 +425,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -230,7 +230,7 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
   return { valid: false, error: 'Unsupported JWT algorithm' };
 }
 
-async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string }> {
+async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string; nonce?: string | null }> {
   const exp = url.searchParams.get(gate.expires_param || 'exp');
   const sig = url.searchParams.get(gate.signature_param || 'sig');
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
@@ -240,12 +240,22 @@ async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ v
     return { valid: false, error: 'URL expired' };
   }
 
+  let nonce: string | null = null;
+  if (gate.nonce_param) {
+    nonce = url.searchParams.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
   const secret = env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'URL signing secret not configured' };
 
-  const expected = await hmacSha256Base64Url(secret, `${url.pathname}${exp}`);
+  const signData = `${url.pathname}${exp}` + (nonce ? `|${nonce}` : '');
+  const expected = await hmacSha256Base64Url(secret, signData);
   if (!timingSafeEqual(expected, sig)) return { valid: false, error: 'Invalid signature' };
-  return { valid: true };
+  return { valid: true, nonce };
 }
 
 function isHostAllowed(hostHeader: string): boolean {
@@ -374,8 +384,16 @@ export default {
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);
 
+    // Nonce to forward to origin after a successful signed_url verification.
+    // Collected here and attached when we build the origin-facing Request.
+    let signedUrlNonce: string | null = null;
     for (const gate of CFG.authGates) {
-      const isProtected = gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
+      // signed_url gates may opt into exact_path matching to prevent a signature
+      // for /assets/ from being replayed against /assets/other-file.
+      const useExact = gate.type === 'signed_url' && gate.exact_path === true;
+      const isProtected = useExact
+        ? gate.protectedPrefixes.some((p: string) => url.pathname === p)
+        : gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
       if (!isProtected) continue;
 
       if (gate.type === 'static_token') {
@@ -443,6 +461,9 @@ export default {
           if (r) return r;
           continue;
         }
+        if (gate.nonce_param && verified.nonce) {
+          signedUrlNonce = verified.nonce;
+        }
       }
     }
 
@@ -471,6 +492,12 @@ export default {
         const headerName = CFG.originAuth.header || 'X-Origin-Verify';
         forwardHeaders.set(headerName, secret);
       }
+    }
+    // Forward signed-URL nonce so origin can enforce single-use. The edge
+    // cannot enforce replay protection statelessly — origin must reject
+    // re-use (SET NX in KV/Redis).
+    if (signedUrlNonce) {
+      forwardHeaders.set('X-Signed-URL-Nonce', signedUrlNonce);
     }
 
     const res = await fetch(new Request(url.toString(), {

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -308,15 +308,30 @@ function verifySignedUrl(uri, querystring, gate) {
   const params = new URLSearchParams(querystring);
   const exp = params.get(gate.expires_param);
   const sig = params.get(gate.signature_param);
-  
+
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
   if (Date.now() > parseInt(exp) * 1000) return { valid: false, error: 'URL expired' };
-  
-  // Compute expected signature: HMAC-SHA256(uri + exp, secret)
+
+  let nonce = null;
+  if (gate.nonce_param) {
+    nonce = params.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    // Reject empty / overly long nonces before hitting origin. 16..256 chars
+    // matches a typical ULID/UUID/base64(16B) envelope; anything outside that
+    // is almost certainly crafted noise.
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
+  // Compute expected signature: HMAC-SHA256(uri + exp [+ nonce], secret)
   const secret = process.env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'Secret not configured' };
-  
-  const signData = uri + exp;
+
+  // When a nonce is part of the scheme, include it in the signed material so
+  // tampering with it invalidates the signature (origin still enforces single-
+  // use separately).
+  const signData = uri + exp + (nonce ? ('|' + nonce) : '');
   const expectedSig = crypto.createHmac('sha256', secret)
     .update(signData)
     .digest('base64url');
@@ -327,7 +342,7 @@ function verifySignedUrl(uri, querystring, gate) {
   const isValid = expectedBuf.length === providedBuf.length &&
     crypto.timingSafeEqual(expectedBuf, providedBuf);
 
-  return { valid: isValid };
+  return { valid: isValid, nonce };
 }
 
 // Check JWT auth gates
@@ -376,19 +391,33 @@ async function checkJwtGates(request) {
 function checkSignedUrlGates(request) {
   const uri = request.uri || '/';
   const qs = request.querystring || '';
-  
+
   for (const gate of CFG.signedUrlGates) {
-    const isProtected = gate.protectedPrefixes.some(
-      p => uri === p || uri.startsWith(p + '/')
-    );
+    // exact_path: signature is bound to the exact URI. Without it, a signed
+    // URL for /assets/ can be replayed against /assets/other-file if an
+    // operator accidentally signs a prefix. exact_path rejects any request
+    // whose URI is not one of the protected paths verbatim.
+    const isProtected = gate.exact_path
+      ? gate.protectedPrefixes.some((p) => uri === p)
+      : gate.protectedPrefixes.some((p) => uri === p || uri.startsWith(p + '/'));
     if (!isProtected) continue;
-    
+
     const result = verifySignedUrl(uri, qs, gate);
     if (!result.valid) {
       return resp(403, result.error || 'Invalid signature');
     }
+
+    // Forward the nonce to origin so it can enforce single-use (SET NX in
+    // Redis / conditional write in DynamoDB). The edge alone cannot enforce
+    // replay protection statelessly — origin cooperation is required.
+    if (gate.nonce_param && result.nonce && request.headers) {
+      request.headers['x-signed-url-nonce'] = [{
+        key: 'X-Signed-URL-Nonce',
+        value: result.nonce,
+      }];
+    }
   }
-  
+
   return null;
 }
 

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -230,7 +230,7 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
   return { valid: false, error: 'Unsupported JWT algorithm' };
 }
 
-async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string }> {
+async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string; nonce?: string | null }> {
   const exp = url.searchParams.get(gate.expires_param || 'exp');
   const sig = url.searchParams.get(gate.signature_param || 'sig');
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
@@ -240,12 +240,22 @@ async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ v
     return { valid: false, error: 'URL expired' };
   }
 
+  let nonce: string | null = null;
+  if (gate.nonce_param) {
+    nonce = url.searchParams.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
   const secret = env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'URL signing secret not configured' };
 
-  const expected = await hmacSha256Base64Url(secret, `${url.pathname}${exp}`);
+  const signData = `${url.pathname}${exp}` + (nonce ? `|${nonce}` : '');
+  const expected = await hmacSha256Base64Url(secret, signData);
   if (!timingSafeEqual(expected, sig)) return { valid: false, error: 'Invalid signature' };
-  return { valid: true };
+  return { valid: true, nonce };
 }
 
 function isHostAllowed(hostHeader: string): boolean {
@@ -374,8 +384,16 @@ export default {
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);
 
+    // Nonce to forward to origin after a successful signed_url verification.
+    // Collected here and attached when we build the origin-facing Request.
+    let signedUrlNonce: string | null = null;
     for (const gate of CFG.authGates) {
-      const isProtected = gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
+      // signed_url gates may opt into exact_path matching to prevent a signature
+      // for /assets/ from being replayed against /assets/other-file.
+      const useExact = gate.type === 'signed_url' && gate.exact_path === true;
+      const isProtected = useExact
+        ? gate.protectedPrefixes.some((p: string) => url.pathname === p)
+        : gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
       if (!isProtected) continue;
 
       if (gate.type === 'static_token') {
@@ -443,6 +461,9 @@ export default {
           if (r) return r;
           continue;
         }
+        if (gate.nonce_param && verified.nonce) {
+          signedUrlNonce = verified.nonce;
+        }
       }
     }
 
@@ -471,6 +492,12 @@ export default {
         const headerName = CFG.originAuth.header || 'X-Origin-Verify';
         forwardHeaders.set(headerName, secret);
       }
+    }
+    // Forward signed-URL nonce so origin can enforce single-use. The edge
+    // cannot enforce replay protection statelessly — origin must reject
+    // re-use (SET NX in KV/Redis).
+    if (signedUrlNonce) {
+      forwardHeaders.set('X-Signed-URL-Nonce', signedUrlNonce);
     }
 
     const res = await fetch(new Request(url.toString(), {

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -308,15 +308,30 @@ function verifySignedUrl(uri, querystring, gate) {
   const params = new URLSearchParams(querystring);
   const exp = params.get(gate.expires_param);
   const sig = params.get(gate.signature_param);
-  
+
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
   if (Date.now() > parseInt(exp) * 1000) return { valid: false, error: 'URL expired' };
-  
-  // Compute expected signature: HMAC-SHA256(uri + exp, secret)
+
+  let nonce = null;
+  if (gate.nonce_param) {
+    nonce = params.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    // Reject empty / overly long nonces before hitting origin. 16..256 chars
+    // matches a typical ULID/UUID/base64(16B) envelope; anything outside that
+    // is almost certainly crafted noise.
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
+  // Compute expected signature: HMAC-SHA256(uri + exp [+ nonce], secret)
   const secret = process.env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'Secret not configured' };
-  
-  const signData = uri + exp;
+
+  // When a nonce is part of the scheme, include it in the signed material so
+  // tampering with it invalidates the signature (origin still enforces single-
+  // use separately).
+  const signData = uri + exp + (nonce ? ('|' + nonce) : '');
   const expectedSig = crypto.createHmac('sha256', secret)
     .update(signData)
     .digest('base64url');
@@ -327,7 +342,7 @@ function verifySignedUrl(uri, querystring, gate) {
   const isValid = expectedBuf.length === providedBuf.length &&
     crypto.timingSafeEqual(expectedBuf, providedBuf);
 
-  return { valid: isValid };
+  return { valid: isValid, nonce };
 }
 
 // Check JWT auth gates
@@ -376,19 +391,33 @@ async function checkJwtGates(request) {
 function checkSignedUrlGates(request) {
   const uri = request.uri || '/';
   const qs = request.querystring || '';
-  
+
   for (const gate of CFG.signedUrlGates) {
-    const isProtected = gate.protectedPrefixes.some(
-      p => uri === p || uri.startsWith(p + '/')
-    );
+    // exact_path: signature is bound to the exact URI. Without it, a signed
+    // URL for /assets/ can be replayed against /assets/other-file if an
+    // operator accidentally signs a prefix. exact_path rejects any request
+    // whose URI is not one of the protected paths verbatim.
+    const isProtected = gate.exact_path
+      ? gate.protectedPrefixes.some((p) => uri === p)
+      : gate.protectedPrefixes.some((p) => uri === p || uri.startsWith(p + '/'));
     if (!isProtected) continue;
-    
+
     const result = verifySignedUrl(uri, qs, gate);
     if (!result.valid) {
       return resp(403, result.error || 'Invalid signature');
     }
+
+    // Forward the nonce to origin so it can enforce single-use (SET NX in
+    // Redis / conditional write in DynamoDB). The edge alone cannot enforce
+    // replay protection statelessly — origin cooperation is required.
+    if (gate.nonce_param && result.nonce && request.headers) {
+      request.headers['x-signed-url-nonce'] = [{
+        key: 'X-Signed-URL-Nonce',
+        value: result.nonce,
+      }];
+    }
   }
-  
+
   return null;
 }
 

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -230,7 +230,7 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
   return { valid: false, error: 'Unsupported JWT algorithm' };
 }
 
-async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string }> {
+async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string; nonce?: string | null }> {
   const exp = url.searchParams.get(gate.expires_param || 'exp');
   const sig = url.searchParams.get(gate.signature_param || 'sig');
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
@@ -240,12 +240,22 @@ async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ v
     return { valid: false, error: 'URL expired' };
   }
 
+  let nonce: string | null = null;
+  if (gate.nonce_param) {
+    nonce = url.searchParams.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
   const secret = env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'URL signing secret not configured' };
 
-  const expected = await hmacSha256Base64Url(secret, `${url.pathname}${exp}`);
+  const signData = `${url.pathname}${exp}` + (nonce ? `|${nonce}` : '');
+  const expected = await hmacSha256Base64Url(secret, signData);
   if (!timingSafeEqual(expected, sig)) return { valid: false, error: 'Invalid signature' };
-  return { valid: true };
+  return { valid: true, nonce };
 }
 
 function isHostAllowed(hostHeader: string): boolean {
@@ -374,8 +384,16 @@ export default {
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);
 
+    // Nonce to forward to origin after a successful signed_url verification.
+    // Collected here and attached when we build the origin-facing Request.
+    let signedUrlNonce: string | null = null;
     for (const gate of CFG.authGates) {
-      const isProtected = gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
+      // signed_url gates may opt into exact_path matching to prevent a signature
+      // for /assets/ from being replayed against /assets/other-file.
+      const useExact = gate.type === 'signed_url' && gate.exact_path === true;
+      const isProtected = useExact
+        ? gate.protectedPrefixes.some((p: string) => url.pathname === p)
+        : gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
       if (!isProtected) continue;
 
       if (gate.type === 'static_token') {
@@ -443,6 +461,9 @@ export default {
           if (r) return r;
           continue;
         }
+        if (gate.nonce_param && verified.nonce) {
+          signedUrlNonce = verified.nonce;
+        }
       }
     }
 
@@ -471,6 +492,12 @@ export default {
         const headerName = CFG.originAuth.header || 'X-Origin-Verify';
         forwardHeaders.set(headerName, secret);
       }
+    }
+    // Forward signed-URL nonce so origin can enforce single-use. The edge
+    // cannot enforce replay protection statelessly — origin must reject
+    // re-use (SET NX in KV/Redis).
+    if (signedUrlNonce) {
+      forwardHeaders.set('X-Signed-URL-Nonce', signedUrlNonce);
     }
 
     const res = await fetch(new Request(url.toString(), {

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -308,15 +308,30 @@ function verifySignedUrl(uri, querystring, gate) {
   const params = new URLSearchParams(querystring);
   const exp = params.get(gate.expires_param);
   const sig = params.get(gate.signature_param);
-  
+
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
   if (Date.now() > parseInt(exp) * 1000) return { valid: false, error: 'URL expired' };
-  
-  // Compute expected signature: HMAC-SHA256(uri + exp, secret)
+
+  let nonce = null;
+  if (gate.nonce_param) {
+    nonce = params.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    // Reject empty / overly long nonces before hitting origin. 16..256 chars
+    // matches a typical ULID/UUID/base64(16B) envelope; anything outside that
+    // is almost certainly crafted noise.
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
+  // Compute expected signature: HMAC-SHA256(uri + exp [+ nonce], secret)
   const secret = process.env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'Secret not configured' };
-  
-  const signData = uri + exp;
+
+  // When a nonce is part of the scheme, include it in the signed material so
+  // tampering with it invalidates the signature (origin still enforces single-
+  // use separately).
+  const signData = uri + exp + (nonce ? ('|' + nonce) : '');
   const expectedSig = crypto.createHmac('sha256', secret)
     .update(signData)
     .digest('base64url');
@@ -327,7 +342,7 @@ function verifySignedUrl(uri, querystring, gate) {
   const isValid = expectedBuf.length === providedBuf.length &&
     crypto.timingSafeEqual(expectedBuf, providedBuf);
 
-  return { valid: isValid };
+  return { valid: isValid, nonce };
 }
 
 // Check JWT auth gates
@@ -376,19 +391,33 @@ async function checkJwtGates(request) {
 function checkSignedUrlGates(request) {
   const uri = request.uri || '/';
   const qs = request.querystring || '';
-  
+
   for (const gate of CFG.signedUrlGates) {
-    const isProtected = gate.protectedPrefixes.some(
-      p => uri === p || uri.startsWith(p + '/')
-    );
+    // exact_path: signature is bound to the exact URI. Without it, a signed
+    // URL for /assets/ can be replayed against /assets/other-file if an
+    // operator accidentally signs a prefix. exact_path rejects any request
+    // whose URI is not one of the protected paths verbatim.
+    const isProtected = gate.exact_path
+      ? gate.protectedPrefixes.some((p) => uri === p)
+      : gate.protectedPrefixes.some((p) => uri === p || uri.startsWith(p + '/'));
     if (!isProtected) continue;
-    
+
     const result = verifySignedUrl(uri, qs, gate);
     if (!result.valid) {
       return resp(403, result.error || 'Invalid signature');
     }
+
+    // Forward the nonce to origin so it can enforce single-use (SET NX in
+    // Redis / conditional write in DynamoDB). The edge alone cannot enforce
+    // replay protection statelessly — origin cooperation is required.
+    if (gate.nonce_param && result.nonce && request.headers) {
+      request.headers['x-signed-url-nonce'] = [{
+        key: 'X-Signed-URL-Nonce',
+        value: result.nonce,
+      }];
+    }
   }
-  
+
   return null;
 }
 

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -230,7 +230,7 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
   return { valid: false, error: 'Unsupported JWT algorithm' };
 }
 
-async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string }> {
+async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ valid: boolean; error?: string; nonce?: string | null }> {
   const exp = url.searchParams.get(gate.expires_param || 'exp');
   const sig = url.searchParams.get(gate.signature_param || 'sig');
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
@@ -240,12 +240,22 @@ async function verifySignedUrl(gate: any, url: URL, env: WorkerEnv): Promise<{ v
     return { valid: false, error: 'URL expired' };
   }
 
+  let nonce: string | null = null;
+  if (gate.nonce_param) {
+    nonce = url.searchParams.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
   const secret = env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'URL signing secret not configured' };
 
-  const expected = await hmacSha256Base64Url(secret, `${url.pathname}${exp}`);
+  const signData = `${url.pathname}${exp}` + (nonce ? `|${nonce}` : '');
+  const expected = await hmacSha256Base64Url(secret, signData);
   if (!timingSafeEqual(expected, sig)) return { valid: false, error: 'Invalid signature' };
-  return { valid: true };
+  return { valid: true, nonce };
 }
 
 function isHostAllowed(hostHeader: string): boolean {
@@ -374,8 +384,16 @@ export default {
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);
 
+    // Nonce to forward to origin after a successful signed_url verification.
+    // Collected here and attached when we build the origin-facing Request.
+    let signedUrlNonce: string | null = null;
     for (const gate of CFG.authGates) {
-      const isProtected = gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
+      // signed_url gates may opt into exact_path matching to prevent a signature
+      // for /assets/ from being replayed against /assets/other-file.
+      const useExact = gate.type === 'signed_url' && gate.exact_path === true;
+      const isProtected = useExact
+        ? gate.protectedPrefixes.some((p: string) => url.pathname === p)
+        : gate.protectedPrefixes.some((p: string) => url.pathname === p || url.pathname.startsWith(p + '/'));
       if (!isProtected) continue;
 
       if (gate.type === 'static_token') {
@@ -443,6 +461,9 @@ export default {
           if (r) return r;
           continue;
         }
+        if (gate.nonce_param && verified.nonce) {
+          signedUrlNonce = verified.nonce;
+        }
       }
     }
 
@@ -471,6 +492,12 @@ export default {
         const headerName = CFG.originAuth.header || 'X-Origin-Verify';
         forwardHeaders.set(headerName, secret);
       }
+    }
+    // Forward signed-URL nonce so origin can enforce single-use. The edge
+    // cannot enforce replay protection statelessly — origin must reject
+    // re-use (SET NX in KV/Redis).
+    if (signedUrlNonce) {
+      forwardHeaders.set('X-Signed-URL-Nonce', signedUrlNonce);
     }
 
     const res = await fetch(new Request(url.toString(), {

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -112,15 +112,42 @@ async function hmacSha256Base64Url(secret: string, message: string): Promise<str
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
+// Runtime SSRF guard — mirrors the build-time validator in scripts/lib/
+// compile-core.js. Build already rejects unsafe URLs, but re-checking here
+// limits the blast radius of any future regression that lets an http:// or
+// private-range URL reach the fetcher.
+function isUnsafeJwksUrl(rawUrl: string): string | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
+  const unsafe = isUnsafeJwksUrl(jwksUrl);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   const cached = jwksCache.get(jwksUrl);
   if (cached && (now - cached.fetchedAt) < ttlSec * 1000) {
     return cached.keys;
   }
 
-  const res = await fetch(jwksUrl, { method: 'GET' });
-  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  // `redirect: 'error'` forces Workers' fetch to refuse any 3xx, so an
+  // attacker who briefly controls the JWKS host cannot redirect us to a
+  // cloud-metadata endpoint or a different tenant's IdP.
+  const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
+  if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
   const body = await res.json();
   const keys = Array.isArray(body?.keys) ? body.keys : [];
   jwksCache.set(jwksUrl, { fetchedAt: now, keys });
@@ -429,6 +456,14 @@ export default {
     // XFF value can poison downstream rate limiters, IP allowlists, and logs.
     if (!CFG.trustForwardedFor) {
       forwardHeaders.delete('x-forwarded-for');
+    }
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied Transfer-Encoding / Connection / Upgrade
+    // can desynchronize Worker ↔ origin framing (CL.TE, TE.CL, H2.TE) and
+    // smuggle a second request. Cloudflare re-frames the request, so these
+    // headers carry no legitimate meaning from the viewer.
+    for (const h of ['transfer-encoding', 'connection', 'keep-alive', 'te', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization', 'trailer']) {
+      forwardHeaders.delete(h);
     }
     if (CFG.originAuth && CFG.originAuth.type === 'custom_header') {
       const secret = env[CFG.originAuth.secret_env || ''] || '';

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -308,15 +308,30 @@ function verifySignedUrl(uri, querystring, gate) {
   const params = new URLSearchParams(querystring);
   const exp = params.get(gate.expires_param);
   const sig = params.get(gate.signature_param);
-  
+
   if (!exp || !sig) return { valid: false, error: 'Missing exp or sig' };
   if (Date.now() > parseInt(exp) * 1000) return { valid: false, error: 'URL expired' };
-  
-  // Compute expected signature: HMAC-SHA256(uri + exp, secret)
+
+  let nonce = null;
+  if (gate.nonce_param) {
+    nonce = params.get(gate.nonce_param);
+    if (!nonce) return { valid: false, error: 'Missing nonce' };
+    // Reject empty / overly long nonces before hitting origin. 16..256 chars
+    // matches a typical ULID/UUID/base64(16B) envelope; anything outside that
+    // is almost certainly crafted noise.
+    if (nonce.length < 16 || nonce.length > 256 || !/^[A-Za-z0-9._~-]+$/.test(nonce)) {
+      return { valid: false, error: 'Malformed nonce' };
+    }
+  }
+
+  // Compute expected signature: HMAC-SHA256(uri + exp [+ nonce], secret)
   const secret = process.env[gate.secret_env] || '';
   if (!secret) return { valid: false, error: 'Secret not configured' };
-  
-  const signData = uri + exp;
+
+  // When a nonce is part of the scheme, include it in the signed material so
+  // tampering with it invalidates the signature (origin still enforces single-
+  // use separately).
+  const signData = uri + exp + (nonce ? ('|' + nonce) : '');
   const expectedSig = crypto.createHmac('sha256', secret)
     .update(signData)
     .digest('base64url');
@@ -327,7 +342,7 @@ function verifySignedUrl(uri, querystring, gate) {
   const isValid = expectedBuf.length === providedBuf.length &&
     crypto.timingSafeEqual(expectedBuf, providedBuf);
 
-  return { valid: isValid };
+  return { valid: isValid, nonce };
 }
 
 // Check JWT auth gates
@@ -376,19 +391,33 @@ async function checkJwtGates(request) {
 function checkSignedUrlGates(request) {
   const uri = request.uri || '/';
   const qs = request.querystring || '';
-  
+
   for (const gate of CFG.signedUrlGates) {
-    const isProtected = gate.protectedPrefixes.some(
-      p => uri === p || uri.startsWith(p + '/')
-    );
+    // exact_path: signature is bound to the exact URI. Without it, a signed
+    // URL for /assets/ can be replayed against /assets/other-file if an
+    // operator accidentally signs a prefix. exact_path rejects any request
+    // whose URI is not one of the protected paths verbatim.
+    const isProtected = gate.exact_path
+      ? gate.protectedPrefixes.some((p) => uri === p)
+      : gate.protectedPrefixes.some((p) => uri === p || uri.startsWith(p + '/'));
     if (!isProtected) continue;
-    
+
     const result = verifySignedUrl(uri, qs, gate);
     if (!result.valid) {
       return resp(403, result.error || 'Invalid signature');
     }
+
+    // Forward the nonce to origin so it can enforce single-use (SET NX in
+    // Redis / conditional write in DynamoDB). The edge alone cannot enforce
+    // replay protection statelessly — origin cooperation is required.
+    if (gate.nonce_param && result.nonce && request.headers) {
+      request.headers['x-signed-url-nonce'] = [{
+        key: 'X-Signed-URL-Nonce',
+        value: result.nonce,
+      }];
+    }
   }
-  
+
   return null;
 }
 

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -62,8 +62,33 @@ function checkHeaderSize(request) {
   return null;
 }
 
+// Defense-in-depth check before every outbound JWKS fetch. The build-time
+// validator already rejects unsafe URLs, but runtime re-validation limits
+// the blast radius of any future regression (cache-poisoning, config hot-
+// reload bugs, operator typo bypassing lint) that allows an http:// or
+// private-range URL to reach here.
+function isUnsafeJwksUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return 'malformed URL'; }
+  if (u.protocol !== 'https:') return 'non-https scheme';
+  if (u.username || u.password) return 'userinfo present';
+  const host = (u.hostname || '').toLowerCase();
+  if (!host || host === 'localhost') return 'loopback hostname';
+  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
+  if (/^10\./.test(host)) return 'rfc1918 10/8';
+  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
+  if (/^169\.254\./.test(host)) return 'link-local / metadata';
+  if (/^0\./.test(host)) return 'reserved 0/8';
+  return null;
+}
+
 // Fetch JWKS from URL with caching
 async function fetchJwks(url) {
+  const unsafe = isUnsafeJwksUrl(url);
+  if (unsafe) {
+    throw new Error('JWKS URL rejected: ' + unsafe);
+  }
   const now = Date.now();
   if (jwksCache[url] && (now - jwksCache[url].time) < JWKS_CACHE_TTL) {
     return jwksCache[url].keys;
@@ -71,6 +96,19 @@ async function fetchJwks(url) {
 
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
+      // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
+      // to http://, etc.). Node's https.get does not follow redirects by
+      // default, but be explicit in case that ever changes.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        res.resume();
+        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -396,6 +434,24 @@ exports.handler = async (event) => {
     // origin and may be invoked without a preceding CFF in some setups.
     if (req && req.headers && !CFG.trustForwardedFor) {
       delete req.headers['x-forwarded-for'];
+    }
+
+    // Request-smuggling defense: strip hop-by-hop headers before origin
+    // forward. Any client-supplied `Transfer-Encoding: chunked`,
+    // `Connection: ...`, or `Upgrade` can desynchronize the CloudFront ↔
+    // origin framing (CL.TE / TE.CL / H2.TE) and smuggle a second request.
+    // CloudFront itself re-frames the request, so these headers carry no
+    // legitimate meaning from the viewer.
+    if (req && req.headers) {
+      delete req.headers['transfer-encoding'];
+      delete req.headers['connection'];
+      delete req.headers['keep-alive'];
+      delete req.headers['te'];
+      delete req.headers['upgrade'];
+      delete req.headers['proxy-connection'];
+      delete req.headers['proxy-authenticate'];
+      delete req.headers['proxy-authorization'];
+      delete req.headers['trailer'];
     }
 
     // Header size check (Lambda@Edge can access all headers)


### PR DESCRIPTION
## Summary

- **`exact_path`** (new, default `false`): when `true`, signed URL signature binds to a single URI path — no more sibling-path replay under the same prefix
- **`nonce_param`** (new, default `""`): binds a per-URL nonce into the HMAC input (`uri + exp + '|' + nonce`), and forwards the nonce to origin as `X-Signed-URL-Nonce` for single-use enforcement
- Build-time warning when `signed_url` gate protects write-like paths (`/api`, `/write`, `/admin`, `/upload`, `/delete`) without `nonce_param`
- Docs: `docs/signed-urls.{md,ja.md}` + threat model §11
- Covers both AWS origin-request Lambda@Edge and Cloudflare Workers targets
- All 3 profiles + `base.yml` golden fixtures regenerated

Closes #6
Closes #43

> Depends on #47 (PR 4 JWKS SSRF hardening). The diff will auto-clean once #47 merges to `develop`.

## Test plan

- [x] `npm run test:unit` — 5 new signed-URL cases (warn, exact_path emit, nonce_param emit, defaults) green
- [x] `npm run build && npm run test:runtime` — 52/52 AWS + all Cloudflare cases green, including:
  - Sibling-path replay rejected under `exact_path: true`
  - Missing nonce → 403 Missing nonce
  - Malformed nonce (length/charset) → 403 Malformed nonce
  - Valid one-time URL → passthrough with `X-Signed-URL-Nonce` forwarded
- [x] `npm run test:drift` — base + 3 profiles OK
- [x] `npm run lint:policy` — all 4 profiles OK

## Security notes

Edge cannot enforce single-use on its own (CloudFront Functions / Workers are stateless per invocation). Origin-side atomic check (e.g., Redis `SET NX`) remains required — documented in `docs/signed-urls.md`.