### PR TITLE
feat: programmatic API with structured results (closes #67)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -101,6 +101,7 @@ Terraform / CDK / WAF の利用例は [IaC 連携](docs/iac.ja.md) を参照。
 
 ### 運用ドキュメント
 - [CLI リファレンス](docs/cli.ja.md) — `init` / `build` / `emit-waf` / `doctor` / `migrate`
+- [プログラマティック API](docs/programmatic-api.ja.md) — `require('cdn-security-framework')` で CI / IaC から直接呼び出し
 - [アーキタイプ](docs/archetypes.ja.md) — アプリ形状別プリセット（SPA / REST API / 管理画面 / マイクロサービス）
 - [シークレットローテーション runbook](docs/runbooks/secret-rotation.ja.md) — JWT / JWKS / 署名付き URL / 管理トークン / origin シークレット
 - [スキーママイグレーション](docs/schema-migration.ja.md) — `policy/schema.json` のバージョン契約と `migrate` CLI

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [IaC integration](docs/iac.md) for Terraform / CDK / WAF usage.
 
 ### Operational docs
 - [CLI reference](docs/cli.md) — `init` / `build` / `emit-waf` / `doctor` / `migrate`
+- [Programmatic API](docs/programmatic-api.md) — `require('cdn-security-framework')` for CI / IaC integration
 - [Archetypes](docs/archetypes.md) — app-shaped policy presets (SPA, REST API, admin, microservice)
 - [Secret rotation runbook](docs/runbooks/secret-rotation.md) — JWT / JWKS / signed URL / admin token / origin secret
 - [Schema migration](docs/schema-migration.md) — how `policy/schema.json` evolves and the `migrate` CLI

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -138,82 +138,38 @@ program
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--fail-on-permissive', 'Exit non-zero when policy.metadata.risk_level is "permissive" (gate for production CI)')
   .action((opts) => {
+    const { compile } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     let policyPath = opts.policy;
     if (!policyPath) {
       const security = path.join(cwd, 'policy', 'security.yml');
       const base = path.join(cwd, 'policy', 'base.yml');
       policyPath = fs.existsSync(security) ? security : base;
-    } else if (!path.isAbsolute(policyPath)) {
-      policyPath = path.join(cwd, policyPath);
-    }
-    const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
-
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
     }
 
-    // Lint
-    const lintPath = path.join(pkgRoot, 'scripts', 'policy-lint.js');
-    const { spawnSync } = require('child_process');
-    const lintResult = spawnSync(process.execPath, [lintPath, policyPath], {
-      stdio: 'inherit',
+    const result = compile({
+      policyPath,
+      outDir: opts.outDir,
+      target: opts.target,
+      outputMode: opts.outputMode,
+      ruleGroupOnly: !!opts.ruleGroupOnly,
+      failOnPermissive: !!opts.failOnPermissive,
       cwd,
+      pkgRoot,
     });
-    if (lintResult.status !== 0) {
-      console.error('[ERROR] Policy validation failed.');
+
+    result.warnings.forEach((w) => console.warn(w));
+
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
       process.exit(1);
     }
+
     console.log('[INFO] Validating policy... OK');
-
-    const permissiveFlag = opts.failOnPermissive ? ['--fail-on-permissive'] : [];
-
-    if (opts.target === 'aws') {
-      console.log('[INFO] Target: AWS CloudFront Functions');
-      const compilePath = path.join(pkgRoot, 'scripts', 'compile.js');
-      const compileResult = spawnSync(process.execPath, [
-        compilePath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        ...permissiveFlag,
-      ], { stdio: 'inherit', cwd });
-      if (compileResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'viewer-request.js'));
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'viewer-response.js'));
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'origin-request.js'));
-      const compileInfraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
-      const compileInfraResult = spawnSync(process.execPath, [
-        compileInfraPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        '--output-mode', opts.outputMode,
-        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
-      ], { stdio: 'inherit', cwd });
-      if (compileInfraResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', '*.tf.json'));
-    } else if (opts.target === 'cloudflare') {
-      console.log('[INFO] Target: Cloudflare Workers');
-      const compileCfPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare.js');
-      const compileCfResult = spawnSync(process.execPath, [
-        compileCfPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        ...permissiveFlag,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'cloudflare', 'index.ts'));
-      const compileCfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
-      const compileCfWafResult = spawnSync(process.execPath, [
-        compileCfWafPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfWafResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', 'cloudflare-waf.tf.json'));
-    } else {
-      console.error('[ERROR] Unknown target:', opts.target);
-      process.exit(1);
+    console.log('[INFO] Target:', result.target === 'aws' ? 'AWS CloudFront Functions' : 'Cloudflare Workers');
+    result.edgeFiles.forEach((f) => console.log('[SUCCESS] Generated ' + f));
+    if (result.infraFiles.length > 0) {
+      console.log('[SUCCESS] Generated ' + path.join(result.outDir, 'infra', '*.tf.json'));
     }
   });
 
@@ -244,66 +200,37 @@ program
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--format <format>', 'Output format: terraform | cloudformation | cdk (terraform is the only format currently generated; others return exit 2)', 'terraform')
   .action((opts) => {
+    const { emitWaf } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     let policyPath = opts.policy;
     if (!policyPath) {
       const security = path.join(cwd, 'policy', 'security.yml');
       const base = path.join(cwd, 'policy', 'base.yml');
       policyPath = fs.existsSync(security) ? security : base;
-    } else if (!path.isAbsolute(policyPath)) {
-      policyPath = path.join(cwd, policyPath);
-    }
-    const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
-
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
-    }
-    if (!['aws', 'cloudflare'].includes(opts.target)) {
-      console.error('[ERROR] Unknown target:', opts.target, '(expected aws | cloudflare)');
-      process.exit(1);
-    }
-    if (!['terraform', 'cloudformation', 'cdk'].includes(opts.format)) {
-      console.error('[ERROR] Unknown --format:', opts.format, '(expected terraform | cloudformation | cdk)');
-      process.exit(1);
-    }
-    if (opts.format !== 'terraform') {
-      console.error(`[ERROR] --format ${opts.format} is not yet implemented. Only terraform is generated today; cloudformation and cdk are reserved flags with stub rejection so pipelines fail loudly rather than silently falling back.`);
-      process.exit(2);
     }
 
-    // Lint first — emit-waf still goes through schema validation so a broken
-    // policy does not silently produce half a waf-rules.tf.json.
-    const { spawnSync } = require('child_process');
-    const lintPath = path.join(pkgRoot, 'scripts', 'policy-lint.js');
-    const lintResult = spawnSync(process.execPath, [lintPath, policyPath], { stdio: 'inherit', cwd });
-    if (lintResult.status !== 0) {
-      console.error('[ERROR] Policy validation failed.');
-      process.exit(1);
+    const result = emitWaf({
+      policyPath,
+      outDir: opts.outDir,
+      target: opts.target,
+      format: opts.format,
+      outputMode: opts.outputMode,
+      ruleGroupOnly: !!opts.ruleGroupOnly,
+      cwd,
+      pkgRoot,
+    });
+
+    result.warnings.forEach((w) => console.warn(w));
+
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
+      // Reserved format = exit 2 so pipelines notice silent-fallback is not an option.
+      process.exit(result.formatNotImplemented ? 2 : 1);
     }
 
-    if (opts.target === 'aws') {
-      console.log('[INFO] Target: AWS WAFv2 / CloudFront infra');
-      const compileInfraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
-      const compileInfraResult = spawnSync(process.execPath, [
-        compileInfraPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        '--output-mode', opts.outputMode,
-        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
-      ], { stdio: 'inherit', cwd });
-      if (compileInfraResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', '*.tf.json'));
-    } else {
-      console.log('[INFO] Target: Cloudflare WAF');
-      const compileCfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
-      const compileCfWafResult = spawnSync(process.execPath, [
-        compileCfWafPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfWafResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', 'cloudflare-waf.tf.json'));
+    console.log('[INFO] Target:', result.target === 'aws' ? 'AWS WAFv2 / CloudFront infra' : 'Cloudflare WAF');
+    if (result.infraFiles.length > 0) {
+      console.log('[SUCCESS] Generated ' + path.join(result.outDir, 'infra', '*.tf.json'));
     }
   });
 
@@ -314,45 +241,31 @@ program
   .option('--to <version>', 'Target schema version', '1')
   .option('--write', 'Write the migrated policy back in place (no-op on v1)')
   .action((opts) => {
+    const { migratePolicy } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     const policyPath = path.isAbsolute(opts.policy) ? opts.policy : path.join(cwd, opts.policy);
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
-    }
-    const yaml = require('js-yaml');
-    const doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-    const fromVersion = doc && doc.version;
-    const toVersion = Number(opts.to);
 
-    if (fromVersion === undefined) {
-      console.error('[ERROR] Policy has no `version` field. Add `version: 1` and retry.');
-      process.exit(1);
-    }
-    if (Number.isNaN(toVersion)) {
-      console.error('[ERROR] --to must be a number. Got:', opts.to);
-      process.exit(1);
+    const result = migratePolicy({
+      policyPath,
+      toVersion: opts.to,
+      cwd,
+    });
+
+    if (result.fromVersion !== undefined) {
+      console.log('[INFO] Policy:', policyPath);
+      console.log('[INFO] Current schema version:', result.fromVersion);
+      console.log('[INFO] Target schema version: ', result.toVersion);
     }
 
-    console.log('[INFO] Policy:', policyPath);
-    console.log('[INFO] Current schema version:', fromVersion);
-    console.log('[INFO] Target schema version: ', toVersion);
-
-    if (fromVersion === toVersion) {
+    if (result.ok && result.noop) {
       console.log('[OK] Already at target version — no migration needed.');
       process.exit(0);
     }
-    if (toVersion < fromVersion) {
-      console.error('[ERROR] Downgrade migrations are not supported.');
-      process.exit(1);
-    }
 
-    // Forward migrations are registered here when a new schema version ships.
-    // The contract: each step is a pure function (v_n policy) -> (v_n+1 policy).
-    // v1 is currently the only shipped schema, so there is nothing to run.
-    console.error(`[ERROR] No migration path from v${fromVersion} to v${toVersion} is registered in this CLI version.`);
-    console.error('        See docs/schema-migration.md for the migration policy and supported versions.');
-    process.exit(2);
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
+      process.exit(result.reservedExit2 ? 2 : 1);
+    }
   });
 
 program.parse();

--- a/docs/programmatic-api.ja.md
+++ b/docs/programmatic-api.ja.md
@@ -1,0 +1,169 @@
+# プログラマティック API
+
+> **Languages:** [English](./programmatic-api.md) · 日本語
+
+`cdn-security-framework` は Node.js から直接呼び出せる安定 API を公開しています。CI パイプライン・IaC ツール・独自ラッパーから CLI をシェル起動せずにコンパイラを駆動できます。CLI サブコマンドと同じ機能を提供しますが、`process.exit` を呼ばず構造化された結果を返します。
+
+```js
+const { compile, emitWaf, lintPolicy, migratePolicy, runDoctor } = require('cdn-security-framework');
+```
+
+## 存在理由
+
+1.2.0 より前は CLI 経由でしか統合できませんでした。CI は stderr を取り込み文字列一致で失敗分類し、終了コード 1 / 2 の違いを慣習で扱い、出力ファイル一覧を取得する安定手段もありませんでした。プログラマティック API はこれを以下に置き換えます。
+
+- 統一された `{ ok, errors, warnings, ... }` の形
+- 明示的な `edgeFiles` / `infraFiles` 配列（絶対パス）
+- `formatNotImplemented` / `reservedExit2` といった機械可読フラグ（stderr 文字列一致に依存しない）
+- `process.exit` を呼ばないためプロセス全体への副作用なし
+
+CLI（`bin/cli.js`）もこれらの関数に委譲しています。CLI で再現するバグは API でも再現し、逆もまた然りです。
+
+## スコープ
+
+`compile()` と `emitWaf()` は現状 `spawnSync` で既存のコンパイラスクリプトをサブプロセスとして呼び出します。API の契約（入出力・エラー意味論）は安定しており、サブプロセス境界は実装詳細です。issue #69 で in-process 化しますが、表面は変えません。`lintPolicy()` と `migratePolicy()` は最初から完全 in-process です。
+
+## リファレンス
+
+### `compile(opts)`
+
+ポリシーを検証し、エッジランタイムコード + インフラ設定を生成します。
+
+**入力**
+
+| フィールド | 型 | 備考 |
+| --- | --- | --- |
+| `policyPath` | `string` | 必須。絶対または `cwd` からの相対。 |
+| `outDir` | `string` | 必須。絶対または `cwd` からの相対。 |
+| `target` | `'aws' \| 'cloudflare'` | デフォルト `'aws'`。 |
+| `outputMode` | `'full' \| 'rule-group'` | AWS のみ。デフォルト `'full'`。 |
+| `ruleGroupOnly` | `boolean` | AWS のみ。`aws_wafv2_web_acl` を出さず rule group のみ。 |
+| `failOnPermissive` | `boolean` | `metadata.risk_level === 'permissive'` を失敗扱い。 |
+| `cwd` | `string` | デフォルト `process.cwd()`。 |
+| `pkgRoot` | `string` | インストール済みパッケージルート。 |
+| `env` | `NodeJS.ProcessEnv` | デフォルト `process.env`。 |
+
+**出力**
+
+```ts
+interface CompileResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  edgeFiles: string[];   // 絶対パス
+  infraFiles: string[];  // 絶対パス
+  policyPath: string;    // 解決済み
+  outDir: string;        // 解決済み
+  target: 'aws' | 'cloudflare';
+}
+```
+
+**例**
+
+```js
+const { compile } = require('cdn-security-framework');
+
+const result = compile({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+});
+
+if (!result.ok) {
+  for (const err of result.errors) console.error(err);
+  process.exit(1);
+}
+
+for (const warn of result.warnings) console.warn(warn);
+for (const file of result.edgeFiles) console.log('edge:', file);
+for (const file of result.infraFiles) console.log('infra:', file);
+```
+
+### `emitWaf(opts)`
+
+インフラ/WAF 設定のみを生成します。`edgeFiles` は常に `[]`。
+
+`compile` と同じ入力に加えて `format: 'terraform' | 'cloudformation' | 'cdk'`（デフォルト `'terraform'`）。
+
+現状 `terraform` のみ生成します。`cloudformation` と `cdk` は `{ ok: false, formatNotImplemented: true, errors: [...] }` を返します。CLI は `formatNotImplemented: true` を終了コード 2 に翻訳するので、パイプラインは「未実装」と「実装が失敗」を区別できます。
+
+```js
+const { emitWaf } = require('cdn-security-framework');
+
+const result = emitWaf({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+  format: 'terraform',
+});
+```
+
+### `lintPolicy(opts)`
+
+完全 in-process のポリシー検証（スキーマ、パスパターン、auth gate、WAF 健全性、env 参照）。
+
+**入力**
+
+| フィールド | 型 | 備考 |
+| --- | --- | --- |
+| `policyPath` | `string` | 必須。 |
+| `pkgRoot` | `string` | スキーマ/プロファイル解決用ルート。 |
+| `env` | `NodeJS.ProcessEnv` | ポリシーが参照する env 変数確認用。 |
+
+**出力**
+
+```ts
+interface LintResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  policy: unknown;  // ok === true のとき YAML パース結果
+}
+```
+
+### `migratePolicy(opts)`
+
+ポリシーをスキーマバージョン間で移行します。現状 v1 のみリリース済みなので、v1 → v1 は no-op（`{ ok: true, noop: true }`）。
+
+**出力**
+
+```ts
+interface MigrateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  fromVersion?: number | string;
+  toVersion?: number | string;
+  migrated?: unknown;
+  noop?: boolean;
+  reservedExit2?: boolean;  // CLI は終了コード 2 に翻訳
+}
+```
+
+### `runDoctor(opts)`
+
+環境診断を実行します。`{ exitCode: number, report: {...} }` を返します。この API 表面より前から存在するので、そのまま再エクスポートしています。
+
+## エラー意味論
+
+API は `process.exit` を呼びません。全ての失敗は `{ ok: false, errors: [...] }` として表面化します。プロセス終了コードへの翻訳は CLI レイヤだけが行います。
+
+| ケース | CLI 終了コード | API フラグ |
+| --- | --- | --- |
+| 成功 | `0` | `ok: true` |
+| 一般的な失敗 | `1` | `ok: false` |
+| 予約/未実装（例: `emit-waf --format cdk`） | `2` | `formatNotImplemented: true` または `reservedExit2: true` |
+
+独自ラッパーを書くときは stderr をパースせず、構造化フラグを参照してください。
+
+## 後方互換性
+
+- `bin/cli.js` のサブコマンド・オプション・終了コードは従来どおり。
+- stderr メッセージは既存の大文字/ハイフンを保持（`Unknown --format:`, `Unknown target:`）。grep しているスクリプトはそのまま動きます。
+- `process.exit` を呼ぶのは CLI のみ。
+
+## 関連ドキュメント
+
+- [CLI リファレンス](./cli.ja.md)
+- [スキーマ移行](./schema-migration.ja.md)
+- [ROADMAP](./ROADMAP.ja.md) の #69（in-process 化）

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -1,0 +1,169 @@
+# Programmatic API
+
+> **Languages:** English · [日本語](./programmatic-api.ja.md)
+
+`cdn-security-framework` exposes a stable Node.js API so CI pipelines, IaC tools, and custom wrappers can drive the compiler without shelling out to the CLI. The API mirrors the CLI subcommands but returns structured results instead of calling `process.exit`.
+
+```js
+const { compile, emitWaf, lintPolicy, migratePolicy, runDoctor } = require('cdn-security-framework');
+```
+
+## Why this exists
+
+Before 1.2.0, the only integration path was the CLI. CI systems had to capture stderr to classify failures, parse exit codes (1 vs 2) by convention, and had no stable way to enumerate emitted files. The programmatic API replaces that with:
+
+- Uniform `{ ok, errors, warnings, ... }` shape
+- Explicit `edgeFiles` / `infraFiles` arrays (absolute paths)
+- Machine-readable flags (e.g. `formatNotImplemented`, `reservedExit2`) instead of string-matching stderr
+- No process-wide side effects — never calls `process.exit`
+
+The CLI (`bin/cli.js`) now delegates to these same functions. If a bug shows up in the CLI, the API sees it too — and vice versa.
+
+## Scope note
+
+`compile()` and `emitWaf()` currently invoke the existing compiler scripts in a subprocess via `spawnSync`. The API contract (inputs, outputs, error semantics) is stable; the subprocess boundary is an implementation detail that will move in-process under issue #69 without changing the surface. `lintPolicy()` and `migratePolicy()` already run fully in-process.
+
+## Reference
+
+### `compile(opts)`
+
+Validate a policy, compile edge runtime code, and emit infra config.
+
+**Input**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `policyPath` | `string` | Required. Absolute or relative to `cwd`. |
+| `outDir` | `string` | Required. Absolute or relative to `cwd`. |
+| `target` | `'aws' \| 'cloudflare'` | Defaults to `'aws'`. |
+| `outputMode` | `'full' \| 'rule-group'` | AWS only. Defaults to `'full'`. |
+| `ruleGroupOnly` | `boolean` | AWS only. Emit rule groups without `aws_wafv2_web_acl`. |
+| `failOnPermissive` | `boolean` | Non-zero-equivalent when `metadata.risk_level === 'permissive'`. |
+| `cwd` | `string` | Defaults to `process.cwd()`. |
+| `pkgRoot` | `string` | Defaults to the installed package root. |
+| `env` | `NodeJS.ProcessEnv` | Defaults to `process.env`. |
+
+**Output**
+
+```ts
+interface CompileResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  edgeFiles: string[];   // absolute paths
+  infraFiles: string[];  // absolute paths
+  policyPath: string;    // resolved
+  outDir: string;        // resolved
+  target: 'aws' | 'cloudflare';
+}
+```
+
+**Example**
+
+```js
+const { compile } = require('cdn-security-framework');
+
+const result = compile({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+});
+
+if (!result.ok) {
+  for (const err of result.errors) console.error(err);
+  process.exit(1);
+}
+
+for (const warn of result.warnings) console.warn(warn);
+for (const file of result.edgeFiles) console.log('edge:', file);
+for (const file of result.infraFiles) console.log('infra:', file);
+```
+
+### `emitWaf(opts)`
+
+Emit only the infra/WAF config. `edgeFiles` is always `[]`.
+
+Same input shape as `compile` plus `format: 'terraform' | 'cloudformation' | 'cdk'` (defaults to `'terraform'`).
+
+Only `terraform` is generated today. `cloudformation` and `cdk` return `{ ok: false, formatNotImplemented: true, errors: [...] }`. The CLI translates `formatNotImplemented: true` to exit code 2 so pipelines can distinguish "not implemented" from "implementation failed".
+
+```js
+const { emitWaf } = require('cdn-security-framework');
+
+const result = emitWaf({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+  format: 'terraform',
+});
+```
+
+### `lintPolicy(opts)`
+
+Fully in-process policy validation (schema, path patterns, auth gates, WAF hygiene, env references).
+
+**Input**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `policyPath` | `string` | Required. |
+| `pkgRoot` | `string` | Schema/profiles resolution root. |
+| `env` | `NodeJS.ProcessEnv` | For env-var referenced by policy. |
+
+**Output**
+
+```ts
+interface LintResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  policy: unknown;  // parsed YAML when ok === true
+}
+```
+
+### `migratePolicy(opts)`
+
+Migrate a policy file between schema versions. v1 is the only shipped version today; a v1 → v1 call is a no-op with `{ ok: true, noop: true }`.
+
+**Output**
+
+```ts
+interface MigrateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  fromVersion?: number | string;
+  toVersion?: number | string;
+  migrated?: unknown;
+  noop?: boolean;
+  reservedExit2?: boolean;  // CLI translates to exit 2
+}
+```
+
+### `runDoctor(opts)`
+
+Run environment diagnostics. Returns `{ exitCode: number, report: {...} }`. Unlike the other functions, `runDoctor` already pre-dates this surface and is re-exported unchanged.
+
+## Error semantics
+
+The API never calls `process.exit`. All failure modes surface as `{ ok: false, errors: [...] }`. The CLI layer is the only caller that translates to process exit codes:
+
+| Case | CLI exit | API flag |
+| --- | --- | --- |
+| Success | `0` | `ok: true` |
+| Generic failure | `1` | `ok: false` |
+| Reserved / not-implemented (e.g. `emit-waf --format cdk`) | `2` | `formatNotImplemented: true` or `reservedExit2: true` |
+
+When building your own wrapper, prefer inspecting the structured flags rather than parsing stderr.
+
+## Backwards compatibility
+
+- `bin/cli.js` still uses the same subcommands, options, and exit codes as before.
+- Stderr messages preserve existing capitalization (`Unknown --format:`, `Unknown target:`) so scripts grepping for them continue to work.
+- The CLI is the only place `process.exit` is called.
+
+## See also
+
+- [CLI reference](./cli.md)
+- [Schema migration](./schema-migration.md)
+- Roadmap item #69 (in-process compile) in [ROADMAP.md](./ROADMAP.md)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,203 @@
+/**
+ * Programmatic API: compile
+ *
+ * Build edge runtime + infra config from a policy file. Stable public
+ * contract. Internally delegates to the existing compiler scripts via
+ * spawnSync (see note in lib/index.js); that will be replaced by in-process
+ * module boundaries in #69 without changing this surface.
+ *
+ * Input:
+ *   {
+ *     policyPath:       string,     // required, absolute or relative to cwd
+ *     outDir:           string,     // required, absolute or relative to cwd
+ *     target:           'aws' | 'cloudflare',
+ *     failOnPermissive?: boolean,
+ *     outputMode?:      'full' | 'rule-group',   // AWS only
+ *     ruleGroupOnly?:   boolean,                  // AWS only
+ *     cwd?:             string,     // defaults to process.cwd()
+ *     pkgRoot?:         string,     // defaults to installed package root
+ *     env?:             NodeJS.ProcessEnv,
+ *   }
+ *
+ * Output:
+ *   {
+ *     ok:         boolean,
+ *     errors:     string[],
+ *     warnings:   string[],
+ *     edgeFiles:  string[],    // absolute paths to emitted edge code
+ *     infraFiles: string[],    // absolute paths to emitted infra config
+ *     policyPath: string,      // resolved policy path
+ *     outDir:     string,      // resolved output dir
+ *     target:     string,
+ *   }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { lintPolicy } = require('./lint');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+const AWS_EDGE_FILES = ['viewer-request.js', 'viewer-response.js', 'origin-request.js'];
+const CF_EDGE_FILES = [path.join('cloudflare', 'index.ts')];
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function listInfraArtifacts(outDir) {
+  const infraDir = path.join(outDir, 'infra');
+  if (!fs.existsSync(infraDir)) return [];
+  return fs
+    .readdirSync(infraDir)
+    .filter((name) => name.endsWith('.tf.json'))
+    .map((name) => path.join(infraDir, name));
+}
+
+function compile(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const env = opts.env || process.env;
+
+  const errors = [];
+  const warnings = [];
+  const baseResult = {
+    edgeFiles: [],
+    infraFiles: [],
+    policyPath: null,
+    outDir: null,
+    target: opts.target || 'aws',
+  };
+
+  if (!opts.policyPath) {
+    return { ok: false, errors: ['policyPath is required'], warnings, ...baseResult };
+  }
+  if (!opts.outDir) {
+    return { ok: false, errors: ['outDir is required'], warnings, ...baseResult };
+  }
+  const target = opts.target || 'aws';
+  if (target !== 'aws' && target !== 'cloudflare') {
+    return {
+      ok: false,
+      errors: [`Unknown target: ${target} (expected aws | cloudflare)`],
+      warnings,
+      ...baseResult,
+      target,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  const outDir = resolveAbsolute(opts.outDir, cwd);
+  baseResult.policyPath = policyPath;
+  baseResult.outDir = outDir;
+  baseResult.target = target;
+
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      ...baseResult,
+    };
+  }
+
+  // Step 1: lint (in-process — fast, deterministic).
+  const lint = lintPolicy({ policyPath, pkgRoot, env });
+  warnings.push(...lint.warnings);
+  if (!lint.ok) {
+    errors.push(...lint.errors);
+    return { ok: false, errors, warnings, ...baseResult };
+  }
+
+  const permissiveFlag = opts.failOnPermissive ? ['--fail-on-permissive'] : [];
+
+  // Step 2: edge compile.
+  if (target === 'aws') {
+    const compilePath = path.join(pkgRoot, 'scripts', 'compile.js');
+    const compileResult = spawnSync(
+      process.execPath,
+      [
+        compilePath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...permissiveFlag,
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (compileResult.status !== 0) {
+      errors.push(`edge compile failed (status ${compileResult.status})`);
+      if (compileResult.stderr) errors.push(compileResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (compileResult.stderr) {
+      warnings.push(...compileResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.edgeFiles = AWS_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
+
+    const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
+    const infraResult = spawnSync(
+      process.execPath,
+      [
+        infraPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        '--output-mode', opts.outputMode || 'full',
+        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (infraResult.status !== 0) {
+      errors.push(`infra compile failed (status ${infraResult.status})`);
+      if (infraResult.stderr) errors.push(infraResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (infraResult.stderr) {
+      warnings.push(...infraResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  } else {
+    const compileCfPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare.js');
+    const cfResult = spawnSync(
+      process.execPath,
+      [
+        compileCfPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...permissiveFlag,
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (cfResult.status !== 0) {
+      errors.push(`cloudflare edge compile failed (status ${cfResult.status})`);
+      if (cfResult.stderr) errors.push(cfResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (cfResult.stderr) {
+      warnings.push(...cfResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.edgeFiles = CF_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
+
+    const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
+    const cfWafResult = spawnSync(
+      process.execPath,
+      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (cfWafResult.status !== 0) {
+      errors.push(`cloudflare waf compile failed (status ${cfWafResult.status})`);
+      if (cfWafResult.stderr) errors.push(cfWafResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (cfWafResult.stderr) {
+      warnings.push(...cfWafResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  }
+
+  return { ok: true, errors, warnings, ...baseResult };
+}
+
+module.exports = { compile };

--- a/lib/emit-waf.js
+++ b/lib/emit-waf.js
@@ -1,0 +1,166 @@
+/**
+ * Programmatic API: emitWaf
+ *
+ * Generate only the WAF/infra config — no edge code. Mirrors the CLI
+ * `emit-waf` subcommand and keeps the same flag surface.
+ *
+ * Input:
+ *   {
+ *     policyPath:     string,
+ *     outDir:         string,
+ *     target:         'aws' | 'cloudflare',
+ *     format?:        'terraform' | 'cloudformation' | 'cdk',
+ *     outputMode?:    'full' | 'rule-group',
+ *     ruleGroupOnly?: boolean,
+ *     cwd?:           string,
+ *     pkgRoot?:       string,
+ *     env?:           NodeJS.ProcessEnv,
+ *   }
+ *
+ * Output: same shape as compile() but edgeFiles is always [].
+ *
+ * Error semantics for unimplemented formats: cloudformation and cdk return
+ * { ok: false } with `errors` explaining the format is not implemented. The
+ * CLI layer translates this to exit code 2 (see bin/cli.js).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { lintPolicy } = require('./lint');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function listInfraArtifacts(outDir) {
+  const infraDir = path.join(outDir, 'infra');
+  if (!fs.existsSync(infraDir)) return [];
+  return fs
+    .readdirSync(infraDir)
+    .filter((name) => name.endsWith('.tf.json'))
+    .map((name) => path.join(infraDir, name));
+}
+
+function emitWaf(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const env = opts.env || process.env;
+  const format = opts.format || 'terraform';
+  const target = opts.target || 'aws';
+
+  const errors = [];
+  const warnings = [];
+  const baseResult = {
+    edgeFiles: [],
+    infraFiles: [],
+    policyPath: null,
+    outDir: null,
+    target,
+    format,
+    formatNotImplemented: false,
+  };
+
+  if (!opts.policyPath) {
+    return { ok: false, errors: ['policyPath is required'], warnings, ...baseResult };
+  }
+  if (!opts.outDir) {
+    return { ok: false, errors: ['outDir is required'], warnings, ...baseResult };
+  }
+  if (target !== 'aws' && target !== 'cloudflare') {
+    return {
+      ok: false,
+      errors: [`Unknown target: ${target} (expected aws | cloudflare)`],
+      warnings,
+      ...baseResult,
+    };
+  }
+  if (!['terraform', 'cloudformation', 'cdk'].includes(format)) {
+    return {
+      ok: false,
+      errors: [`Unknown --format: ${format} (expected terraform | cloudformation | cdk)`],
+      warnings,
+      ...baseResult,
+    };
+  }
+  if (format !== 'terraform') {
+    return {
+      ok: false,
+      errors: [
+        `--format ${format} is not yet implemented. Only terraform is generated today; cloudformation and cdk are reserved and intentionally fail loudly to prevent silent fallback.`,
+      ],
+      warnings,
+      ...baseResult,
+      formatNotImplemented: true,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  const outDir = resolveAbsolute(opts.outDir, cwd);
+  baseResult.policyPath = policyPath;
+  baseResult.outDir = outDir;
+
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      ...baseResult,
+    };
+  }
+
+  const lint = lintPolicy({ policyPath, pkgRoot, env });
+  warnings.push(...lint.warnings);
+  if (!lint.ok) {
+    errors.push(...lint.errors);
+    return { ok: false, errors, warnings, ...baseResult };
+  }
+
+  if (target === 'aws') {
+    const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
+    const result = spawnSync(
+      process.execPath,
+      [
+        infraPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        '--output-mode', opts.outputMode || 'full',
+        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (result.status !== 0) {
+      errors.push(`infra compile failed (status ${result.status})`);
+      if (result.stderr) errors.push(result.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (result.stderr) {
+      warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  } else {
+    const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
+    const result = spawnSync(
+      process.execPath,
+      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (result.status !== 0) {
+      errors.push(`cloudflare waf compile failed (status ${result.status})`);
+      if (result.stderr) errors.push(result.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (result.stderr) {
+      warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  }
+
+  return { ok: true, errors, warnings, ...baseResult };
+}
+
+module.exports = { emitWaf };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,38 @@
+/**
+ * cdn-security-framework — Programmatic API
+ *
+ * Stable Node.js entry point for embedding the compiler in existing CI/CD
+ * pipelines (Terraform wrappers, CDK app synth hooks, custom policy servers,
+ * etc.) without shelling out to the CLI.
+ *
+ * Every exported function returns a structured result object. **None of them
+ * call process.exit** — callers decide exit behaviour.
+ *
+ * Result contract (all functions):
+ *   {
+ *     ok:       boolean,        // true iff zero errors
+ *     errors:   string[],       // human-readable error lines
+ *     warnings: string[],       // non-fatal advisories
+ *     ...cmdSpecific,           // per-function extra fields (see each docstring)
+ *   }
+ *
+ * Scope note: v1 of this API provides a stable contract. compile() and
+ * emitWaf() currently delegate to subprocesses internally; that is an
+ * implementation detail and will be replaced by in-process module boundaries
+ * in #69 (module split) without changing the public shape.
+ */
+
+const { lintPolicy } = require('./lint');
+const { compile } = require('./compile');
+const { emitWaf } = require('./emit-waf');
+const { migratePolicy } = require('./migrate');
+
+const { runDoctor } = require('../scripts/cli-doctor');
+
+module.exports = {
+  lintPolicy,
+  compile,
+  emitWaf,
+  runDoctor,
+  migratePolicy,
+};

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,0 +1,183 @@
+/**
+ * Programmatic API: lintPolicy
+ *
+ * In-process equivalent of `scripts/policy-lint.js`. Returns a structured
+ * result instead of calling process.exit. Stable public surface — the
+ * underlying ajv / validateAuthGates / parsePathPatterns plumbing may change,
+ * but the return shape is stable.
+ *
+ * Input:
+ *   { policyPath: string, pkgRoot?: string }
+ *   pkgRoot defaults to the installed package root (where schema.json lives).
+ *
+ * Output:
+ *   { ok, errors[], warnings[], policy }
+ *   - `policy` is the parsed YAML object (null if parse failed).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const Ajv = require('ajv');
+
+const {
+  validateAuthGates,
+  parsePathPatterns,
+} = require('../scripts/lib/compile-core');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+function formatAjvErrors(errors) {
+  return errors.map((err) => {
+    const loc = err.instancePath || '(root)';
+    const key =
+      err.params && err.params.additionalProperty
+        ? ` (property "${err.params.additionalProperty}")`
+        : '';
+    return `  - ${loc} ${err.message}${key}`;
+  });
+}
+
+function lintPolicy(opts) {
+  opts = opts || {};
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const policyPath = opts.policyPath;
+  const env = opts.env || process.env;
+
+  const errors = [];
+  const warnings = [];
+
+  if (!policyPath) {
+    return {
+      ok: false,
+      errors: ['policyPath is required'],
+      warnings: [],
+      policy: null,
+    };
+  }
+
+  let policy = null;
+  try {
+    policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return {
+        ok: false,
+        errors: [`policy file not found: ${policyPath}`],
+        warnings: [],
+        policy: null,
+      };
+    }
+    return {
+      ok: false,
+      errors: [`failed to parse policy YAML: ${e.message}`],
+      warnings: [],
+      policy: null,
+    };
+  }
+
+  let schema;
+  try {
+    schema = JSON.parse(
+      fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'),
+    );
+  } catch (e) {
+    return {
+      ok: false,
+      errors: [`failed to load schema: ${e.message}`],
+      warnings: [],
+      policy,
+    };
+  }
+
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: true,
+    strictRequired: false,
+    allowUnionTypes: true,
+  });
+  const validate = ajv.compile(schema);
+  if (!validate(policy)) {
+    errors.push('Schema validation failed:');
+    errors.push(...formatAjvErrors(validate.errors || []));
+  }
+
+  try {
+    const block = (policy && policy.request && policy.request.block) || {};
+    if (block.path_patterns !== undefined) {
+      parsePathPatterns(block.path_patterns);
+    }
+  } catch (e) {
+    errors.push(`  - request.block.path_patterns: ${e.message}`);
+  }
+
+  try {
+    validateAuthGates(policy, {
+      exitOnError: false,
+      allowPlaceholderToken: true,
+    });
+  } catch (e) {
+    if (Array.isArray(e.validationErrors)) {
+      errors.push('Auth gate validation failed:');
+      e.validationErrors.forEach((msg) => errors.push('  - ' + msg));
+    } else {
+      errors.push('Auth gate validation error: ' + e.message);
+    }
+  }
+
+  const waf = (policy && policy.firewall && policy.firewall.waf) || {};
+  if (
+    waf.fingerprint_action &&
+    !['block', 'count'].includes(waf.fingerprint_action)
+  ) {
+    errors.push(
+      '  - firewall.waf.fingerprint_action must be "block" or "count"',
+    );
+  }
+
+  const mode = (policy && policy.defaults && policy.defaults.mode) || null;
+  const isEnforce = mode === 'enforce';
+  const hasWaf = policy && policy.firewall && policy.firewall.waf;
+  if (isEnforce && hasWaf) {
+    const managed = Array.isArray(waf.managed_rules) ? waf.managed_rules : [];
+    const hasCoreSignal = managed.some(
+      (r) =>
+        r === 'AWSManagedRulesBotControlRuleSet' ||
+        r === 'AWSManagedRulesATPRuleSet' ||
+        r === 'AWSManagedRulesIPReputationList' ||
+        r === 'AWSManagedRulesAnonymousIpList',
+    );
+    if (!hasCoreSignal) {
+      warnings.push(
+        'firewall.waf.managed_rules does not include any of BotControl / ATP / IPReputation / AnonymousIp. Consider adding at least IPReputation + AnonymousIp for production enforce mode.',
+      );
+    }
+    const loggingEnabled = waf.logging && waf.logging.enabled === true;
+    if (waf.scope === 'CLOUDFRONT' && !loggingEnabled) {
+      warnings.push(
+        'firewall.waf.logging is not enabled while scope=CLOUDFRONT. PCI-DSS / SOC2 require WAF log retention — set logging.enabled: true and supply destination_arn_env.',
+      );
+    }
+  }
+
+  const originAuth = policy && policy.origin && policy.origin.auth;
+  if (originAuth && originAuth.type === 'custom_header' && originAuth.secret_env) {
+    const envVal = env[originAuth.secret_env];
+    if (envVal !== undefined && envVal.length === 0) {
+      warnings.push(
+        'origin.auth.secret_env "' +
+          originAuth.secret_env +
+          '" is set but empty in the current shell. The edge will refuse to forward the origin-auth header, breaking origin trust. Unset the env or supply a value.',
+      );
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    policy,
+  };
+}
+
+module.exports = { lintPolicy };

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,0 +1,153 @@
+/**
+ * Programmatic API: migratePolicy
+ *
+ * v1 is the only shipped schema, so this is a no-op for v1 → v1. Reports
+ * structured errors for unknown targets, missing versions, and unregistered
+ * migration paths. The CLI `migrate` subcommand translates this into exit
+ * codes 0/1/2.
+ *
+ * Input:
+ *   {
+ *     policyPath: string,
+ *     toVersion?: number | string,   // default: 1
+ *     cwd?:       string,
+ *   }
+ *
+ * Output:
+ *   {
+ *     ok:          boolean,
+ *     errors:      string[],
+ *     warnings:    string[],
+ *     fromVersion: number | undefined,
+ *     toVersion:   number,
+ *     migrated:    boolean,           // true iff a migration actually ran
+ *     noop:        boolean,           // true iff already at target
+ *     reservedExit2?: boolean,        // true for "no migration path registered" — CLI exits 2
+ *   }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function migratePolicy(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const toVersionRaw = opts.toVersion === undefined ? 1 : opts.toVersion;
+  const toVersion = Number(toVersionRaw);
+
+  const warnings = [];
+
+  if (!opts.policyPath) {
+    return {
+      ok: false,
+      errors: ['policyPath is required'],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  if (Number.isNaN(toVersion)) {
+    return {
+      ok: false,
+      errors: [`toVersion must be a number. Got: ${toVersionRaw}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion: NaN,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  let doc;
+  try {
+    doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+  } catch (e) {
+    return {
+      ok: false,
+      errors: [`failed to parse policy YAML: ${e.message}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  const fromVersion = doc && doc.version;
+
+  if (fromVersion === undefined) {
+    return {
+      ok: false,
+      errors: ['Policy has no `version` field. Add `version: 1` and retry.'],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  if (fromVersion === toVersion) {
+    return {
+      ok: true,
+      errors: [],
+      warnings,
+      fromVersion,
+      toVersion,
+      migrated: false,
+      noop: true,
+    };
+  }
+
+  if (toVersion < fromVersion) {
+    return {
+      ok: false,
+      errors: ['Downgrade migrations are not supported.'],
+      warnings,
+      fromVersion,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  // Forward migrations are registered here when a new schema version ships.
+  // Contract: each step is a pure function (v_n policy) -> (v_n+1 policy).
+  // v1 is currently the only shipped schema, so there is nothing to run.
+  return {
+    ok: false,
+    errors: [
+      `No migration path from v${fromVersion} to v${toVersion} is registered in this CLI version.`,
+      'See docs/schema-migration.md for the migration policy and supported versions.',
+    ],
+    warnings,
+    fromVersion,
+    toVersion,
+    migrated: false,
+    noop: false,
+    reservedExit2: true,
+  };
+}
+
+module.exports = { migratePolicy };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cdn-security-framework",
   "version": "1.1.0",
   "description": "Policy-driven CDN edge security. Init YAML with npx cdn-security init, then npx cdn-security build to generate runtime code.",
+  "main": "lib/index.js",
   "bin": {
     "cdn-security": "bin/cli.js"
   },
@@ -9,12 +10,12 @@
     "build": "node scripts/compile.js",
     "lint:policy": "node scripts/policy-lint.js",
     "test:runtime": "node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
-    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js",
+    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js",
     "test:drift": "node scripts/check-drift.js",
     "test:security-baseline": "node scripts/security-baseline-check.js",
     "test:fuzz": "node scripts/regex-fuzz-tests.js",
     "test:cloudflare-integration": "node scripts/cloudflare-integration-tests.js",
-    "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
+    "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
     "test:all": "npm run build && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration",
     "fingerprints:candidates": "node scripts/fingerprint-candidates.js"
   },
@@ -38,6 +39,7 @@
   },
   "files": [
     "bin/",
+    "lib/",
     "scripts/",
     "templates/",
     "policy/profiles/",

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+/**
+ * Programmatic API integration tests.
+ *
+ * These exercise the public entry `require('cdn-security-framework')` from
+ * the repo (via its lib/index.js). We assert every function returns a
+ * structured result object and NEVER calls process.exit — the whole point
+ * of the Programmatic API is that callers decide exit behaviour.
+ *
+ * Coverage focus:
+ *   - result shape stability (this is the contract)
+ *   - lintPolicy in-process happy/error paths
+ *   - compile + emitWaf backwards-compat (subprocess-backed today)
+ *   - migratePolicy noop and error branches (no process.exit)
+ *   - runDoctor re-export is callable
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const api = require('../lib');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('OK:', name);
+  } catch (e) {
+    console.error('FAIL:', name);
+    console.error(e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  }
+}
+
+const repoRoot = path.join(__dirname, '..');
+
+const BASIC_AWS_POLICY = `
+version: 1
+project: api-test
+request:
+  allow_methods: [GET, POST]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
+
+const BROKEN_POLICY = `
+version: 1
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+unknown_top_level_key: true
+`;
+
+function tmpProject(yamlBody) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
+  const policyDir = path.join(tmp, 'policy');
+  fs.mkdirSync(policyDir);
+  const policyPath = path.join(policyDir, 'security.yml');
+  fs.writeFileSync(policyPath, yamlBody, 'utf8');
+  return {
+    tmp,
+    policyPath,
+    outDir: path.join(tmp, 'dist'),
+    cleanup() { fs.rmSync(tmp, { recursive: true, force: true }); },
+  };
+}
+
+// --- Exports surface ---
+
+test('api exports stable surface', () => {
+  assert.strictEqual(typeof api.lintPolicy, 'function');
+  assert.strictEqual(typeof api.compile, 'function');
+  assert.strictEqual(typeof api.emitWaf, 'function');
+  assert.strictEqual(typeof api.runDoctor, 'function');
+  assert.strictEqual(typeof api.migratePolicy, 'function');
+});
+
+test('api entry point matches package.json main', () => {
+  const pkg = require('../package.json');
+  assert.strictEqual(pkg.main, 'lib/index.js', 'package.json main must point to lib/index.js');
+  // The require above would have thrown if the path was wrong, but assert anyway.
+  assert.ok(fs.existsSync(path.join(repoRoot, 'lib', 'index.js')));
+});
+
+// --- lintPolicy ---
+
+test('lintPolicy: returns ok=true for valid policy', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.lintPolicy({ policyPath: ctx.policyPath });
+    assert.strictEqual(result.ok, true, `lint failed: ${JSON.stringify(result.errors)}`);
+    assert.ok(Array.isArray(result.errors));
+    assert.ok(Array.isArray(result.warnings));
+    assert.ok(result.policy && result.policy.version === 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('lintPolicy: missing policyPath → structured error, no throw', () => {
+  const result = api.lintPolicy({});
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+  assert.strictEqual(result.policy, null);
+});
+
+test('lintPolicy: nonexistent file → structured error', () => {
+  const result = api.lintPolicy({ policyPath: '/no/such/file.yml' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+});
+
+test('lintPolicy: invalid policy surfaces schema errors', () => {
+  const ctx = tmpProject(BROKEN_POLICY);
+  try {
+    const result = api.lintPolicy({ policyPath: ctx.policyPath });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.length > 0, 'expected errors for invalid policy');
+    assert.ok(result.policy !== null, 'policy should still be parsed');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('lintPolicy: does not call process.exit (isolation probe)', () => {
+  // If lintPolicy ever calls process.exit, Node will terminate this test
+  // process before subsequent tests run. Reaching the assertion below
+  // confirms non-termination for the error path.
+  const result = api.lintPolicy({ policyPath: '/no/such/file.yml' });
+  assert.strictEqual(result.ok, false);
+});
+
+// --- compile ---
+
+test('compile: aws target writes edge + infra, returns file lists', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.compile({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.ok, true, `compile failed: ${result.errors.join(' ')}`);
+    assert.strictEqual(result.target, 'aws');
+    assert.ok(result.edgeFiles.length >= 3, 'aws target emits 3 edge files');
+    assert.ok(result.edgeFiles.every((f) => fs.existsSync(f)), 'all edge files must exist');
+    assert.ok(result.infraFiles.length > 0, 'aws target emits infra files');
+    assert.ok(result.infraFiles.every((f) => fs.existsSync(f)));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compile: unknown target returns structured error', () => {
+  const result = api.compile({
+    policyPath: '/tmp/nothing.yml',
+    outDir: '/tmp/out',
+    target: 'gcp',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /unknown target/i.test(e)));
+});
+
+test('compile: missing policyPath → error, no exit', () => {
+  const result = api.compile({ outDir: '/tmp', target: 'aws' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+});
+
+test('compile: missing outDir → error, no exit', () => {
+  const result = api.compile({ policyPath: '/tmp/x.yml', target: 'aws' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /outDir is required/.test(e)));
+});
+
+test('compile: nonexistent policy file → structured error', () => {
+  const result = api.compile({
+    policyPath: '/no/such/policy.yml',
+    outDir: '/tmp/irrelevant-should-not-be-created',
+    target: 'aws',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+});
+
+// --- emitWaf ---
+
+test('emitWaf: aws emits only infra, edgeFiles empty', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.emitWaf({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.ok, true, `emitWaf failed: ${result.errors.join(' ')}`);
+    assert.deepStrictEqual(result.edgeFiles, [], 'emit-waf must NOT emit edge files');
+    assert.ok(result.infraFiles.length > 0);
+    const edgeDir = path.join(ctx.outDir, 'edge');
+    assert.ok(!fs.existsSync(edgeDir), 'emit-waf must not create dist/edge/');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('emitWaf: --format cloudformation returns ok=false with formatNotImplemented flag', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.emitWaf({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      format: 'cloudformation',
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.formatNotImplemented, true);
+    assert.ok(result.errors.some((e) => /not yet implemented/i.test(e)));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('emitWaf: unknown format → structured error', () => {
+  const result = api.emitWaf({
+    policyPath: '/tmp/x.yml',
+    outDir: '/tmp/out',
+    target: 'aws',
+    format: 'pulumi',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /unknown --format/i.test(e)));
+});
+
+// --- migratePolicy ---
+
+test('migratePolicy: v1 → v1 is ok+noop', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.migratePolicy({ policyPath: ctx.policyPath, toVersion: 1 });
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.noop, true);
+    assert.strictEqual(result.migrated, false);
+    assert.strictEqual(result.fromVersion, 1);
+    assert.strictEqual(result.toVersion, 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('migratePolicy: no version field → ok=false with guidance error', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-'));
+  try {
+    const policyPath = path.join(tmp, 'policy.yml');
+    fs.writeFileSync(policyPath, 'project: noversion\n', 'utf8');
+    const result = api.migratePolicy({ policyPath });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((e) => /no `version` field/.test(e)));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('migratePolicy: unknown forward path sets reservedExit2', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.migratePolicy({ policyPath: ctx.policyPath, toVersion: 99 });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reservedExit2, true);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('migratePolicy: downgrade rejected', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-'));
+  try {
+    const policyPath = path.join(tmp, 'policy.yml');
+    fs.writeFileSync(policyPath, 'version: 5\nproject: future\n', 'utf8');
+    const result = api.migratePolicy({ policyPath, toVersion: 1 });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((e) => /Downgrade/.test(e)));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- runDoctor re-export ---
+
+test('runDoctor: re-export is callable and returns exitCode + report', () => {
+  // Doctor needs to run in a dir with no policy to hit the "policy_exists" fail
+  // path cleanly — we don't care about pass/fail here, just the shape.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-'));
+  try {
+    const result = api.runDoctor({
+      cwd: tmp,
+      pkgRoot: repoRoot,
+      reportPath: null,
+    });
+    assert.strictEqual(typeof result.exitCode, 'number');
+    assert.ok(result.report && Array.isArray(result.report.checks));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- regression: CLI still works after refactor ---
+
+test('CLI backwards-compat: `cdn-security build --target aws` still succeeds', () => {
+  // We shell out to the CLI here precisely to verify the refactored bin/cli.js
+  // still honors the legacy exit-code + stdout contract. Isolated tmp dir.
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result = spawnSync(process.execPath, [
+      cli, 'build',
+      '-p', ctx.policyPath,
+      '-o', ctx.outDir,
+      '--target', 'aws',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.status, 0, `CLI build failed: ${result.stderr}`);
+    assert.ok(fs.existsSync(path.join(ctx.outDir, 'edge', 'viewer-request.js')));
+    assert.ok(fs.existsSync(path.join(ctx.outDir, 'infra', 'waf-rules.tf.json')));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}


### PR DESCRIPTION
## Summary

- Ships `require('cdn-security-framework')` as the stable public Node.js surface so CI / IaC / custom wrappers can drive the compiler without shelling out.
- Adds `lib/` with 5 entry points: `compile`, `emitWaf`, `lintPolicy`, `migratePolicy`, `runDoctor`. All return `{ ok, errors, warnings, ... }`; none call `process.exit`.
- Refactors `bin/cli.js` — `build` / `emit-waf` / `migrate` delegate to the API; the CLI is the only layer that maps structured results to exit codes (1 for failure, 2 for reserved/not-implemented via `formatNotImplemented` / `reservedExit2` flags).
- 21 new unit tests cover the surface, the no-`process.exit` invariant, error semantics, and CLI backwards compatibility.
- Docs: `docs/programmatic-api.md` + `.ja.md`; linked from both READMEs.

## Why this, why now

The external review (issues #67–#70) flagged four items. `#67 programmatic API` is the one with zero open questions and the prerequisite for the rest: the subsequent module split (#69) and TS migration (#70) both need a stable public contract to refactor behind. Picking this one first is scope-contained and unblocks the others.

## Scope note

`compile()` and `emitWaf()` currently invoke `scripts/compile.js` / `compile-infra.js` / `compile-cloudflare.js` via `spawnSync`. The **contract is stable**; the subprocess boundary is an implementation detail that moves in-process under #69 without changing the surface. `lintPolicy` and `migratePolicy` are already fully in-process.

## Backwards compatibility

- CLI subcommands, options, exit codes unchanged.
- Stderr wording preserved (`Unknown --format:`, `Unknown target:`) so scripts grepping stderr keep working. The `CLI backwards-compat` test in the new suite exercises an end-to-end `cdn-security build --target aws` subprocess to lock this in.
- `package.json` `main` points to `lib/index.js`; `lib/` added to `files`.

## Test plan

- [x] `npm run test:unit` — all suites pass (compile-unit, infra-unit, schema-lint, doctor-unit, emit-waf-unit, **programmatic-api-unit (21 tests)**)
- [x] `npm run build` + `npm run test:runtime` — AWS + Cloudflare runtime tests pass with `EDGE_ADMIN_TOKEN` set
- [x] `npm run lint:policy` (all profiles)
- [x] Manual: `node -e "console.log(Object.keys(require('./lib')))"` prints the 5 exports
- [x] Manual: `bin/cli.js build` / `emit-waf` / `migrate` all still produce identical output
- [x] Manual: `emit-waf --format cdk` exits 2 with `formatNotImplemented`
- [x] Docs: `docs/programmatic-api.md` + `.ja.md` linked from both READMEs

Closes #67.