### PR TITLE
feat: Cloudflare WAF parity transparency (closes #68)

### DIFF
--- a/.github/workflows/policy-lint.yml
+++ b/.github/workflows/policy-lint.yml
@@ -65,6 +65,13 @@ jobs:
       - name: Build Cloudflare (compile policy → dist)
         run: node scripts/compile-cloudflare.js
 
+      - name: Cloudflare WAF parity gate (base policy must build without approximation warnings)
+        # base.yml intentionally uses only equivalent AWS rules. Any policy change
+        # that introduces approximate or unsupported mappings must be accompanied
+        # by an explicit docs/cloudflare-waf-parity.md update; this gate fails
+        # CI loudly instead of silently degrading.
+        run: node scripts/compile-cloudflare-waf.js --policy policy/base.yml --out-dir dist --fail-on-waf-approximation
+
       - name: Ensure build produces dist/
         run: |
           test -f dist/edge/viewer-request.js || (echo "Missing dist/edge/viewer-request.js"; exit 1)

--- a/README.ja.md
+++ b/README.ja.md
@@ -101,6 +101,7 @@ Terraform / CDK / WAF の利用例は [IaC 連携](docs/iac.ja.md) を参照。
 
 ### 運用ドキュメント
 - [CLI リファレンス](docs/cli.ja.md) — `init` / `build` / `emit-waf` / `doctor` / `migrate`
+- [プログラマティック API](docs/programmatic-api.ja.md) — `require('cdn-security-framework')` で CI / IaC から直接呼び出し
 - [アーキタイプ](docs/archetypes.ja.md) — アプリ形状別プリセット（SPA / REST API / 管理画面 / マイクロサービス）
 - [シークレットローテーション runbook](docs/runbooks/secret-rotation.ja.md) — JWT / JWKS / 署名付き URL / 管理トークン / origin シークレット
 - [スキーママイグレーション](docs/schema-migration.ja.md) — `policy/schema.json` のバージョン契約と `migrate` CLI

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [IaC integration](docs/iac.md) for Terraform / CDK / WAF usage.
 
 ### Operational docs
 - [CLI reference](docs/cli.md) — `init` / `build` / `emit-waf` / `doctor` / `migrate`
+- [Programmatic API](docs/programmatic-api.md) — `require('cdn-security-framework')` for CI / IaC integration
 - [Archetypes](docs/archetypes.md) — app-shaped policy presets (SPA, REST API, admin, microservice)
 - [Secret rotation runbook](docs/runbooks/secret-rotation.md) — JWT / JWKS / signed URL / admin token / origin secret
 - [Schema migration](docs/schema-migration.md) — how `policy/schema.json` evolves and the `migrate` CLI

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -138,82 +138,38 @@ program
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--fail-on-permissive', 'Exit non-zero when policy.metadata.risk_level is "permissive" (gate for production CI)')
   .action((opts) => {
+    const { compile } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     let policyPath = opts.policy;
     if (!policyPath) {
       const security = path.join(cwd, 'policy', 'security.yml');
       const base = path.join(cwd, 'policy', 'base.yml');
       policyPath = fs.existsSync(security) ? security : base;
-    } else if (!path.isAbsolute(policyPath)) {
-      policyPath = path.join(cwd, policyPath);
-    }
-    const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
-
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
     }
 
-    // Lint
-    const lintPath = path.join(pkgRoot, 'scripts', 'policy-lint.js');
-    const { spawnSync } = require('child_process');
-    const lintResult = spawnSync(process.execPath, [lintPath, policyPath], {
-      stdio: 'inherit',
+    const result = compile({
+      policyPath,
+      outDir: opts.outDir,
+      target: opts.target,
+      outputMode: opts.outputMode,
+      ruleGroupOnly: !!opts.ruleGroupOnly,
+      failOnPermissive: !!opts.failOnPermissive,
       cwd,
+      pkgRoot,
     });
-    if (lintResult.status !== 0) {
-      console.error('[ERROR] Policy validation failed.');
+
+    result.warnings.forEach((w) => console.warn(w));
+
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
       process.exit(1);
     }
+
     console.log('[INFO] Validating policy... OK');
-
-    const permissiveFlag = opts.failOnPermissive ? ['--fail-on-permissive'] : [];
-
-    if (opts.target === 'aws') {
-      console.log('[INFO] Target: AWS CloudFront Functions');
-      const compilePath = path.join(pkgRoot, 'scripts', 'compile.js');
-      const compileResult = spawnSync(process.execPath, [
-        compilePath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        ...permissiveFlag,
-      ], { stdio: 'inherit', cwd });
-      if (compileResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'viewer-request.js'));
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'viewer-response.js'));
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'origin-request.js'));
-      const compileInfraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
-      const compileInfraResult = spawnSync(process.execPath, [
-        compileInfraPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        '--output-mode', opts.outputMode,
-        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
-      ], { stdio: 'inherit', cwd });
-      if (compileInfraResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', '*.tf.json'));
-    } else if (opts.target === 'cloudflare') {
-      console.log('[INFO] Target: Cloudflare Workers');
-      const compileCfPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare.js');
-      const compileCfResult = spawnSync(process.execPath, [
-        compileCfPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        ...permissiveFlag,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'edge', 'cloudflare', 'index.ts'));
-      const compileCfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
-      const compileCfWafResult = spawnSync(process.execPath, [
-        compileCfWafPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfWafResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', 'cloudflare-waf.tf.json'));
-    } else {
-      console.error('[ERROR] Unknown target:', opts.target);
-      process.exit(1);
+    console.log('[INFO] Target:', result.target === 'aws' ? 'AWS CloudFront Functions' : 'Cloudflare Workers');
+    result.edgeFiles.forEach((f) => console.log('[SUCCESS] Generated ' + f));
+    if (result.infraFiles.length > 0) {
+      console.log('[SUCCESS] Generated ' + path.join(result.outDir, 'infra', '*.tf.json'));
     }
   });
 
@@ -244,66 +200,37 @@ program
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--format <format>', 'Output format: terraform | cloudformation | cdk (terraform is the only format currently generated; others return exit 2)', 'terraform')
   .action((opts) => {
+    const { emitWaf } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     let policyPath = opts.policy;
     if (!policyPath) {
       const security = path.join(cwd, 'policy', 'security.yml');
       const base = path.join(cwd, 'policy', 'base.yml');
       policyPath = fs.existsSync(security) ? security : base;
-    } else if (!path.isAbsolute(policyPath)) {
-      policyPath = path.join(cwd, policyPath);
-    }
-    const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
-
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
-    }
-    if (!['aws', 'cloudflare'].includes(opts.target)) {
-      console.error('[ERROR] Unknown target:', opts.target, '(expected aws | cloudflare)');
-      process.exit(1);
-    }
-    if (!['terraform', 'cloudformation', 'cdk'].includes(opts.format)) {
-      console.error('[ERROR] Unknown --format:', opts.format, '(expected terraform | cloudformation | cdk)');
-      process.exit(1);
-    }
-    if (opts.format !== 'terraform') {
-      console.error(`[ERROR] --format ${opts.format} is not yet implemented. Only terraform is generated today; cloudformation and cdk are reserved flags with stub rejection so pipelines fail loudly rather than silently falling back.`);
-      process.exit(2);
     }
 
-    // Lint first — emit-waf still goes through schema validation so a broken
-    // policy does not silently produce half a waf-rules.tf.json.
-    const { spawnSync } = require('child_process');
-    const lintPath = path.join(pkgRoot, 'scripts', 'policy-lint.js');
-    const lintResult = spawnSync(process.execPath, [lintPath, policyPath], { stdio: 'inherit', cwd });
-    if (lintResult.status !== 0) {
-      console.error('[ERROR] Policy validation failed.');
-      process.exit(1);
+    const result = emitWaf({
+      policyPath,
+      outDir: opts.outDir,
+      target: opts.target,
+      format: opts.format,
+      outputMode: opts.outputMode,
+      ruleGroupOnly: !!opts.ruleGroupOnly,
+      cwd,
+      pkgRoot,
+    });
+
+    result.warnings.forEach((w) => console.warn(w));
+
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
+      // Reserved format = exit 2 so pipelines notice silent-fallback is not an option.
+      process.exit(result.formatNotImplemented ? 2 : 1);
     }
 
-    if (opts.target === 'aws') {
-      console.log('[INFO] Target: AWS WAFv2 / CloudFront infra');
-      const compileInfraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
-      const compileInfraResult = spawnSync(process.execPath, [
-        compileInfraPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-        '--output-mode', opts.outputMode,
-        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
-      ], { stdio: 'inherit', cwd });
-      if (compileInfraResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', '*.tf.json'));
-    } else {
-      console.log('[INFO] Target: Cloudflare WAF');
-      const compileCfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
-      const compileCfWafResult = spawnSync(process.execPath, [
-        compileCfWafPath,
-        '--policy', policyPath,
-        '--out-dir', outDir,
-      ], { stdio: 'inherit', cwd });
-      if (compileCfWafResult.status !== 0) process.exit(1);
-      console.log('[SUCCESS] Generated ' + path.join(outDir, 'infra', 'cloudflare-waf.tf.json'));
+    console.log('[INFO] Target:', result.target === 'aws' ? 'AWS WAFv2 / CloudFront infra' : 'Cloudflare WAF');
+    if (result.infraFiles.length > 0) {
+      console.log('[SUCCESS] Generated ' + path.join(result.outDir, 'infra', '*.tf.json'));
     }
   });
 
@@ -314,45 +241,31 @@ program
   .option('--to <version>', 'Target schema version', '1')
   .option('--write', 'Write the migrated policy back in place (no-op on v1)')
   .action((opts) => {
+    const { migratePolicy } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
     const policyPath = path.isAbsolute(opts.policy) ? opts.policy : path.join(cwd, opts.policy);
-    if (!fs.existsSync(policyPath)) {
-      console.error('[ERROR] Policy file not found:', policyPath);
-      process.exit(1);
-    }
-    const yaml = require('js-yaml');
-    const doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-    const fromVersion = doc && doc.version;
-    const toVersion = Number(opts.to);
 
-    if (fromVersion === undefined) {
-      console.error('[ERROR] Policy has no `version` field. Add `version: 1` and retry.');
-      process.exit(1);
-    }
-    if (Number.isNaN(toVersion)) {
-      console.error('[ERROR] --to must be a number. Got:', opts.to);
-      process.exit(1);
+    const result = migratePolicy({
+      policyPath,
+      toVersion: opts.to,
+      cwd,
+    });
+
+    if (result.fromVersion !== undefined) {
+      console.log('[INFO] Policy:', policyPath);
+      console.log('[INFO] Current schema version:', result.fromVersion);
+      console.log('[INFO] Target schema version: ', result.toVersion);
     }
 
-    console.log('[INFO] Policy:', policyPath);
-    console.log('[INFO] Current schema version:', fromVersion);
-    console.log('[INFO] Target schema version: ', toVersion);
-
-    if (fromVersion === toVersion) {
+    if (result.ok && result.noop) {
       console.log('[OK] Already at target version — no migration needed.');
       process.exit(0);
     }
-    if (toVersion < fromVersion) {
-      console.error('[ERROR] Downgrade migrations are not supported.');
-      process.exit(1);
-    }
 
-    // Forward migrations are registered here when a new schema version ships.
-    // The contract: each step is a pure function (v_n policy) -> (v_n+1 policy).
-    // v1 is currently the only shipped schema, so there is nothing to run.
-    console.error(`[ERROR] No migration path from v${fromVersion} to v${toVersion} is registered in this CLI version.`);
-    console.error('        See docs/schema-migration.md for the migration policy and supported versions.');
-    process.exit(2);
+    if (!result.ok) {
+      result.errors.forEach((e) => console.error('[ERROR]', e));
+      process.exit(result.reservedExit2 ? 2 : 1);
+    }
   });
 
 program.parse();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -137,6 +137,7 @@ program
   .option('--output-mode <mode>', 'AWS infra output mode: full | rule-group', 'full')
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--fail-on-permissive', 'Exit non-zero when policy.metadata.risk_level is "permissive" (gate for production CI)')
+  .option('--fail-on-waf-approximation', 'Cloudflare only: exit non-zero when the policy relies on approximate or unsupported Cloudflare WAF mappings (see docs/cloudflare-waf-parity.md)')
   .action((opts) => {
     const { compile } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
@@ -154,6 +155,7 @@ program
       outputMode: opts.outputMode,
       ruleGroupOnly: !!opts.ruleGroupOnly,
       failOnPermissive: !!opts.failOnPermissive,
+      failOnWafApproximation: !!opts.failOnWafApproximation,
       cwd,
       pkgRoot,
     });
@@ -199,6 +201,7 @@ program
   .option('--output-mode <mode>', 'AWS infra output mode: full | rule-group', 'full')
   .option('--rule-group-only', 'AWS only: generate WAF rule groups without aws_wafv2_web_acl output')
   .option('--format <format>', 'Output format: terraform | cloudformation | cdk (terraform is the only format currently generated; others return exit 2)', 'terraform')
+  .option('--fail-on-waf-approximation', 'Cloudflare only: exit non-zero when the policy relies on approximate or unsupported Cloudflare WAF mappings (see docs/cloudflare-waf-parity.md)')
   .action((opts) => {
     const { emitWaf } = require(path.join(pkgRoot, 'lib'));
     const cwd = process.cwd();
@@ -216,6 +219,7 @@ program
       format: opts.format,
       outputMode: opts.outputMode,
       ruleGroupOnly: !!opts.ruleGroupOnly,
+      failOnWafApproximation: !!opts.failOnWafApproximation,
       cwd,
       pkgRoot,
     });

--- a/docs/cloudflare-waf-parity.ja.md
+++ b/docs/cloudflare-waf-parity.ja.md
@@ -1,0 +1,136 @@
+# Cloudflare WAF パリティ
+
+> **Languages:** [English](./cloudflare-waf-parity.md) · 日本語
+
+このドキュメントは `scripts/lib/cloudflare-waf-parity.js` から **自動生成** されます。手で編集せず、メタデータ更新後に `node scripts/generate-parity-doc.js --write --lang=ja` を実行してください。`scripts/check-drift.js` がズレを検知すると CI が落ちます。
+
+「1 つの YAML で CloudFront と Cloudflare 両方」という前提は、**どこが 1:1 等価で、どこが近似で、どこが未対応か** を利用者が把握していてはじめて成立します。黙って劣化させるのはアーキテクチャ上の罪なので、コンパイラは equivalent 以外の全てで stderr 警告を出し、`--fail-on-waf-approximation` を付けると本番 CI で非ゼロ終了します。
+
+## 凡例
+
+| ステータス | 意味 |
+| --- | --- |
+| `EQUIVALENT` | Cloudflare に 1:1 のリソースあり。警告なし。 |
+| `APPROXIMATE` | 近いが同一ではない。警告あり。`--fail-on-waf-approximation` で非ゼロ終了。 |
+| `UNSUPPORTED` | 現状 Cloudflare に対応物なし。ルールは `enabled: false` で出力。警告あり、`--fail-on-waf-approximation` で非ゼロ終了。 |
+
+## AWS マネージドルール
+
+| AWS ルール | ステータス | Cloudflare ターゲット | 最終確認日 |
+| --- | --- | --- | --- |
+| `AWSManagedRulesCommonRuleSet` | `EQUIVALENT` | Cloudflare Managed Ruleset (`efb7b8c949ac4650a09736fc376e9aee`) | 2026-04-24 |
+| `AWSManagedRulesKnownBadInputsRuleSet` | `APPROXIMATE` | Cloudflare OWASP Core Ruleset (`4814384a9e5d4991b9815dcfc25d2f1f`) | 2026-04-24 |
+| `AWSManagedRulesSQLiRuleSet` | `APPROXIMATE` | Cloudflare OWASP Core Ruleset (`4814384a9e5d4991b9815dcfc25d2f1f`) | 2026-04-24 |
+| `AWSManagedRulesIPReputationList` | `APPROXIMATE` | Cloudflare Exposed Credentials Check Managed Ruleset (`c2e184081120413c86c3ab7e14069605`) | 2026-04-24 |
+| `AWSManagedRulesBotControlRuleSet` | `APPROXIMATE` | Bot Fight Mode (zone setting) / Bot Management (paid) | 2026-04-24 |
+| `AWSManagedRulesAnonymousIpList` | `APPROXIMATE` | Cloudflare Security Level (zone setting) + IP Lists (manual feeds) | 2026-04-24 |
+| `AWSManagedRulesATPRuleSet` | `UNSUPPORTED` | — | 2026-04-24 |
+
+### `AWSManagedRulesCommonRuleSet`
+
+- **ステータス:** `EQUIVALENT`
+- **Cloudflare ターゲット:** Cloudflare Managed Ruleset（id `efb7b8c949ac4650a09736fc376e9aee`）
+- **ドキュメント:** https://developers.cloudflare.com/waf/managed-rules/reference/cloudflare-managed-ruleset/
+- **最終確認日:** 2026-04-24
+
+Cloudflare Managed Ruleset covers the same baseline injection / traversal / scanner signatures as AWS Common Rule Set. Field names differ but blocked traffic class is equivalent.
+
+### `AWSManagedRulesKnownBadInputsRuleSet`
+
+- **ステータス:** `APPROXIMATE`
+- **Cloudflare ターゲット:** Cloudflare OWASP Core Ruleset（id `4814384a9e5d4991b9815dcfc25d2f1f`）
+- **ドキュメント:** https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/
+- **最終確認日:** 2026-04-24
+
+OWASP Core Ruleset overlaps with Known Bad Inputs for scanner / exploit probes but is broader: enabling it also triggers the SQLi / XSS / LFI rule families. Tune the paranoia level and sensitivity after adopting.
+
+### `AWSManagedRulesSQLiRuleSet`
+
+- **ステータス:** `APPROXIMATE`
+- **Cloudflare ターゲット:** Cloudflare OWASP Core Ruleset（id `4814384a9e5d4991b9815dcfc25d2f1f`）
+- **ドキュメント:** https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/
+- **最終確認日:** 2026-04-24
+
+Cloudflare does not ship a standalone SQLi ruleset. The OWASP Core Ruleset covers SQLi via its 942xxx rule family, but declaring it means accepting the full OWASP bundle. If you only want SQLi today, map the individual OWASP rule IDs instead.
+
+### `AWSManagedRulesIPReputationList`
+
+- **ステータス:** `APPROXIMATE`
+- **Cloudflare ターゲット:** Cloudflare Exposed Credentials Check Managed Ruleset（id `c2e184081120413c86c3ab7e14069605`）
+- **ドキュメント:** https://developers.cloudflare.com/waf/managed-rules/reference/exposed-credentials-check/
+- **最終確認日:** 2026-04-24
+
+Cloudflare does not expose its IP reputation list via Ruleset Engine the way AWS does. Closest adjacent Cloudflare feature is Exposed Credentials Check (threat intel against credential-stuffing). If you need IP reputation specifically, enable Cloudflare Security Level (zone-scoped) outside this policy or use IP Lists against known-bad feeds.
+
+### `AWSManagedRulesBotControlRuleSet`
+
+- **ステータス:** `APPROXIMATE`
+- **Cloudflare ターゲット:** Bot Fight Mode (zone setting) / Bot Management (paid)
+- **ドキュメント:** https://developers.cloudflare.com/bots/
+- **最終確認日:** 2026-04-24
+
+Cloudflare bot mitigation is not a ruleset — it is a zone-scoped feature (Bot Fight Mode on free; Bot Management on enterprise). The compiler sets `bot_fight_mode: on` via cloudflare_zone_settings_override, which is only a coarse approximation of AWS Bot Control.
+
+### `AWSManagedRulesAnonymousIpList`
+
+- **ステータス:** `APPROXIMATE`
+- **Cloudflare ターゲット:** Cloudflare Security Level (zone setting) + IP Lists (manual feeds)
+- **ドキュメント:** https://developers.cloudflare.com/waf/tools/security-level/
+- **最終確認日:** 2026-04-24
+
+Cloudflare does not expose a managed anonymous-IP / VPN / Tor list as a Ruleset. Approximate coverage is available via the zone-level Security Level setting (blocks threat-scored traffic including known anonymizers) and Tor-exit custom IP Lists seeded from public feeds. Neither is a drop-in replacement for the AWS AnonymousIpList; the compiler emits the rule disabled so operators choose explicitly.
+
+### `AWSManagedRulesATPRuleSet`
+
+- **ステータス:** `UNSUPPORTED`
+- **Cloudflare ターゲット:** なし
+- **ドキュメント:** https://developers.cloudflare.com/bots/concepts/bot-score/
+- **最終確認日:** 2026-04-24
+
+AWS ATP (Account Takeover Prevention) runs credential-stuffing detection at the edge with stateful scoring. Cloudflare does not expose an equivalent via Ruleset Engine. Closest features (Bot Management, Super Bot Fight Mode) are not policy-portable. Declare ATP only on the AWS side for now.
+
+## `scope_down_statement` 形状
+
+AWS の `rate_limit_rules[].scope_down_statement` は構造化 AST ですが、Cloudflare のレートリミットは自由形式 `expression` でスコープを指定します。コンパイラは限られた形状だけ自動変換し、それ以外は policy 側で `rule.expression_cloudflare` を明示してもらう方針です。
+
+| 形状 | ステータス | Cloudflare expression | 備考 |
+| --- | --- | --- | --- |
+| `byte_match_statement(uri_path, STARTS_WITH)` | `EQUIVALENT` | `starts_with(http.request.uri.path, "<value>")` | Direct translation — Cloudflare expression language has starts_with/ends_with/contains helpers. |
+| `byte_match_statement(uri_path, EXACTLY)` | `APPROXIMATE` | `http.request.uri.path eq "<value>"` | Not yet auto-translated by the compiler. Set rule.expression_cloudflare to override. Will be promoted to equivalent once the translator is extended. |
+| `byte_match_statement(uri_path, CONTAINS)` | `APPROXIMATE` | `http.request.uri.path contains "<value>"` | Not yet auto-translated. Set rule.expression_cloudflare. Will be promoted once the translator is extended. |
+| `regex_match_statement` | `APPROXIMATE` | `http.request.uri.path matches "<regex>"` | Cloudflare supports regex via the `matches` operator but differs in flavor (RE2 vs AWS regex). Auto-translation would risk silent re-interpretation of edge cases. Require explicit expression_cloudflare. |
+| `label_match_statement / size_constraint_statement / geo_match_statement (inside scope-down)` | `UNSUPPORTED` | — | These AWS scope-down shapes have no direct expression counterpart. Either flatten the scope-down into a separate Cloudflare rule, or provide expression_cloudflare explicitly on the rate_limit rule. |
+
+## IP レピュテーション / リスト
+
+| 機能 | ステータス | Cloudflare 対応面 | 最終確認日 |
+| --- | --- | --- | --- |
+| AWS WAF IP reputation list (managed) | `APPROXIMATE` | Exposed Credentials Check / Zone Security Level | 2026-04-24 |
+| Custom IP block / allowlists | `EQUIVALENT` | cloudflare_list (ip kind) + custom firewall rule | 2026-04-24 |
+
+- **AWS WAF IP reputation list (managed)** — Cloudflare does not expose IP reputation via Ruleset Engine. Use Security Level (zone setting) plus custom IP Lists seeded from a threat feed for comparable coverage.
+- **Custom IP block / allowlists** — Direct translation. The compiler emits cloudflare_list + ruleset rule referencing $<name>_ip_blocklist.
+
+## ロギング
+
+| 機能 | ステータス | Cloudflare 対応面 | 最終確認日 |
+| --- | --- | --- | --- |
+| AWS WAF logging destination (Kinesis / CloudWatch / S3) | `APPROXIMATE` | cloudflare_logpush_job (dataset: firewall_events) | 2026-04-24 |
+
+- **AWS WAF logging destination (Kinesis / CloudWatch / S3)** — Cloudflare Logpush streams firewall_events to S3/R2/GCS. Field names and event shape differ from AWS WAF logs — downstream log queries must be adapted.
+
+## 本番 CI ゲート
+
+```bash
+npx cdn-security build --target cloudflare --fail-on-waf-approximation
+```
+
+コンパイル対象のポリシーが `APPROXIMATE` か `UNSUPPORTED` に触れていると非ゼロで終了します。`main` ブランチのパイプラインではこのゲートを有効化し、開発ブランチではデフォルト（警告のみ）のままで運用するのが推奨です。
+
+## 更新手順
+
+1. `scripts/lib/cloudflare-waf-parity.js` を編集する。
+2. `lastVerified` を今日の日付に更新する。
+3. `node scripts/generate-parity-doc.js --write` と `node scripts/generate-parity-doc.js --write --lang=ja` を実行する。
+4. メタデータ変更と再生成ドキュメントを同じ PR でコミットする。
+

--- a/docs/cloudflare-waf-parity.md
+++ b/docs/cloudflare-waf-parity.md
@@ -1,0 +1,136 @@
+# Cloudflare WAF parity
+
+> **Languages:** English · [日本語](./cloudflare-waf-parity.ja.md)
+
+This document is **generated** from `scripts/lib/cloudflare-waf-parity.js`. Do not edit by hand — run `node scripts/generate-parity-doc.js --write` after changing the metadata. The drift test in `scripts/check-drift.js` fails CI if this file falls out of sync.
+
+The dual-target story ("one YAML, both CloudFront and Cloudflare") depends on users knowing which parts are 1:1 equivalents, which are approximations, and which simply do not exist on Cloudflare. Silent degradation would undermine the whole value proposition — so the compiler emits stderr warnings for every non-equivalent entry, and `--fail-on-waf-approximation` promotes those to a non-zero exit for production CI.
+
+## Legend
+
+| Status | Meaning |
+| --- | --- |
+| `EQUIVALENT` | Cloudflare has a direct 1:1 resource. No warning. |
+| `APPROXIMATE` | Close but not identical. Compiler warns; `--fail-on-waf-approximation` exits non-zero. |
+| `UNSUPPORTED` | No reasonable Cloudflare mapping today. Rule emitted with `enabled: false`. Compiler warns; `--fail-on-waf-approximation` exits non-zero. |
+
+## AWS managed rule sets
+
+| AWS rule | Status | Cloudflare target | Last verified |
+| --- | --- | --- | --- |
+| `AWSManagedRulesCommonRuleSet` | `EQUIVALENT` | Cloudflare Managed Ruleset (`efb7b8c949ac4650a09736fc376e9aee`) | 2026-04-24 |
+| `AWSManagedRulesKnownBadInputsRuleSet` | `APPROXIMATE` | Cloudflare OWASP Core Ruleset (`4814384a9e5d4991b9815dcfc25d2f1f`) | 2026-04-24 |
+| `AWSManagedRulesSQLiRuleSet` | `APPROXIMATE` | Cloudflare OWASP Core Ruleset (`4814384a9e5d4991b9815dcfc25d2f1f`) | 2026-04-24 |
+| `AWSManagedRulesIPReputationList` | `APPROXIMATE` | Cloudflare Exposed Credentials Check Managed Ruleset (`c2e184081120413c86c3ab7e14069605`) | 2026-04-24 |
+| `AWSManagedRulesBotControlRuleSet` | `APPROXIMATE` | Bot Fight Mode (zone setting) / Bot Management (paid) | 2026-04-24 |
+| `AWSManagedRulesAnonymousIpList` | `APPROXIMATE` | Cloudflare Security Level (zone setting) + IP Lists (manual feeds) | 2026-04-24 |
+| `AWSManagedRulesATPRuleSet` | `UNSUPPORTED` | — | 2026-04-24 |
+
+### `AWSManagedRulesCommonRuleSet`
+
+- **Status:** `EQUIVALENT`
+- **Cloudflare target:** Cloudflare Managed Ruleset (id `efb7b8c949ac4650a09736fc376e9aee`)
+- **Docs:** https://developers.cloudflare.com/waf/managed-rules/reference/cloudflare-managed-ruleset/
+- **Last verified:** 2026-04-24
+
+Cloudflare Managed Ruleset covers the same baseline injection / traversal / scanner signatures as AWS Common Rule Set. Field names differ but blocked traffic class is equivalent.
+
+### `AWSManagedRulesKnownBadInputsRuleSet`
+
+- **Status:** `APPROXIMATE`
+- **Cloudflare target:** Cloudflare OWASP Core Ruleset (id `4814384a9e5d4991b9815dcfc25d2f1f`)
+- **Docs:** https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/
+- **Last verified:** 2026-04-24
+
+OWASP Core Ruleset overlaps with Known Bad Inputs for scanner / exploit probes but is broader: enabling it also triggers the SQLi / XSS / LFI rule families. Tune the paranoia level and sensitivity after adopting.
+
+### `AWSManagedRulesSQLiRuleSet`
+
+- **Status:** `APPROXIMATE`
+- **Cloudflare target:** Cloudflare OWASP Core Ruleset (id `4814384a9e5d4991b9815dcfc25d2f1f`)
+- **Docs:** https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/
+- **Last verified:** 2026-04-24
+
+Cloudflare does not ship a standalone SQLi ruleset. The OWASP Core Ruleset covers SQLi via its 942xxx rule family, but declaring it means accepting the full OWASP bundle. If you only want SQLi today, map the individual OWASP rule IDs instead.
+
+### `AWSManagedRulesIPReputationList`
+
+- **Status:** `APPROXIMATE`
+- **Cloudflare target:** Cloudflare Exposed Credentials Check Managed Ruleset (id `c2e184081120413c86c3ab7e14069605`)
+- **Docs:** https://developers.cloudflare.com/waf/managed-rules/reference/exposed-credentials-check/
+- **Last verified:** 2026-04-24
+
+Cloudflare does not expose its IP reputation list via Ruleset Engine the way AWS does. Closest adjacent Cloudflare feature is Exposed Credentials Check (threat intel against credential-stuffing). If you need IP reputation specifically, enable Cloudflare Security Level (zone-scoped) outside this policy or use IP Lists against known-bad feeds.
+
+### `AWSManagedRulesBotControlRuleSet`
+
+- **Status:** `APPROXIMATE`
+- **Cloudflare target:** Bot Fight Mode (zone setting) / Bot Management (paid)
+- **Docs:** https://developers.cloudflare.com/bots/
+- **Last verified:** 2026-04-24
+
+Cloudflare bot mitigation is not a ruleset — it is a zone-scoped feature (Bot Fight Mode on free; Bot Management on enterprise). The compiler sets `bot_fight_mode: on` via cloudflare_zone_settings_override, which is only a coarse approximation of AWS Bot Control.
+
+### `AWSManagedRulesAnonymousIpList`
+
+- **Status:** `APPROXIMATE`
+- **Cloudflare target:** Cloudflare Security Level (zone setting) + IP Lists (manual feeds)
+- **Docs:** https://developers.cloudflare.com/waf/tools/security-level/
+- **Last verified:** 2026-04-24
+
+Cloudflare does not expose a managed anonymous-IP / VPN / Tor list as a Ruleset. Approximate coverage is available via the zone-level Security Level setting (blocks threat-scored traffic including known anonymizers) and Tor-exit custom IP Lists seeded from public feeds. Neither is a drop-in replacement for the AWS AnonymousIpList; the compiler emits the rule disabled so operators choose explicitly.
+
+### `AWSManagedRulesATPRuleSet`
+
+- **Status:** `UNSUPPORTED`
+- **Cloudflare target:** none
+- **Docs:** https://developers.cloudflare.com/bots/concepts/bot-score/
+- **Last verified:** 2026-04-24
+
+AWS ATP (Account Takeover Prevention) runs credential-stuffing detection at the edge with stateful scoring. Cloudflare does not expose an equivalent via Ruleset Engine. Closest features (Bot Management, Super Bot Fight Mode) are not policy-portable. Declare ATP only on the AWS side for now.
+
+## `scope_down_statement` shapes
+
+AWS `rate_limit_rules[].scope_down_statement` is a structured AST. Cloudflare rate limits scope via the free-form `expression` field. The compiler translates a small set of shapes automatically; anything else must be expressed with `rule.expression_cloudflare` on the policy.
+
+| Shape | Status | Cloudflare expression | Notes |
+| --- | --- | --- | --- |
+| `byte_match_statement(uri_path, STARTS_WITH)` | `EQUIVALENT` | `starts_with(http.request.uri.path, "<value>")` | Direct translation — Cloudflare expression language has starts_with/ends_with/contains helpers. |
+| `byte_match_statement(uri_path, EXACTLY)` | `APPROXIMATE` | `http.request.uri.path eq "<value>"` | Not yet auto-translated by the compiler. Set rule.expression_cloudflare to override. Will be promoted to equivalent once the translator is extended. |
+| `byte_match_statement(uri_path, CONTAINS)` | `APPROXIMATE` | `http.request.uri.path contains "<value>"` | Not yet auto-translated. Set rule.expression_cloudflare. Will be promoted once the translator is extended. |
+| `regex_match_statement` | `APPROXIMATE` | `http.request.uri.path matches "<regex>"` | Cloudflare supports regex via the `matches` operator but differs in flavor (RE2 vs AWS regex). Auto-translation would risk silent re-interpretation of edge cases. Require explicit expression_cloudflare. |
+| `label_match_statement / size_constraint_statement / geo_match_statement (inside scope-down)` | `UNSUPPORTED` | — | These AWS scope-down shapes have no direct expression counterpart. Either flatten the scope-down into a separate Cloudflare rule, or provide expression_cloudflare explicitly on the rate_limit rule. |
+
+## IP reputation and lists
+
+| Feature | Status | Cloudflare surface | Last verified |
+| --- | --- | --- | --- |
+| AWS WAF IP reputation list (managed) | `APPROXIMATE` | Exposed Credentials Check / Zone Security Level | 2026-04-24 |
+| Custom IP block / allowlists | `EQUIVALENT` | cloudflare_list (ip kind) + custom firewall rule | 2026-04-24 |
+
+- **AWS WAF IP reputation list (managed)** — Cloudflare does not expose IP reputation via Ruleset Engine. Use Security Level (zone setting) plus custom IP Lists seeded from a threat feed for comparable coverage.
+- **Custom IP block / allowlists** — Direct translation. The compiler emits cloudflare_list + ruleset rule referencing $<name>_ip_blocklist.
+
+## Logging
+
+| Feature | Status | Cloudflare surface | Last verified |
+| --- | --- | --- | --- |
+| AWS WAF logging destination (Kinesis / CloudWatch / S3) | `APPROXIMATE` | cloudflare_logpush_job (dataset: firewall_events) | 2026-04-24 |
+
+- **AWS WAF logging destination (Kinesis / CloudWatch / S3)** — Cloudflare Logpush streams firewall_events to S3/R2/GCS. Field names and event shape differ from AWS WAF logs — downstream log queries must be adapted.
+
+## Production CI gate
+
+```bash
+npx cdn-security build --target cloudflare --fail-on-waf-approximation
+```
+
+Exits non-zero when any `APPROXIMATE` or `UNSUPPORTED` entry is touched by the compiled policy. Use this gate in `main`-branch pipelines; keep the default (warn-only) for development branches.
+
+## Updating this document
+
+1. Edit `scripts/lib/cloudflare-waf-parity.js`.
+2. Bump `lastVerified` to today.
+3. Run `node scripts/generate-parity-doc.js --write` and `node scripts/generate-parity-doc.js --write --lang=ja`.
+4. Commit both the metadata change and the regenerated docs in the same PR.
+

--- a/docs/programmatic-api.ja.md
+++ b/docs/programmatic-api.ja.md
@@ -1,0 +1,169 @@
+# プログラマティック API
+
+> **Languages:** [English](./programmatic-api.md) · 日本語
+
+`cdn-security-framework` は Node.js から直接呼び出せる安定 API を公開しています。CI パイプライン・IaC ツール・独自ラッパーから CLI をシェル起動せずにコンパイラを駆動できます。CLI サブコマンドと同じ機能を提供しますが、`process.exit` を呼ばず構造化された結果を返します。
+
+```js
+const { compile, emitWaf, lintPolicy, migratePolicy, runDoctor } = require('cdn-security-framework');
+```
+
+## 存在理由
+
+1.2.0 より前は CLI 経由でしか統合できませんでした。CI は stderr を取り込み文字列一致で失敗分類し、終了コード 1 / 2 の違いを慣習で扱い、出力ファイル一覧を取得する安定手段もありませんでした。プログラマティック API はこれを以下に置き換えます。
+
+- 統一された `{ ok, errors, warnings, ... }` の形
+- 明示的な `edgeFiles` / `infraFiles` 配列（絶対パス）
+- `formatNotImplemented` / `reservedExit2` といった機械可読フラグ（stderr 文字列一致に依存しない）
+- `process.exit` を呼ばないためプロセス全体への副作用なし
+
+CLI（`bin/cli.js`）もこれらの関数に委譲しています。CLI で再現するバグは API でも再現し、逆もまた然りです。
+
+## スコープ
+
+`compile()` と `emitWaf()` は現状 `spawnSync` で既存のコンパイラスクリプトをサブプロセスとして呼び出します。API の契約（入出力・エラー意味論）は安定しており、サブプロセス境界は実装詳細です。issue #69 で in-process 化しますが、表面は変えません。`lintPolicy()` と `migratePolicy()` は最初から完全 in-process です。
+
+## リファレンス
+
+### `compile(opts)`
+
+ポリシーを検証し、エッジランタイムコード + インフラ設定を生成します。
+
+**入力**
+
+| フィールド | 型 | 備考 |
+| --- | --- | --- |
+| `policyPath` | `string` | 必須。絶対または `cwd` からの相対。 |
+| `outDir` | `string` | 必須。絶対または `cwd` からの相対。 |
+| `target` | `'aws' \| 'cloudflare'` | デフォルト `'aws'`。 |
+| `outputMode` | `'full' \| 'rule-group'` | AWS のみ。デフォルト `'full'`。 |
+| `ruleGroupOnly` | `boolean` | AWS のみ。`aws_wafv2_web_acl` を出さず rule group のみ。 |
+| `failOnPermissive` | `boolean` | `metadata.risk_level === 'permissive'` を失敗扱い。 |
+| `cwd` | `string` | デフォルト `process.cwd()`。 |
+| `pkgRoot` | `string` | インストール済みパッケージルート。 |
+| `env` | `NodeJS.ProcessEnv` | デフォルト `process.env`。 |
+
+**出力**
+
+```ts
+interface CompileResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  edgeFiles: string[];   // 絶対パス
+  infraFiles: string[];  // 絶対パス
+  policyPath: string;    // 解決済み
+  outDir: string;        // 解決済み
+  target: 'aws' | 'cloudflare';
+}
+```
+
+**例**
+
+```js
+const { compile } = require('cdn-security-framework');
+
+const result = compile({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+});
+
+if (!result.ok) {
+  for (const err of result.errors) console.error(err);
+  process.exit(1);
+}
+
+for (const warn of result.warnings) console.warn(warn);
+for (const file of result.edgeFiles) console.log('edge:', file);
+for (const file of result.infraFiles) console.log('infra:', file);
+```
+
+### `emitWaf(opts)`
+
+インフラ/WAF 設定のみを生成します。`edgeFiles` は常に `[]`。
+
+`compile` と同じ入力に加えて `format: 'terraform' | 'cloudformation' | 'cdk'`（デフォルト `'terraform'`）。
+
+現状 `terraform` のみ生成します。`cloudformation` と `cdk` は `{ ok: false, formatNotImplemented: true, errors: [...] }` を返します。CLI は `formatNotImplemented: true` を終了コード 2 に翻訳するので、パイプラインは「未実装」と「実装が失敗」を区別できます。
+
+```js
+const { emitWaf } = require('cdn-security-framework');
+
+const result = emitWaf({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+  format: 'terraform',
+});
+```
+
+### `lintPolicy(opts)`
+
+完全 in-process のポリシー検証（スキーマ、パスパターン、auth gate、WAF 健全性、env 参照）。
+
+**入力**
+
+| フィールド | 型 | 備考 |
+| --- | --- | --- |
+| `policyPath` | `string` | 必須。 |
+| `pkgRoot` | `string` | スキーマ/プロファイル解決用ルート。 |
+| `env` | `NodeJS.ProcessEnv` | ポリシーが参照する env 変数確認用。 |
+
+**出力**
+
+```ts
+interface LintResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  policy: unknown;  // ok === true のとき YAML パース結果
+}
+```
+
+### `migratePolicy(opts)`
+
+ポリシーをスキーマバージョン間で移行します。現状 v1 のみリリース済みなので、v1 → v1 は no-op（`{ ok: true, noop: true }`）。
+
+**出力**
+
+```ts
+interface MigrateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  fromVersion?: number | string;
+  toVersion?: number | string;
+  migrated?: unknown;
+  noop?: boolean;
+  reservedExit2?: boolean;  // CLI は終了コード 2 に翻訳
+}
+```
+
+### `runDoctor(opts)`
+
+環境診断を実行します。`{ exitCode: number, report: {...} }` を返します。この API 表面より前から存在するので、そのまま再エクスポートしています。
+
+## エラー意味論
+
+API は `process.exit` を呼びません。全ての失敗は `{ ok: false, errors: [...] }` として表面化します。プロセス終了コードへの翻訳は CLI レイヤだけが行います。
+
+| ケース | CLI 終了コード | API フラグ |
+| --- | --- | --- |
+| 成功 | `0` | `ok: true` |
+| 一般的な失敗 | `1` | `ok: false` |
+| 予約/未実装（例: `emit-waf --format cdk`） | `2` | `formatNotImplemented: true` または `reservedExit2: true` |
+
+独自ラッパーを書くときは stderr をパースせず、構造化フラグを参照してください。
+
+## 後方互換性
+
+- `bin/cli.js` のサブコマンド・オプション・終了コードは従来どおり。
+- stderr メッセージは既存の大文字/ハイフンを保持（`Unknown --format:`, `Unknown target:`）。grep しているスクリプトはそのまま動きます。
+- `process.exit` を呼ぶのは CLI のみ。
+
+## 関連ドキュメント
+
+- [CLI リファレンス](./cli.ja.md)
+- [スキーマ移行](./schema-migration.ja.md)
+- [ROADMAP](./ROADMAP.ja.md) の #69（in-process 化）

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -1,0 +1,169 @@
+# Programmatic API
+
+> **Languages:** English · [日本語](./programmatic-api.ja.md)
+
+`cdn-security-framework` exposes a stable Node.js API so CI pipelines, IaC tools, and custom wrappers can drive the compiler without shelling out to the CLI. The API mirrors the CLI subcommands but returns structured results instead of calling `process.exit`.
+
+```js
+const { compile, emitWaf, lintPolicy, migratePolicy, runDoctor } = require('cdn-security-framework');
+```
+
+## Why this exists
+
+Before 1.2.0, the only integration path was the CLI. CI systems had to capture stderr to classify failures, parse exit codes (1 vs 2) by convention, and had no stable way to enumerate emitted files. The programmatic API replaces that with:
+
+- Uniform `{ ok, errors, warnings, ... }` shape
+- Explicit `edgeFiles` / `infraFiles` arrays (absolute paths)
+- Machine-readable flags (e.g. `formatNotImplemented`, `reservedExit2`) instead of string-matching stderr
+- No process-wide side effects — never calls `process.exit`
+
+The CLI (`bin/cli.js`) now delegates to these same functions. If a bug shows up in the CLI, the API sees it too — and vice versa.
+
+## Scope note
+
+`compile()` and `emitWaf()` currently invoke the existing compiler scripts in a subprocess via `spawnSync`. The API contract (inputs, outputs, error semantics) is stable; the subprocess boundary is an implementation detail that will move in-process under issue #69 without changing the surface. `lintPolicy()` and `migratePolicy()` already run fully in-process.
+
+## Reference
+
+### `compile(opts)`
+
+Validate a policy, compile edge runtime code, and emit infra config.
+
+**Input**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `policyPath` | `string` | Required. Absolute or relative to `cwd`. |
+| `outDir` | `string` | Required. Absolute or relative to `cwd`. |
+| `target` | `'aws' \| 'cloudflare'` | Defaults to `'aws'`. |
+| `outputMode` | `'full' \| 'rule-group'` | AWS only. Defaults to `'full'`. |
+| `ruleGroupOnly` | `boolean` | AWS only. Emit rule groups without `aws_wafv2_web_acl`. |
+| `failOnPermissive` | `boolean` | Non-zero-equivalent when `metadata.risk_level === 'permissive'`. |
+| `cwd` | `string` | Defaults to `process.cwd()`. |
+| `pkgRoot` | `string` | Defaults to the installed package root. |
+| `env` | `NodeJS.ProcessEnv` | Defaults to `process.env`. |
+
+**Output**
+
+```ts
+interface CompileResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  edgeFiles: string[];   // absolute paths
+  infraFiles: string[];  // absolute paths
+  policyPath: string;    // resolved
+  outDir: string;        // resolved
+  target: 'aws' | 'cloudflare';
+}
+```
+
+**Example**
+
+```js
+const { compile } = require('cdn-security-framework');
+
+const result = compile({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+});
+
+if (!result.ok) {
+  for (const err of result.errors) console.error(err);
+  process.exit(1);
+}
+
+for (const warn of result.warnings) console.warn(warn);
+for (const file of result.edgeFiles) console.log('edge:', file);
+for (const file of result.infraFiles) console.log('infra:', file);
+```
+
+### `emitWaf(opts)`
+
+Emit only the infra/WAF config. `edgeFiles` is always `[]`.
+
+Same input shape as `compile` plus `format: 'terraform' | 'cloudformation' | 'cdk'` (defaults to `'terraform'`).
+
+Only `terraform` is generated today. `cloudformation` and `cdk` return `{ ok: false, formatNotImplemented: true, errors: [...] }`. The CLI translates `formatNotImplemented: true` to exit code 2 so pipelines can distinguish "not implemented" from "implementation failed".
+
+```js
+const { emitWaf } = require('cdn-security-framework');
+
+const result = emitWaf({
+  policyPath: 'policy/security.yml',
+  outDir: 'dist',
+  target: 'aws',
+  format: 'terraform',
+});
+```
+
+### `lintPolicy(opts)`
+
+Fully in-process policy validation (schema, path patterns, auth gates, WAF hygiene, env references).
+
+**Input**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `policyPath` | `string` | Required. |
+| `pkgRoot` | `string` | Schema/profiles resolution root. |
+| `env` | `NodeJS.ProcessEnv` | For env-var referenced by policy. |
+
+**Output**
+
+```ts
+interface LintResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  policy: unknown;  // parsed YAML when ok === true
+}
+```
+
+### `migratePolicy(opts)`
+
+Migrate a policy file between schema versions. v1 is the only shipped version today; a v1 → v1 call is a no-op with `{ ok: true, noop: true }`.
+
+**Output**
+
+```ts
+interface MigrateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  fromVersion?: number | string;
+  toVersion?: number | string;
+  migrated?: unknown;
+  noop?: boolean;
+  reservedExit2?: boolean;  // CLI translates to exit 2
+}
+```
+
+### `runDoctor(opts)`
+
+Run environment diagnostics. Returns `{ exitCode: number, report: {...} }`. Unlike the other functions, `runDoctor` already pre-dates this surface and is re-exported unchanged.
+
+## Error semantics
+
+The API never calls `process.exit`. All failure modes surface as `{ ok: false, errors: [...] }`. The CLI layer is the only caller that translates to process exit codes:
+
+| Case | CLI exit | API flag |
+| --- | --- | --- |
+| Success | `0` | `ok: true` |
+| Generic failure | `1` | `ok: false` |
+| Reserved / not-implemented (e.g. `emit-waf --format cdk`) | `2` | `formatNotImplemented: true` or `reservedExit2: true` |
+
+When building your own wrapper, prefer inspecting the structured flags rather than parsing stderr.
+
+## Backwards compatibility
+
+- `bin/cli.js` still uses the same subcommands, options, and exit codes as before.
+- Stderr messages preserve existing capitalization (`Unknown --format:`, `Unknown target:`) so scripts grepping for them continue to work.
+- The CLI is the only place `process.exit` is called.
+
+## See also
+
+- [CLI reference](./cli.md)
+- [Schema migration](./schema-migration.md)
+- Roadmap item #69 (in-process compile) in [ROADMAP.md](./ROADMAP.md)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,203 @@
+/**
+ * Programmatic API: compile
+ *
+ * Build edge runtime + infra config from a policy file. Stable public
+ * contract. Internally delegates to the existing compiler scripts via
+ * spawnSync (see note in lib/index.js); that will be replaced by in-process
+ * module boundaries in #69 without changing this surface.
+ *
+ * Input:
+ *   {
+ *     policyPath:       string,     // required, absolute or relative to cwd
+ *     outDir:           string,     // required, absolute or relative to cwd
+ *     target:           'aws' | 'cloudflare',
+ *     failOnPermissive?: boolean,
+ *     outputMode?:      'full' | 'rule-group',   // AWS only
+ *     ruleGroupOnly?:   boolean,                  // AWS only
+ *     cwd?:             string,     // defaults to process.cwd()
+ *     pkgRoot?:         string,     // defaults to installed package root
+ *     env?:             NodeJS.ProcessEnv,
+ *   }
+ *
+ * Output:
+ *   {
+ *     ok:         boolean,
+ *     errors:     string[],
+ *     warnings:   string[],
+ *     edgeFiles:  string[],    // absolute paths to emitted edge code
+ *     infraFiles: string[],    // absolute paths to emitted infra config
+ *     policyPath: string,      // resolved policy path
+ *     outDir:     string,      // resolved output dir
+ *     target:     string,
+ *   }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { lintPolicy } = require('./lint');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+const AWS_EDGE_FILES = ['viewer-request.js', 'viewer-response.js', 'origin-request.js'];
+const CF_EDGE_FILES = [path.join('cloudflare', 'index.ts')];
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function listInfraArtifacts(outDir) {
+  const infraDir = path.join(outDir, 'infra');
+  if (!fs.existsSync(infraDir)) return [];
+  return fs
+    .readdirSync(infraDir)
+    .filter((name) => name.endsWith('.tf.json'))
+    .map((name) => path.join(infraDir, name));
+}
+
+function compile(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const env = opts.env || process.env;
+
+  const errors = [];
+  const warnings = [];
+  const baseResult = {
+    edgeFiles: [],
+    infraFiles: [],
+    policyPath: null,
+    outDir: null,
+    target: opts.target || 'aws',
+  };
+
+  if (!opts.policyPath) {
+    return { ok: false, errors: ['policyPath is required'], warnings, ...baseResult };
+  }
+  if (!opts.outDir) {
+    return { ok: false, errors: ['outDir is required'], warnings, ...baseResult };
+  }
+  const target = opts.target || 'aws';
+  if (target !== 'aws' && target !== 'cloudflare') {
+    return {
+      ok: false,
+      errors: [`Unknown target: ${target} (expected aws | cloudflare)`],
+      warnings,
+      ...baseResult,
+      target,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  const outDir = resolveAbsolute(opts.outDir, cwd);
+  baseResult.policyPath = policyPath;
+  baseResult.outDir = outDir;
+  baseResult.target = target;
+
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      ...baseResult,
+    };
+  }
+
+  // Step 1: lint (in-process — fast, deterministic).
+  const lint = lintPolicy({ policyPath, pkgRoot, env });
+  warnings.push(...lint.warnings);
+  if (!lint.ok) {
+    errors.push(...lint.errors);
+    return { ok: false, errors, warnings, ...baseResult };
+  }
+
+  const permissiveFlag = opts.failOnPermissive ? ['--fail-on-permissive'] : [];
+
+  // Step 2: edge compile.
+  if (target === 'aws') {
+    const compilePath = path.join(pkgRoot, 'scripts', 'compile.js');
+    const compileResult = spawnSync(
+      process.execPath,
+      [
+        compilePath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...permissiveFlag,
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (compileResult.status !== 0) {
+      errors.push(`edge compile failed (status ${compileResult.status})`);
+      if (compileResult.stderr) errors.push(compileResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (compileResult.stderr) {
+      warnings.push(...compileResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.edgeFiles = AWS_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
+
+    const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
+    const infraResult = spawnSync(
+      process.execPath,
+      [
+        infraPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        '--output-mode', opts.outputMode || 'full',
+        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (infraResult.status !== 0) {
+      errors.push(`infra compile failed (status ${infraResult.status})`);
+      if (infraResult.stderr) errors.push(infraResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (infraResult.stderr) {
+      warnings.push(...infraResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  } else {
+    const compileCfPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare.js');
+    const cfResult = spawnSync(
+      process.execPath,
+      [
+        compileCfPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...permissiveFlag,
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (cfResult.status !== 0) {
+      errors.push(`cloudflare edge compile failed (status ${cfResult.status})`);
+      if (cfResult.stderr) errors.push(cfResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (cfResult.stderr) {
+      warnings.push(...cfResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.edgeFiles = CF_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
+
+    const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
+    const cfWafResult = spawnSync(
+      process.execPath,
+      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (cfWafResult.status !== 0) {
+      errors.push(`cloudflare waf compile failed (status ${cfWafResult.status})`);
+      if (cfWafResult.stderr) errors.push(cfWafResult.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (cfWafResult.stderr) {
+      warnings.push(...cfWafResult.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  }
+
+  return { ok: true, errors, warnings, ...baseResult };
+}
+
+module.exports = { compile };

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -12,6 +12,7 @@
  *     outDir:           string,     // required, absolute or relative to cwd
  *     target:           'aws' | 'cloudflare',
  *     failOnPermissive?: boolean,
+ *     failOnWafApproximation?: boolean,           // Cloudflare only
  *     outputMode?:      'full' | 'rule-group',   // AWS only
  *     ruleGroupOnly?:   boolean,                  // AWS only
  *     cwd?:             string,     // defaults to process.cwd()
@@ -183,7 +184,12 @@ function compile(opts) {
     const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
     const cfWafResult = spawnSync(
       process.execPath,
-      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      [
+        cfWafPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...(opts.failOnWafApproximation ? ['--fail-on-waf-approximation'] : []),
+      ],
       { cwd, encoding: 'utf8', env },
     );
     if (cfWafResult.status !== 0) {

--- a/lib/emit-waf.js
+++ b/lib/emit-waf.js
@@ -1,0 +1,166 @@
+/**
+ * Programmatic API: emitWaf
+ *
+ * Generate only the WAF/infra config — no edge code. Mirrors the CLI
+ * `emit-waf` subcommand and keeps the same flag surface.
+ *
+ * Input:
+ *   {
+ *     policyPath:     string,
+ *     outDir:         string,
+ *     target:         'aws' | 'cloudflare',
+ *     format?:        'terraform' | 'cloudformation' | 'cdk',
+ *     outputMode?:    'full' | 'rule-group',
+ *     ruleGroupOnly?: boolean,
+ *     cwd?:           string,
+ *     pkgRoot?:       string,
+ *     env?:           NodeJS.ProcessEnv,
+ *   }
+ *
+ * Output: same shape as compile() but edgeFiles is always [].
+ *
+ * Error semantics for unimplemented formats: cloudformation and cdk return
+ * { ok: false } with `errors` explaining the format is not implemented. The
+ * CLI layer translates this to exit code 2 (see bin/cli.js).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { lintPolicy } = require('./lint');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function listInfraArtifacts(outDir) {
+  const infraDir = path.join(outDir, 'infra');
+  if (!fs.existsSync(infraDir)) return [];
+  return fs
+    .readdirSync(infraDir)
+    .filter((name) => name.endsWith('.tf.json'))
+    .map((name) => path.join(infraDir, name));
+}
+
+function emitWaf(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const env = opts.env || process.env;
+  const format = opts.format || 'terraform';
+  const target = opts.target || 'aws';
+
+  const errors = [];
+  const warnings = [];
+  const baseResult = {
+    edgeFiles: [],
+    infraFiles: [],
+    policyPath: null,
+    outDir: null,
+    target,
+    format,
+    formatNotImplemented: false,
+  };
+
+  if (!opts.policyPath) {
+    return { ok: false, errors: ['policyPath is required'], warnings, ...baseResult };
+  }
+  if (!opts.outDir) {
+    return { ok: false, errors: ['outDir is required'], warnings, ...baseResult };
+  }
+  if (target !== 'aws' && target !== 'cloudflare') {
+    return {
+      ok: false,
+      errors: [`Unknown target: ${target} (expected aws | cloudflare)`],
+      warnings,
+      ...baseResult,
+    };
+  }
+  if (!['terraform', 'cloudformation', 'cdk'].includes(format)) {
+    return {
+      ok: false,
+      errors: [`Unknown --format: ${format} (expected terraform | cloudformation | cdk)`],
+      warnings,
+      ...baseResult,
+    };
+  }
+  if (format !== 'terraform') {
+    return {
+      ok: false,
+      errors: [
+        `--format ${format} is not yet implemented. Only terraform is generated today; cloudformation and cdk are reserved and intentionally fail loudly to prevent silent fallback.`,
+      ],
+      warnings,
+      ...baseResult,
+      formatNotImplemented: true,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  const outDir = resolveAbsolute(opts.outDir, cwd);
+  baseResult.policyPath = policyPath;
+  baseResult.outDir = outDir;
+
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      ...baseResult,
+    };
+  }
+
+  const lint = lintPolicy({ policyPath, pkgRoot, env });
+  warnings.push(...lint.warnings);
+  if (!lint.ok) {
+    errors.push(...lint.errors);
+    return { ok: false, errors, warnings, ...baseResult };
+  }
+
+  if (target === 'aws') {
+    const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
+    const result = spawnSync(
+      process.execPath,
+      [
+        infraPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        '--output-mode', opts.outputMode || 'full',
+        ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
+      ],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (result.status !== 0) {
+      errors.push(`infra compile failed (status ${result.status})`);
+      if (result.stderr) errors.push(result.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (result.stderr) {
+      warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  } else {
+    const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
+    const result = spawnSync(
+      process.execPath,
+      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      { cwd, encoding: 'utf8', env },
+    );
+    if (result.status !== 0) {
+      errors.push(`cloudflare waf compile failed (status ${result.status})`);
+      if (result.stderr) errors.push(result.stderr.trim());
+      return { ok: false, errors, warnings, ...baseResult };
+    }
+    if (result.stderr) {
+      warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+    }
+    baseResult.infraFiles = listInfraArtifacts(outDir);
+  }
+
+  return { ok: true, errors, warnings, ...baseResult };
+}
+
+module.exports = { emitWaf };

--- a/lib/emit-waf.js
+++ b/lib/emit-waf.js
@@ -12,6 +12,7 @@
  *     format?:        'terraform' | 'cloudformation' | 'cdk',
  *     outputMode?:    'full' | 'rule-group',
  *     ruleGroupOnly?: boolean,
+ *     failOnWafApproximation?: boolean,  // cloudflare only
  *     cwd?:           string,
  *     pkgRoot?:       string,
  *     env?:           NodeJS.ProcessEnv,
@@ -146,7 +147,12 @@ function emitWaf(opts) {
     const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
     const result = spawnSync(
       process.execPath,
-      [cfWafPath, '--policy', policyPath, '--out-dir', outDir],
+      [
+        cfWafPath,
+        '--policy', policyPath,
+        '--out-dir', outDir,
+        ...(opts.failOnWafApproximation ? ['--fail-on-waf-approximation'] : []),
+      ],
       { cwd, encoding: 'utf8', env },
     );
     if (result.status !== 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,38 @@
+/**
+ * cdn-security-framework — Programmatic API
+ *
+ * Stable Node.js entry point for embedding the compiler in existing CI/CD
+ * pipelines (Terraform wrappers, CDK app synth hooks, custom policy servers,
+ * etc.) without shelling out to the CLI.
+ *
+ * Every exported function returns a structured result object. **None of them
+ * call process.exit** — callers decide exit behaviour.
+ *
+ * Result contract (all functions):
+ *   {
+ *     ok:       boolean,        // true iff zero errors
+ *     errors:   string[],       // human-readable error lines
+ *     warnings: string[],       // non-fatal advisories
+ *     ...cmdSpecific,           // per-function extra fields (see each docstring)
+ *   }
+ *
+ * Scope note: v1 of this API provides a stable contract. compile() and
+ * emitWaf() currently delegate to subprocesses internally; that is an
+ * implementation detail and will be replaced by in-process module boundaries
+ * in #69 (module split) without changing the public shape.
+ */
+
+const { lintPolicy } = require('./lint');
+const { compile } = require('./compile');
+const { emitWaf } = require('./emit-waf');
+const { migratePolicy } = require('./migrate');
+
+const { runDoctor } = require('../scripts/cli-doctor');
+
+module.exports = {
+  lintPolicy,
+  compile,
+  emitWaf,
+  runDoctor,
+  migratePolicy,
+};

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,0 +1,183 @@
+/**
+ * Programmatic API: lintPolicy
+ *
+ * In-process equivalent of `scripts/policy-lint.js`. Returns a structured
+ * result instead of calling process.exit. Stable public surface — the
+ * underlying ajv / validateAuthGates / parsePathPatterns plumbing may change,
+ * but the return shape is stable.
+ *
+ * Input:
+ *   { policyPath: string, pkgRoot?: string }
+ *   pkgRoot defaults to the installed package root (where schema.json lives).
+ *
+ * Output:
+ *   { ok, errors[], warnings[], policy }
+ *   - `policy` is the parsed YAML object (null if parse failed).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const Ajv = require('ajv');
+
+const {
+  validateAuthGates,
+  parsePathPatterns,
+} = require('../scripts/lib/compile-core');
+
+const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+
+function formatAjvErrors(errors) {
+  return errors.map((err) => {
+    const loc = err.instancePath || '(root)';
+    const key =
+      err.params && err.params.additionalProperty
+        ? ` (property "${err.params.additionalProperty}")`
+        : '';
+    return `  - ${loc} ${err.message}${key}`;
+  });
+}
+
+function lintPolicy(opts) {
+  opts = opts || {};
+  const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
+  const policyPath = opts.policyPath;
+  const env = opts.env || process.env;
+
+  const errors = [];
+  const warnings = [];
+
+  if (!policyPath) {
+    return {
+      ok: false,
+      errors: ['policyPath is required'],
+      warnings: [],
+      policy: null,
+    };
+  }
+
+  let policy = null;
+  try {
+    policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return {
+        ok: false,
+        errors: [`policy file not found: ${policyPath}`],
+        warnings: [],
+        policy: null,
+      };
+    }
+    return {
+      ok: false,
+      errors: [`failed to parse policy YAML: ${e.message}`],
+      warnings: [],
+      policy: null,
+    };
+  }
+
+  let schema;
+  try {
+    schema = JSON.parse(
+      fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'),
+    );
+  } catch (e) {
+    return {
+      ok: false,
+      errors: [`failed to load schema: ${e.message}`],
+      warnings: [],
+      policy,
+    };
+  }
+
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: true,
+    strictRequired: false,
+    allowUnionTypes: true,
+  });
+  const validate = ajv.compile(schema);
+  if (!validate(policy)) {
+    errors.push('Schema validation failed:');
+    errors.push(...formatAjvErrors(validate.errors || []));
+  }
+
+  try {
+    const block = (policy && policy.request && policy.request.block) || {};
+    if (block.path_patterns !== undefined) {
+      parsePathPatterns(block.path_patterns);
+    }
+  } catch (e) {
+    errors.push(`  - request.block.path_patterns: ${e.message}`);
+  }
+
+  try {
+    validateAuthGates(policy, {
+      exitOnError: false,
+      allowPlaceholderToken: true,
+    });
+  } catch (e) {
+    if (Array.isArray(e.validationErrors)) {
+      errors.push('Auth gate validation failed:');
+      e.validationErrors.forEach((msg) => errors.push('  - ' + msg));
+    } else {
+      errors.push('Auth gate validation error: ' + e.message);
+    }
+  }
+
+  const waf = (policy && policy.firewall && policy.firewall.waf) || {};
+  if (
+    waf.fingerprint_action &&
+    !['block', 'count'].includes(waf.fingerprint_action)
+  ) {
+    errors.push(
+      '  - firewall.waf.fingerprint_action must be "block" or "count"',
+    );
+  }
+
+  const mode = (policy && policy.defaults && policy.defaults.mode) || null;
+  const isEnforce = mode === 'enforce';
+  const hasWaf = policy && policy.firewall && policy.firewall.waf;
+  if (isEnforce && hasWaf) {
+    const managed = Array.isArray(waf.managed_rules) ? waf.managed_rules : [];
+    const hasCoreSignal = managed.some(
+      (r) =>
+        r === 'AWSManagedRulesBotControlRuleSet' ||
+        r === 'AWSManagedRulesATPRuleSet' ||
+        r === 'AWSManagedRulesIPReputationList' ||
+        r === 'AWSManagedRulesAnonymousIpList',
+    );
+    if (!hasCoreSignal) {
+      warnings.push(
+        'firewall.waf.managed_rules does not include any of BotControl / ATP / IPReputation / AnonymousIp. Consider adding at least IPReputation + AnonymousIp for production enforce mode.',
+      );
+    }
+    const loggingEnabled = waf.logging && waf.logging.enabled === true;
+    if (waf.scope === 'CLOUDFRONT' && !loggingEnabled) {
+      warnings.push(
+        'firewall.waf.logging is not enabled while scope=CLOUDFRONT. PCI-DSS / SOC2 require WAF log retention — set logging.enabled: true and supply destination_arn_env.',
+      );
+    }
+  }
+
+  const originAuth = policy && policy.origin && policy.origin.auth;
+  if (originAuth && originAuth.type === 'custom_header' && originAuth.secret_env) {
+    const envVal = env[originAuth.secret_env];
+    if (envVal !== undefined && envVal.length === 0) {
+      warnings.push(
+        'origin.auth.secret_env "' +
+          originAuth.secret_env +
+          '" is set but empty in the current shell. The edge will refuse to forward the origin-auth header, breaking origin trust. Unset the env or supply a value.',
+      );
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    policy,
+  };
+}
+
+module.exports = { lintPolicy };

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,0 +1,153 @@
+/**
+ * Programmatic API: migratePolicy
+ *
+ * v1 is the only shipped schema, so this is a no-op for v1 → v1. Reports
+ * structured errors for unknown targets, missing versions, and unregistered
+ * migration paths. The CLI `migrate` subcommand translates this into exit
+ * codes 0/1/2.
+ *
+ * Input:
+ *   {
+ *     policyPath: string,
+ *     toVersion?: number | string,   // default: 1
+ *     cwd?:       string,
+ *   }
+ *
+ * Output:
+ *   {
+ *     ok:          boolean,
+ *     errors:      string[],
+ *     warnings:    string[],
+ *     fromVersion: number | undefined,
+ *     toVersion:   number,
+ *     migrated:    boolean,           // true iff a migration actually ran
+ *     noop:        boolean,           // true iff already at target
+ *     reservedExit2?: boolean,        // true for "no migration path registered" — CLI exits 2
+ *   }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function resolveAbsolute(inputPath, cwd) {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
+}
+
+function migratePolicy(opts) {
+  opts = opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const toVersionRaw = opts.toVersion === undefined ? 1 : opts.toVersion;
+  const toVersion = Number(toVersionRaw);
+
+  const warnings = [];
+
+  if (!opts.policyPath) {
+    return {
+      ok: false,
+      errors: ['policyPath is required'],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  const policyPath = resolveAbsolute(opts.policyPath, cwd);
+  if (!fs.existsSync(policyPath)) {
+    return {
+      ok: false,
+      errors: [`policy file not found: ${policyPath}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  if (Number.isNaN(toVersion)) {
+    return {
+      ok: false,
+      errors: [`toVersion must be a number. Got: ${toVersionRaw}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion: NaN,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  let doc;
+  try {
+    doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+  } catch (e) {
+    return {
+      ok: false,
+      errors: [`failed to parse policy YAML: ${e.message}`],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  const fromVersion = doc && doc.version;
+
+  if (fromVersion === undefined) {
+    return {
+      ok: false,
+      errors: ['Policy has no `version` field. Add `version: 1` and retry.'],
+      warnings,
+      fromVersion: undefined,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  if (fromVersion === toVersion) {
+    return {
+      ok: true,
+      errors: [],
+      warnings,
+      fromVersion,
+      toVersion,
+      migrated: false,
+      noop: true,
+    };
+  }
+
+  if (toVersion < fromVersion) {
+    return {
+      ok: false,
+      errors: ['Downgrade migrations are not supported.'],
+      warnings,
+      fromVersion,
+      toVersion,
+      migrated: false,
+      noop: false,
+    };
+  }
+
+  // Forward migrations are registered here when a new schema version ships.
+  // Contract: each step is a pure function (v_n policy) -> (v_n+1 policy).
+  // v1 is currently the only shipped schema, so there is nothing to run.
+  return {
+    ok: false,
+    errors: [
+      `No migration path from v${fromVersion} to v${toVersion} is registered in this CLI version.`,
+      'See docs/schema-migration.md for the migration policy and supported versions.',
+    ],
+    warnings,
+    fromVersion,
+    toVersion,
+    migrated: false,
+    noop: false,
+    reservedExit2: true,
+  };
+}
+
+module.exports = { migratePolicy };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "node scripts/compile.js",
     "lint:policy": "node scripts/policy-lint.js",
     "test:runtime": "node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
-    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js",
+    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js",
     "test:drift": "node scripts/check-drift.js",
     "test:security-baseline": "node scripts/security-baseline-check.js",
     "test:fuzz": "node scripts/regex-fuzz-tests.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cdn-security-framework",
   "version": "1.1.0",
   "description": "Policy-driven CDN edge security. Init YAML with npx cdn-security init, then npx cdn-security build to generate runtime code.",
+  "main": "lib/index.js",
   "bin": {
     "cdn-security": "bin/cli.js"
   },
@@ -9,12 +10,12 @@
     "build": "node scripts/compile.js",
     "lint:policy": "node scripts/policy-lint.js",
     "test:runtime": "node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
-    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js",
+    "test:unit": "node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js",
     "test:drift": "node scripts/check-drift.js",
     "test:security-baseline": "node scripts/security-baseline-check.js",
     "test:fuzz": "node scripts/regex-fuzz-tests.js",
     "test:cloudflare-integration": "node scripts/cloudflare-integration-tests.js",
-    "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
+    "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
     "test:all": "npm run build && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration",
     "fingerprints:candidates": "node scripts/fingerprint-candidates.js"
   },
@@ -38,6 +39,7 @@
   },
   "files": [
     "bin/",
+    "lib/",
     "scripts/",
     "templates/",
     "policy/profiles/",

--- a/scripts/check-drift.js
+++ b/scripts/check-drift.js
@@ -121,6 +121,30 @@ function compareScenario(scenario) {
   return !failed;
 }
 
+function checkParityDocsFresh() {
+  const { renderEn, renderJa } = require('./generate-parity-doc');
+  const targets = [
+    { label: 'docs/cloudflare-waf-parity.md', path: path.join(repoRoot, 'docs', 'cloudflare-waf-parity.md'), actual: renderEn() },
+    { label: 'docs/cloudflare-waf-parity.ja.md', path: path.join(repoRoot, 'docs', 'cloudflare-waf-parity.ja.md'), actual: renderJa() },
+  ];
+  let ok = true;
+  for (const t of targets) {
+    if (!fs.existsSync(t.path)) {
+      console.error(`[parity-doc] MISSING: ${t.label}. Run: node scripts/generate-parity-doc.js --write${t.label.endsWith('.ja.md') ? ' --lang=ja' : ''}`);
+      ok = false;
+      continue;
+    }
+    const committed = fs.readFileSync(t.path, 'utf8');
+    if (committed !== t.actual) {
+      console.error(`[parity-doc] DRIFT: ${t.label} is out of sync with scripts/lib/cloudflare-waf-parity.js. Run: node scripts/generate-parity-doc.js --write${t.label.endsWith('.ja.md') ? ' --lang=ja' : ''}`);
+      ok = false;
+    } else {
+      console.log(`[parity-doc] OK (no drift): ${t.label}`);
+    }
+  }
+  return ok;
+}
+
 function main() {
   let allPassed = true;
 
@@ -129,12 +153,14 @@ function main() {
     if (!ok) allPassed = false;
   }
 
+  if (!checkParityDocsFresh()) allPassed = false;
+
   if (!allPassed) {
     console.error('Drift check failed. Regenerate golden fixtures if change is intentional.');
     process.exit(1);
   }
 
-  console.log('Drift check passed for base + all profiles.');
+  console.log('Drift check passed for base + all profiles + parity docs.');
 }
 
 main();

--- a/scripts/cloudflare-waf-parity-unit-tests.js
+++ b/scripts/cloudflare-waf-parity-unit-tests.js
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the Cloudflare WAF parity system (issue #68).
+ *
+ * Exercises:
+ *   - scripts/lib/cloudflare-waf-parity.js    — classification + warning format
+ *   - scripts/compile-cloudflare-waf.js       — stderr warnings, --fail-on-waf-approximation flag
+ *   - scripts/generate-parity-doc.js          — rendered doc is stable + contains expected keys
+ *   - drift: committed docs/ cloudflare-waf-parity.*.md matches generator output
+ *
+ * Kept self-contained (no Jest/Mocha) to match the existing test harness.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..');
+const parityLib = require(path.join(repoRoot, 'scripts', 'lib', 'cloudflare-waf-parity'));
+const generator = require(path.join(repoRoot, 'scripts', 'generate-parity-doc'));
+const compilerPath = path.join(repoRoot, 'scripts', 'compile-cloudflare-waf.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('OK:', name);
+  } catch (e) {
+    console.error('FAIL:', name);
+    console.error(e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  }
+}
+
+function tmpProject(policy) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-parity-'));
+  const policyPath = path.join(dir, 'policy.yml');
+  fs.writeFileSync(policyPath, policy, 'utf8');
+  return {
+    dir,
+    policyPath,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function runCompiler(policyPath, outDir, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [compilerPath, '--policy', policyPath, '--out-dir', outDir, ...extraArgs],
+    { encoding: 'utf8' },
+  );
+}
+
+// ---- classifyManagedRule ----
+
+test('classifyManagedRule: known rule returns the registered entry', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesCommonRuleSet');
+  assert.strictEqual(entry.status, 'equivalent');
+  assert.ok(entry.cloudflare.rulesetId);
+});
+
+test('classifyManagedRule: approximate rule keeps its rationale', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesSQLiRuleSet');
+  assert.strictEqual(entry.status, 'approximate');
+  assert.ok(/OWASP/i.test(entry.rationale));
+});
+
+test('classifyManagedRule: unsupported rule emits null rulesetId', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesATPRuleSet');
+  assert.strictEqual(entry.status, 'unsupported');
+  assert.strictEqual(entry.cloudflare.rulesetId, null);
+});
+
+test('classifyManagedRule: unknown rule degrades to unsupported', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesTotallyMadeUp');
+  assert.strictEqual(entry.status, 'unsupported');
+  assert.strictEqual(entry.cloudflare.rulesetId, null);
+  assert.ok(/no parity entry/i.test(entry.rationale));
+});
+
+test('formatManagedRuleWarning: equivalent returns null (no warning)', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesCommonRuleSet');
+  assert.strictEqual(parityLib.formatManagedRuleWarning(entry), null);
+});
+
+test('formatManagedRuleWarning: approximate includes rule name and rationale', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesSQLiRuleSet');
+  const msg = parityLib.formatManagedRuleWarning(entry);
+  assert.ok(/APPROXIMATE/.test(msg));
+  assert.ok(/AWSManagedRulesSQLiRuleSet/.test(msg));
+  assert.ok(/OWASP/i.test(msg));
+});
+
+test('formatManagedRuleWarning: unsupported flags enabled: false in message', () => {
+  const entry = parityLib.classifyManagedRule('AWSManagedRulesATPRuleSet');
+  const msg = parityLib.formatManagedRuleWarning(entry);
+  assert.ok(/UNSUPPORTED/.test(msg));
+  assert.ok(/enabled: false/.test(msg));
+});
+
+// ---- compiler stderr warnings ----
+
+const POLICY_EQUIVALENT = `
+version: 1
+project: parity-unit
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
+
+const POLICY_APPROXIMATE = `
+version: 1
+project: parity-unit
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesSQLiRuleSet
+`;
+
+const POLICY_UNSUPPORTED = `
+version: 1
+project: parity-unit
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesATPRuleSet
+`;
+
+const POLICY_SCOPE_DOWN_UNTRANSLATED = `
+version: 1
+project: parity-unit
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit_rules:
+      - name: exact-match
+        aggregate_key_type: IP
+        limit: 100
+        scope_down_statement:
+          byte_match_statement:
+            field_to_match: { uri_path: {} }
+            positional_constraint: EXACTLY
+            search_string: "/login"
+`;
+
+test('compiler: equivalent-only policy emits no parity warning', () => {
+  const ctx = tmpProject(POLICY_EQUIVALENT);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(!/APPROXIMATE|UNSUPPORTED/.test(r.stderr), `unexpected stderr: ${r.stderr}`);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: approximate rule emits APPROXIMATE stderr warning, exit 0 by default', () => {
+  const ctx = tmpProject(POLICY_APPROXIMATE);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(/APPROXIMATE/.test(r.stderr));
+    assert.ok(/AWSManagedRulesSQLiRuleSet/.test(r.stderr));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: --fail-on-waf-approximation exits non-zero on approximate', () => {
+  const ctx = tmpProject(POLICY_APPROXIMATE);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir, ['--fail-on-waf-approximation']);
+    assert.strictEqual(r.status, 1);
+    assert.ok(/--fail-on-waf-approximation/.test(r.stderr));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: --fail-on-waf-approximation exits non-zero on unsupported', () => {
+  const ctx = tmpProject(POLICY_UNSUPPORTED);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir, ['--fail-on-waf-approximation']);
+    assert.strictEqual(r.status, 1);
+    assert.ok(/UNSUPPORTED/.test(r.stderr));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: unknown AWS managed rule treated as unsupported (disabled, warned)', () => {
+  const policy = POLICY_UNSUPPORTED.replace('AWSManagedRulesATPRuleSet', 'AWSManagedRulesTotallyFake');
+  const ctx = tmpProject(policy);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(/UNSUPPORTED: AWSManagedRulesTotallyFake/.test(r.stderr));
+    const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+    const managed = tf.resource.cloudflare_ruleset['parity-unit_managed'];
+    const rule = managed.rules.find((r) => /Fake/.test(r.description));
+    assert.ok(rule, 'expected managed rule emitted');
+    assert.strictEqual(rule.enabled, false);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: untranslated scope_down emits parity warning and degrades expression', () => {
+  const ctx = tmpProject(POLICY_SCOPE_DOWN_UNTRANSLATED);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(/scope_down_statement/i.test(r.stderr));
+    assert.ok(/match-all/.test(r.stderr));
+    const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+    const rl = tf.resource.cloudflare_ruleset['parity-unit_ratelimit'];
+    const rule = rl.rules.find((r) => r.description === 'exact-match');
+    assert.strictEqual(rule.expression, 'true');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: expression_cloudflare override suppresses the scope_down warning', () => {
+  const policy = `${POLICY_SCOPE_DOWN_UNTRANSLATED}        expression_cloudflare: 'http.request.uri.path eq "/login"'
+`;
+  const ctx = tmpProject(policy);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(!/scope_down_statement.*match-all/.test(r.stderr), `unexpected warning: ${r.stderr}`);
+    const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+    const rl = tf.resource.cloudflare_ruleset['parity-unit_ratelimit'];
+    const rule = rl.rules.find((r) => r.description === 'exact-match');
+    assert.strictEqual(rule.expression, 'http.request.uri.path eq "/login"');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+// ---- generator ----
+
+test('generator: EN render includes every managed rule entry', () => {
+  const out = generator.renderEn();
+  for (const e of parityLib.MANAGED_RULES) {
+    assert.ok(out.includes(`\`${e.aws}\``), `missing ${e.aws} in EN doc`);
+  }
+  assert.ok(/--fail-on-waf-approximation/.test(out));
+});
+
+test('generator: JA render includes every managed rule entry', () => {
+  const out = generator.renderJa();
+  for (const e of parityLib.MANAGED_RULES) {
+    assert.ok(out.includes(`\`${e.aws}\``), `missing ${e.aws} in JA doc`);
+  }
+  assert.ok(/--fail-on-waf-approximation/.test(out));
+});
+
+test('generator: render is deterministic (stable across calls)', () => {
+  assert.strictEqual(generator.renderEn(), generator.renderEn());
+  assert.strictEqual(generator.renderJa(), generator.renderJa());
+});
+
+test('drift: committed docs/cloudflare-waf-parity.md matches generator output', () => {
+  const committed = fs.readFileSync(path.join(repoRoot, 'docs', 'cloudflare-waf-parity.md'), 'utf8');
+  assert.strictEqual(committed, generator.renderEn(), 'run `node scripts/generate-parity-doc.js --write` to regenerate');
+});
+
+test('drift: committed docs/cloudflare-waf-parity.ja.md matches generator output', () => {
+  const committed = fs.readFileSync(path.join(repoRoot, 'docs', 'cloudflare-waf-parity.ja.md'), 'utf8');
+  assert.strictEqual(committed, generator.renderJa(), 'run `node scripts/generate-parity-doc.js --write --lang=ja` to regenerate');
+});

--- a/scripts/compile-cloudflare-waf.js
+++ b/scripts/compile-cloudflare-waf.js
@@ -19,16 +19,31 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+const parity = require('./lib/cloudflare-waf-parity');
+
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
 const securityPath = path.join(repoRoot, 'policy', 'security.yml');
 const basePath = path.join(repoRoot, 'policy', 'base.yml');
 let policyPath = fs.existsSync(securityPath) ? securityPath : basePath;
 let outDir = path.join(repoRoot, 'dist');
+let failOnApproximation = false;
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === '--policy' && argv[i + 1]) { policyPath = argv[++i]; continue; }
   if (argv[i] === '--out-dir' && argv[i + 1]) { outDir = argv[++i]; continue; }
+  if (argv[i] === '--fail-on-waf-approximation') { failOnApproximation = true; continue; }
   if (!argv[i].startsWith('--')) { policyPath = argv[i]; }
+}
+
+// Parity warnings collected during emission — surfaced once at the end so
+// the order is stable (managed rules first, then scope-down notes).
+const parityWarnings = [];
+let sawApproximationOrUnsupported = false;
+function recordParity(entry) {
+  const msg = parity.formatManagedRuleWarning(entry);
+  if (!msg) return;
+  parityWarnings.push(msg);
+  sawApproximationOrUnsupported = true;
 }
 
 let policy;
@@ -227,13 +242,25 @@ if (Array.isArray(waf.rate_limit_rules)) {
     // `expression_cloudflare` to be set by the user. Unknown shapes degrade
     // to a `true` expression (global).
     let expression = 'true';
+    let translatedShape = null;
     const sd = rule.scope_down_statement || {};
     const bm = sd.byte_match_statement;
     if (bm && bm.field_to_match && bm.field_to_match.uri_path && bm.positional_constraint === 'STARTS_WITH' && typeof bm.search_string === 'string') {
       expression = `starts_with(http.request.uri.path, "${String(bm.search_string).replace(/"/g, '\\"')}")`;
+      translatedShape = 'byte_match_statement(uri_path, STARTS_WITH)';
     }
     if (typeof rule.expression_cloudflare === 'string' && rule.expression_cloudflare.trim()) {
       expression = rule.expression_cloudflare;
+      translatedShape = 'expression_cloudflare override';
+    }
+    // Warn if a scope_down_statement was declared but not auto-translated and
+    // no explicit expression_cloudflare override is present. This is the
+    // silent-match-all class of drift the parity policy exists to prevent.
+    if (Object.keys(sd).length > 0 && translatedShape === null) {
+      parityWarnings.push(
+        `[cloudflare-waf-parity] APPROXIMATE: rate_limit rule "${rule.name}" has scope_down_statement that this compiler does not auto-translate to a Cloudflare expression (shape: ${Object.keys(sd).join(', ')}). Rule degraded to expression: "true" (match-all). Set rule.expression_cloudflare on the policy to provide the exact scope. See docs/cloudflare-waf-parity.md#scope_down_statement-shapes.`,
+      );
+      sawApproximationOrUnsupported = true;
     }
     const characteristicsMap = {
       IP: ['ip.src'],
@@ -269,24 +296,23 @@ if (rateRules.length > 0) {
   };
 }
 
-// 4. Managed rulesets (OWASP-equivalents on Cloudflare)
-// managed_rules entries are AWS names; map the well-known ones to Cloudflare
-// managed ruleset IDs. Unknown names render as a commented placeholder so the
-// operator can map them explicitly.
-const AWS_TO_CF_MANAGED = {
-  AWSManagedRulesCommonRuleSet: 'efb7b8c949ac4650a09736fc376e9aee',    // Cloudflare Managed Ruleset
-  AWSManagedRulesKnownBadInputsRuleSet: '4814384a9e5d4991b9815dcfc25d2f1f', // Cloudflare OWASP Core Ruleset
-  AWSManagedRulesSQLiRuleSet: '4814384a9e5d4991b9815dcfc25d2f1f',      // OWASP (covers SQLi)
-  AWSManagedRulesIPReputationList: 'c2e184081120413c86c3ab7e14069605',  // Cloudflare Exposed Credentials Check Managed Ruleset (nearest semantic fit)
-};
+// 4. Managed rulesets — consult cloudflare-waf-parity.js for every AWS entry
+// so the compiler emits warnings for anything that is not `equivalent`. The
+// compiler never silently swaps an AWS ruleset for a semantically-different
+// Cloudflare one without surfacing the mismatch.
 const managedEntries = Array.isArray(waf.managed_rules) ? waf.managed_rules : [];
 if (managedEntries.length > 0) {
   const managedRules = [];
   for (const name of managedEntries) {
-    const cfId = AWS_TO_CF_MANAGED[name];
+    const entry = parity.classifyManagedRule(name);
+    recordParity(entry);
+    const cfId = entry.cloudflare && entry.cloudflare.rulesetId;
     if (cfId) {
       managedRules.push({
-        description: `AWS managed rule mapped to Cloudflare: ${name}`,
+        description:
+          entry.status === 'equivalent'
+            ? `AWS ${name} → Cloudflare ${entry.cloudflare.rulesetName} (equivalent)`
+            : `AWS ${name} → Cloudflare ${entry.cloudflare.rulesetName} (APPROXIMATE — see docs/cloudflare-waf-parity.md)`,
         enabled: true,
         expression: 'true',
         action: 'execute',
@@ -294,7 +320,7 @@ if (managedEntries.length > 0) {
       });
     } else {
       managedRules.push({
-        description: `UNMAPPED AWS managed rule: ${name}. Review Cloudflare catalog and replace with the equivalent ruleset id.`,
+        description: `UNSUPPORTED AWS managed rule: ${name}. No Cloudflare mapping — emitted disabled. See docs/cloudflare-waf-parity.md.`,
         enabled: false,
         expression: 'true',
         action: 'log',
@@ -352,3 +378,15 @@ if (logging.enabled) {
 const outPath = path.join(distDir, 'cloudflare-waf.tf.json');
 fs.writeFileSync(outPath, JSON.stringify(tfJson, null, 2), 'utf8');
 console.log('Build complete:', outPath);
+
+// Emit parity warnings AFTER the file write so a failing exit still leaves a
+// diffable artifact for the operator to inspect. stderr stream only — stdout
+// reserved for the Terraform consumer / CI log.
+for (const msg of parityWarnings) {
+  console.error(msg);
+}
+
+if (failOnApproximation && sawApproximationOrUnsupported) {
+  console.error('[cloudflare-waf-parity] --fail-on-waf-approximation set; exiting non-zero because the policy relies on approximate or unsupported Cloudflare mappings.');
+  process.exit(1);
+}

--- a/scripts/generate-parity-doc.js
+++ b/scripts/generate-parity-doc.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * Generate docs/cloudflare-waf-parity.md from scripts/lib/cloudflare-waf-parity.js.
+ *
+ * Stdout-only by default — callers redirect to disk or diff. Pass `--write`
+ * to write to docs/cloudflare-waf-parity.md (and `.ja.md` if `--lang=ja`).
+ * Drift test (scripts/check-drift.js) runs this generator in stdout mode and
+ * compares byte-for-byte against the committed doc.
+ *
+ * Usage:
+ *   node scripts/generate-parity-doc.js                  # print EN markdown
+ *   node scripts/generate-parity-doc.js --lang=ja        # print JA markdown
+ *   node scripts/generate-parity-doc.js --write          # write EN to docs/
+ *   node scripts/generate-parity-doc.js --write --lang=ja
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const parity = require('./lib/cloudflare-waf-parity');
+
+const STATUS_BADGE = {
+  equivalent: 'EQUIVALENT',
+  approximate: 'APPROXIMATE',
+  unsupported: 'UNSUPPORTED',
+};
+
+function renderEn() {
+  const lines = [];
+  lines.push('# Cloudflare WAF parity');
+  lines.push('');
+  lines.push('> **Languages:** English · [日本語](./cloudflare-waf-parity.ja.md)');
+  lines.push('');
+  lines.push('This document is **generated** from `scripts/lib/cloudflare-waf-parity.js`. Do not edit by hand — run `node scripts/generate-parity-doc.js --write` after changing the metadata. The drift test in `scripts/check-drift.js` fails CI if this file falls out of sync.');
+  lines.push('');
+  lines.push('The dual-target story ("one YAML, both CloudFront and Cloudflare") depends on users knowing which parts are 1:1 equivalents, which are approximations, and which simply do not exist on Cloudflare. Silent degradation would undermine the whole value proposition — so the compiler emits stderr warnings for every non-equivalent entry, and `--fail-on-waf-approximation` promotes those to a non-zero exit for production CI.');
+  lines.push('');
+  lines.push('## Legend');
+  lines.push('');
+  lines.push('| Status | Meaning |');
+  lines.push('| --- | --- |');
+  lines.push('| `EQUIVALENT` | Cloudflare has a direct 1:1 resource. No warning. |');
+  lines.push('| `APPROXIMATE` | Close but not identical. Compiler warns; `--fail-on-waf-approximation` exits non-zero. |');
+  lines.push('| `UNSUPPORTED` | No reasonable Cloudflare mapping today. Rule emitted with `enabled: false`. Compiler warns; `--fail-on-waf-approximation` exits non-zero. |');
+  lines.push('');
+  lines.push('## AWS managed rule sets');
+  lines.push('');
+  lines.push('| AWS rule | Status | Cloudflare target | Last verified |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const e of parity.MANAGED_RULES) {
+    const target = e.cloudflare.rulesetName
+      ? (e.cloudflare.rulesetId ? `${e.cloudflare.rulesetName} (\`${e.cloudflare.rulesetId}\`)` : e.cloudflare.rulesetName)
+      : '—';
+    lines.push(`| \`${e.aws}\` | \`${STATUS_BADGE[e.status]}\` | ${target} | ${e.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const e of parity.MANAGED_RULES) {
+    lines.push(`### \`${e.aws}\``);
+    lines.push('');
+    lines.push(`- **Status:** \`${STATUS_BADGE[e.status]}\``);
+    if (e.cloudflare.rulesetName) {
+      lines.push(`- **Cloudflare target:** ${e.cloudflare.rulesetName}${e.cloudflare.rulesetId ? ` (id \`${e.cloudflare.rulesetId}\`)` : ''}`);
+    } else {
+      lines.push('- **Cloudflare target:** none');
+    }
+    if (e.cloudflare.docUrl) lines.push(`- **Docs:** ${e.cloudflare.docUrl}`);
+    lines.push(`- **Last verified:** ${e.lastVerified || '—'}`);
+    lines.push('');
+    lines.push(e.rationale);
+    lines.push('');
+  }
+  lines.push('## `scope_down_statement` shapes');
+  lines.push('');
+  lines.push('AWS `rate_limit_rules[].scope_down_statement` is a structured AST. Cloudflare rate limits scope via the free-form `expression` field. The compiler translates a small set of shapes automatically; anything else must be expressed with `rule.expression_cloudflare` on the policy.');
+  lines.push('');
+  lines.push('| Shape | Status | Cloudflare expression | Notes |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const s of parity.SCOPE_DOWN_TRANSLATIONS) {
+    lines.push(`| \`${s.shape}\` | \`${STATUS_BADGE[s.status]}\` | ${s.cloudflareExpression ? `\`${s.cloudflareExpression}\`` : '—'} | ${s.rationale} |`);
+  }
+  lines.push('');
+  lines.push('## IP reputation and lists');
+  lines.push('');
+  lines.push('| Feature | Status | Cloudflare surface | Last verified |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const f of parity.IP_REPUTATION_FEATURES) {
+    lines.push(`| ${f.feature} | \`${STATUS_BADGE[f.status]}\` | ${f.cloudflareSurface} | ${f.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const f of parity.IP_REPUTATION_FEATURES) {
+    lines.push(`- **${f.feature}** — ${f.rationale}`);
+  }
+  lines.push('');
+  lines.push('## Logging');
+  lines.push('');
+  lines.push('| Feature | Status | Cloudflare surface | Last verified |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const f of parity.LOGGING_FEATURES) {
+    lines.push(`| ${f.feature} | \`${STATUS_BADGE[f.status]}\` | ${f.cloudflareSurface} | ${f.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const f of parity.LOGGING_FEATURES) {
+    lines.push(`- **${f.feature}** — ${f.rationale}`);
+  }
+  lines.push('');
+  lines.push('## Production CI gate');
+  lines.push('');
+  lines.push('```bash');
+  lines.push('npx cdn-security build --target cloudflare --fail-on-waf-approximation');
+  lines.push('```');
+  lines.push('');
+  lines.push('Exits non-zero when any `APPROXIMATE` or `UNSUPPORTED` entry is touched by the compiled policy. Use this gate in `main`-branch pipelines; keep the default (warn-only) for development branches.');
+  lines.push('');
+  lines.push('## Updating this document');
+  lines.push('');
+  lines.push('1. Edit `scripts/lib/cloudflare-waf-parity.js`.');
+  lines.push('2. Bump `lastVerified` to today.');
+  lines.push('3. Run `node scripts/generate-parity-doc.js --write` and `node scripts/generate-parity-doc.js --write --lang=ja`.');
+  lines.push('4. Commit both the metadata change and the regenerated docs in the same PR.');
+  lines.push('');
+  return lines.join('\n') + '\n';
+}
+
+function renderJa() {
+  const lines = [];
+  lines.push('# Cloudflare WAF パリティ');
+  lines.push('');
+  lines.push('> **Languages:** [English](./cloudflare-waf-parity.md) · 日本語');
+  lines.push('');
+  lines.push('このドキュメントは `scripts/lib/cloudflare-waf-parity.js` から **自動生成** されます。手で編集せず、メタデータ更新後に `node scripts/generate-parity-doc.js --write --lang=ja` を実行してください。`scripts/check-drift.js` がズレを検知すると CI が落ちます。');
+  lines.push('');
+  lines.push('「1 つの YAML で CloudFront と Cloudflare 両方」という前提は、**どこが 1:1 等価で、どこが近似で、どこが未対応か** を利用者が把握していてはじめて成立します。黙って劣化させるのはアーキテクチャ上の罪なので、コンパイラは equivalent 以外の全てで stderr 警告を出し、`--fail-on-waf-approximation` を付けると本番 CI で非ゼロ終了します。');
+  lines.push('');
+  lines.push('## 凡例');
+  lines.push('');
+  lines.push('| ステータス | 意味 |');
+  lines.push('| --- | --- |');
+  lines.push('| `EQUIVALENT` | Cloudflare に 1:1 のリソースあり。警告なし。 |');
+  lines.push('| `APPROXIMATE` | 近いが同一ではない。警告あり。`--fail-on-waf-approximation` で非ゼロ終了。 |');
+  lines.push('| `UNSUPPORTED` | 現状 Cloudflare に対応物なし。ルールは `enabled: false` で出力。警告あり、`--fail-on-waf-approximation` で非ゼロ終了。 |');
+  lines.push('');
+  lines.push('## AWS マネージドルール');
+  lines.push('');
+  lines.push('| AWS ルール | ステータス | Cloudflare ターゲット | 最終確認日 |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const e of parity.MANAGED_RULES) {
+    const target = e.cloudflare.rulesetName
+      ? (e.cloudflare.rulesetId ? `${e.cloudflare.rulesetName} (\`${e.cloudflare.rulesetId}\`)` : e.cloudflare.rulesetName)
+      : '—';
+    lines.push(`| \`${e.aws}\` | \`${STATUS_BADGE[e.status]}\` | ${target} | ${e.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const e of parity.MANAGED_RULES) {
+    lines.push(`### \`${e.aws}\``);
+    lines.push('');
+    lines.push(`- **ステータス:** \`${STATUS_BADGE[e.status]}\``);
+    if (e.cloudflare.rulesetName) {
+      lines.push(`- **Cloudflare ターゲット:** ${e.cloudflare.rulesetName}${e.cloudflare.rulesetId ? `（id \`${e.cloudflare.rulesetId}\`）` : ''}`);
+    } else {
+      lines.push('- **Cloudflare ターゲット:** なし');
+    }
+    if (e.cloudflare.docUrl) lines.push(`- **ドキュメント:** ${e.cloudflare.docUrl}`);
+    lines.push(`- **最終確認日:** ${e.lastVerified || '—'}`);
+    lines.push('');
+    lines.push(e.rationale);
+    lines.push('');
+  }
+  lines.push('## `scope_down_statement` 形状');
+  lines.push('');
+  lines.push('AWS の `rate_limit_rules[].scope_down_statement` は構造化 AST ですが、Cloudflare のレートリミットは自由形式 `expression` でスコープを指定します。コンパイラは限られた形状だけ自動変換し、それ以外は policy 側で `rule.expression_cloudflare` を明示してもらう方針です。');
+  lines.push('');
+  lines.push('| 形状 | ステータス | Cloudflare expression | 備考 |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const s of parity.SCOPE_DOWN_TRANSLATIONS) {
+    lines.push(`| \`${s.shape}\` | \`${STATUS_BADGE[s.status]}\` | ${s.cloudflareExpression ? `\`${s.cloudflareExpression}\`` : '—'} | ${s.rationale} |`);
+  }
+  lines.push('');
+  lines.push('## IP レピュテーション / リスト');
+  lines.push('');
+  lines.push('| 機能 | ステータス | Cloudflare 対応面 | 最終確認日 |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const f of parity.IP_REPUTATION_FEATURES) {
+    lines.push(`| ${f.feature} | \`${STATUS_BADGE[f.status]}\` | ${f.cloudflareSurface} | ${f.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const f of parity.IP_REPUTATION_FEATURES) {
+    lines.push(`- **${f.feature}** — ${f.rationale}`);
+  }
+  lines.push('');
+  lines.push('## ロギング');
+  lines.push('');
+  lines.push('| 機能 | ステータス | Cloudflare 対応面 | 最終確認日 |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const f of parity.LOGGING_FEATURES) {
+    lines.push(`| ${f.feature} | \`${STATUS_BADGE[f.status]}\` | ${f.cloudflareSurface} | ${f.lastVerified || '—'} |`);
+  }
+  lines.push('');
+  for (const f of parity.LOGGING_FEATURES) {
+    lines.push(`- **${f.feature}** — ${f.rationale}`);
+  }
+  lines.push('');
+  lines.push('## 本番 CI ゲート');
+  lines.push('');
+  lines.push('```bash');
+  lines.push('npx cdn-security build --target cloudflare --fail-on-waf-approximation');
+  lines.push('```');
+  lines.push('');
+  lines.push('コンパイル対象のポリシーが `APPROXIMATE` か `UNSUPPORTED` に触れていると非ゼロで終了します。`main` ブランチのパイプラインではこのゲートを有効化し、開発ブランチではデフォルト（警告のみ）のままで運用するのが推奨です。');
+  lines.push('');
+  lines.push('## 更新手順');
+  lines.push('');
+  lines.push('1. `scripts/lib/cloudflare-waf-parity.js` を編集する。');
+  lines.push('2. `lastVerified` を今日の日付に更新する。');
+  lines.push('3. `node scripts/generate-parity-doc.js --write` と `node scripts/generate-parity-doc.js --write --lang=ja` を実行する。');
+  lines.push('4. メタデータ変更と再生成ドキュメントを同じ PR でコミットする。');
+  lines.push('');
+  return lines.join('\n') + '\n';
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const lang = argv.find((a) => a === '--lang=ja') ? 'ja' : 'en';
+  const write = argv.includes('--write');
+  const out = lang === 'ja' ? renderJa() : renderEn();
+  if (!write) {
+    process.stdout.write(out);
+    return;
+  }
+  const repoRoot = path.join(__dirname, '..');
+  const target = path.join(repoRoot, 'docs', lang === 'ja' ? 'cloudflare-waf-parity.ja.md' : 'cloudflare-waf-parity.md');
+  fs.writeFileSync(target, out, 'utf8');
+  console.log('Wrote', target);
+}
+
+if (require.main === module) main();
+
+module.exports = { renderEn, renderJa };

--- a/scripts/lib/cloudflare-waf-parity.js
+++ b/scripts/lib/cloudflare-waf-parity.js
@@ -1,0 +1,210 @@
+/**
+ * Cloudflare WAF parity metadata.
+ *
+ * Single source of truth for how AWS-shaped WAF policy concepts map onto
+ * Cloudflare. Consumed by:
+ *   - scripts/compile-cloudflare-waf.js  (emits warnings + resolves ruleset ids)
+ *   - scripts/generate-parity-doc.js     (renders docs/cloudflare-waf-parity.md)
+ *   - scripts/check-drift.js             (ensures the committed doc matches)
+ *
+ * Classifications:
+ *   equivalent  — CF has a 1:1 resource. Compiler emits normally, no warning.
+ *   approximate — CF has something close but not identical. Compiler emits
+ *                 a stderr warning naming the rule, the CF target, and the
+ *                 caveat. `--fail-on-waf-approximation` makes these fatal.
+ *   unsupported — CF has no reasonable mapping today. Compiler emits the
+ *                 rule as `enabled: false` + stderr warning. Also gated
+ *                 by `--fail-on-waf-approximation`.
+ *
+ * Every entry has a `lastVerified` date. The drift test lives in
+ * scripts/check-drift.js — when entries change, the generated doc is
+ * re-rendered; the committed copy must match.
+ */
+
+'use strict';
+
+const MANAGED_RULES = [
+  {
+    aws: 'AWSManagedRulesCommonRuleSet',
+    status: 'equivalent',
+    cloudflare: {
+      rulesetId: 'efb7b8c949ac4650a09736fc376e9aee',
+      rulesetName: 'Cloudflare Managed Ruleset',
+      docUrl: 'https://developers.cloudflare.com/waf/managed-rules/reference/cloudflare-managed-ruleset/',
+    },
+    rationale:
+      'Cloudflare Managed Ruleset covers the same baseline injection / traversal / scanner signatures as AWS Common Rule Set. Field names differ but blocked traffic class is equivalent.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesKnownBadInputsRuleSet',
+    status: 'approximate',
+    cloudflare: {
+      rulesetId: '4814384a9e5d4991b9815dcfc25d2f1f',
+      rulesetName: 'Cloudflare OWASP Core Ruleset',
+      docUrl: 'https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/',
+    },
+    rationale:
+      'OWASP Core Ruleset overlaps with Known Bad Inputs for scanner / exploit probes but is broader: enabling it also triggers the SQLi / XSS / LFI rule families. Tune the paranoia level and sensitivity after adopting.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesSQLiRuleSet',
+    status: 'approximate',
+    cloudflare: {
+      rulesetId: '4814384a9e5d4991b9815dcfc25d2f1f',
+      rulesetName: 'Cloudflare OWASP Core Ruleset',
+      docUrl: 'https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/',
+    },
+    rationale:
+      'Cloudflare does not ship a standalone SQLi ruleset. The OWASP Core Ruleset covers SQLi via its 942xxx rule family, but declaring it means accepting the full OWASP bundle. If you only want SQLi today, map the individual OWASP rule IDs instead.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesIPReputationList',
+    status: 'approximate',
+    cloudflare: {
+      rulesetId: 'c2e184081120413c86c3ab7e14069605',
+      rulesetName: 'Cloudflare Exposed Credentials Check Managed Ruleset',
+      docUrl: 'https://developers.cloudflare.com/waf/managed-rules/reference/exposed-credentials-check/',
+    },
+    rationale:
+      'Cloudflare does not expose its IP reputation list via Ruleset Engine the way AWS does. Closest adjacent Cloudflare feature is Exposed Credentials Check (threat intel against credential-stuffing). If you need IP reputation specifically, enable Cloudflare Security Level (zone-scoped) outside this policy or use IP Lists against known-bad feeds.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesBotControlRuleSet',
+    status: 'approximate',
+    cloudflare: {
+      rulesetId: null,
+      rulesetName: 'Bot Fight Mode (zone setting) / Bot Management (paid)',
+      docUrl: 'https://developers.cloudflare.com/bots/',
+    },
+    rationale:
+      'Cloudflare bot mitigation is not a ruleset — it is a zone-scoped feature (Bot Fight Mode on free; Bot Management on enterprise). The compiler sets `bot_fight_mode: on` via cloudflare_zone_settings_override, which is only a coarse approximation of AWS Bot Control.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesAnonymousIpList',
+    status: 'approximate',
+    cloudflare: {
+      rulesetId: null,
+      rulesetName: 'Cloudflare Security Level (zone setting) + IP Lists (manual feeds)',
+      docUrl: 'https://developers.cloudflare.com/waf/tools/security-level/',
+    },
+    rationale:
+      'Cloudflare does not expose a managed anonymous-IP / VPN / Tor list as a Ruleset. Approximate coverage is available via the zone-level Security Level setting (blocks threat-scored traffic including known anonymizers) and Tor-exit custom IP Lists seeded from public feeds. Neither is a drop-in replacement for the AWS AnonymousIpList; the compiler emits the rule disabled so operators choose explicitly.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    aws: 'AWSManagedRulesATPRuleSet',
+    status: 'unsupported',
+    cloudflare: {
+      rulesetId: null,
+      rulesetName: null,
+      docUrl: 'https://developers.cloudflare.com/bots/concepts/bot-score/',
+    },
+    rationale:
+      'AWS ATP (Account Takeover Prevention) runs credential-stuffing detection at the edge with stateful scoring. Cloudflare does not expose an equivalent via Ruleset Engine. Closest features (Bot Management, Super Bot Fight Mode) are not policy-portable. Declare ATP only on the AWS side for now.',
+    lastVerified: '2026-04-24',
+  },
+];
+
+const SCOPE_DOWN_TRANSLATIONS = [
+  {
+    shape: 'byte_match_statement(uri_path, STARTS_WITH)',
+    status: 'equivalent',
+    cloudflareExpression: 'starts_with(http.request.uri.path, "<value>")',
+    rationale: 'Direct translation — Cloudflare expression language has starts_with/ends_with/contains helpers.',
+  },
+  {
+    shape: 'byte_match_statement(uri_path, EXACTLY)',
+    status: 'approximate',
+    cloudflareExpression: 'http.request.uri.path eq "<value>"',
+    rationale: 'Not yet auto-translated by the compiler. Set rule.expression_cloudflare to override. Will be promoted to equivalent once the translator is extended.',
+  },
+  {
+    shape: 'byte_match_statement(uri_path, CONTAINS)',
+    status: 'approximate',
+    cloudflareExpression: 'http.request.uri.path contains "<value>"',
+    rationale: 'Not yet auto-translated. Set rule.expression_cloudflare. Will be promoted once the translator is extended.',
+  },
+  {
+    shape: 'regex_match_statement',
+    status: 'approximate',
+    cloudflareExpression: 'http.request.uri.path matches "<regex>"',
+    rationale: 'Cloudflare supports regex via the `matches` operator but differs in flavor (RE2 vs AWS regex). Auto-translation would risk silent re-interpretation of edge cases. Require explicit expression_cloudflare.',
+  },
+  {
+    shape: 'label_match_statement / size_constraint_statement / geo_match_statement (inside scope-down)',
+    status: 'unsupported',
+    cloudflareExpression: null,
+    rationale: 'These AWS scope-down shapes have no direct expression counterpart. Either flatten the scope-down into a separate Cloudflare rule, or provide expression_cloudflare explicitly on the rate_limit rule.',
+  },
+];
+
+const IP_REPUTATION_FEATURES = [
+  {
+    feature: 'AWS WAF IP reputation list (managed)',
+    status: 'approximate',
+    cloudflareSurface: 'Exposed Credentials Check / Zone Security Level',
+    rationale:
+      'Cloudflare does not expose IP reputation via Ruleset Engine. Use Security Level (zone setting) plus custom IP Lists seeded from a threat feed for comparable coverage.',
+    lastVerified: '2026-04-24',
+  },
+  {
+    feature: 'Custom IP block / allowlists',
+    status: 'equivalent',
+    cloudflareSurface: 'cloudflare_list (ip kind) + custom firewall rule',
+    rationale: 'Direct translation. The compiler emits cloudflare_list + ruleset rule referencing $<name>_ip_blocklist.',
+    lastVerified: '2026-04-24',
+  },
+];
+
+const LOGGING_FEATURES = [
+  {
+    feature: 'AWS WAF logging destination (Kinesis / CloudWatch / S3)',
+    status: 'approximate',
+    cloudflareSurface: 'cloudflare_logpush_job (dataset: firewall_events)',
+    rationale:
+      'Cloudflare Logpush streams firewall_events to S3/R2/GCS. Field names and event shape differ from AWS WAF logs — downstream log queries must be adapted.',
+    lastVerified: '2026-04-24',
+  },
+];
+
+const MANAGED_RULES_INDEX = Object.fromEntries(MANAGED_RULES.map((e) => [e.aws, e]));
+
+function classifyManagedRule(awsRuleName) {
+  if (Object.prototype.hasOwnProperty.call(MANAGED_RULES_INDEX, awsRuleName)) {
+    return MANAGED_RULES_INDEX[awsRuleName];
+  }
+  return {
+    aws: awsRuleName,
+    status: 'unsupported',
+    cloudflare: { rulesetId: null, rulesetName: null, docUrl: null },
+    rationale:
+      'No parity entry for this AWS managed rule. Treated as unsupported — compiler emits rule with enabled: false so Terraform apply does not silently attach a random ruleset. Add an entry to cloudflare-waf-parity.js when a mapping is decided.',
+    lastVerified: null,
+  };
+}
+
+function formatManagedRuleWarning(entry) {
+  const target = entry.cloudflare.rulesetName
+    ? `${entry.cloudflare.rulesetName}${entry.cloudflare.rulesetId ? ` (id: ${entry.cloudflare.rulesetId})` : ''}`
+    : '(no Cloudflare target)';
+  const docTail = entry.cloudflare.docUrl ? ` See ${entry.cloudflare.docUrl}` : '';
+  if (entry.status === 'equivalent') return null;
+  const prefix = entry.status === 'approximate'
+    ? `[cloudflare-waf-parity] APPROXIMATE: ${entry.aws} → ${target}.`
+    : `[cloudflare-waf-parity] UNSUPPORTED: ${entry.aws} has no mapping; rule emitted with enabled: false.`;
+  return `${prefix} ${entry.rationale}${docTail}`;
+}
+
+module.exports = {
+  MANAGED_RULES,
+  SCOPE_DOWN_TRANSLATIONS,
+  IP_REPUTATION_FEATURES,
+  LOGGING_FEATURES,
+  classifyManagedRule,
+  formatManagedRuleWarning,
+};

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+/**
+ * Programmatic API integration tests.
+ *
+ * These exercise the public entry `require('cdn-security-framework')` from
+ * the repo (via its lib/index.js). We assert every function returns a
+ * structured result object and NEVER calls process.exit — the whole point
+ * of the Programmatic API is that callers decide exit behaviour.
+ *
+ * Coverage focus:
+ *   - result shape stability (this is the contract)
+ *   - lintPolicy in-process happy/error paths
+ *   - compile + emitWaf backwards-compat (subprocess-backed today)
+ *   - migratePolicy noop and error branches (no process.exit)
+ *   - runDoctor re-export is callable
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const api = require('../lib');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('OK:', name);
+  } catch (e) {
+    console.error('FAIL:', name);
+    console.error(e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  }
+}
+
+const repoRoot = path.join(__dirname, '..');
+
+const BASIC_AWS_POLICY = `
+version: 1
+project: api-test
+request:
+  allow_methods: [GET, POST]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
+
+const BROKEN_POLICY = `
+version: 1
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+unknown_top_level_key: true
+`;
+
+function tmpProject(yamlBody) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
+  const policyDir = path.join(tmp, 'policy');
+  fs.mkdirSync(policyDir);
+  const policyPath = path.join(policyDir, 'security.yml');
+  fs.writeFileSync(policyPath, yamlBody, 'utf8');
+  return {
+    tmp,
+    policyPath,
+    outDir: path.join(tmp, 'dist'),
+    cleanup() { fs.rmSync(tmp, { recursive: true, force: true }); },
+  };
+}
+
+// --- Exports surface ---
+
+test('api exports stable surface', () => {
+  assert.strictEqual(typeof api.lintPolicy, 'function');
+  assert.strictEqual(typeof api.compile, 'function');
+  assert.strictEqual(typeof api.emitWaf, 'function');
+  assert.strictEqual(typeof api.runDoctor, 'function');
+  assert.strictEqual(typeof api.migratePolicy, 'function');
+});
+
+test('api entry point matches package.json main', () => {
+  const pkg = require('../package.json');
+  assert.strictEqual(pkg.main, 'lib/index.js', 'package.json main must point to lib/index.js');
+  // The require above would have thrown if the path was wrong, but assert anyway.
+  assert.ok(fs.existsSync(path.join(repoRoot, 'lib', 'index.js')));
+});
+
+// --- lintPolicy ---
+
+test('lintPolicy: returns ok=true for valid policy', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.lintPolicy({ policyPath: ctx.policyPath });
+    assert.strictEqual(result.ok, true, `lint failed: ${JSON.stringify(result.errors)}`);
+    assert.ok(Array.isArray(result.errors));
+    assert.ok(Array.isArray(result.warnings));
+    assert.ok(result.policy && result.policy.version === 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('lintPolicy: missing policyPath → structured error, no throw', () => {
+  const result = api.lintPolicy({});
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+  assert.strictEqual(result.policy, null);
+});
+
+test('lintPolicy: nonexistent file → structured error', () => {
+  const result = api.lintPolicy({ policyPath: '/no/such/file.yml' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+});
+
+test('lintPolicy: invalid policy surfaces schema errors', () => {
+  const ctx = tmpProject(BROKEN_POLICY);
+  try {
+    const result = api.lintPolicy({ policyPath: ctx.policyPath });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.length > 0, 'expected errors for invalid policy');
+    assert.ok(result.policy !== null, 'policy should still be parsed');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('lintPolicy: does not call process.exit (isolation probe)', () => {
+  // If lintPolicy ever calls process.exit, Node will terminate this test
+  // process before subsequent tests run. Reaching the assertion below
+  // confirms non-termination for the error path.
+  const result = api.lintPolicy({ policyPath: '/no/such/file.yml' });
+  assert.strictEqual(result.ok, false);
+});
+
+// --- compile ---
+
+test('compile: aws target writes edge + infra, returns file lists', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.compile({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.ok, true, `compile failed: ${result.errors.join(' ')}`);
+    assert.strictEqual(result.target, 'aws');
+    assert.ok(result.edgeFiles.length >= 3, 'aws target emits 3 edge files');
+    assert.ok(result.edgeFiles.every((f) => fs.existsSync(f)), 'all edge files must exist');
+    assert.ok(result.infraFiles.length > 0, 'aws target emits infra files');
+    assert.ok(result.infraFiles.every((f) => fs.existsSync(f)));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compile: unknown target returns structured error', () => {
+  const result = api.compile({
+    policyPath: '/tmp/nothing.yml',
+    outDir: '/tmp/out',
+    target: 'gcp',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /unknown target/i.test(e)));
+});
+
+test('compile: missing policyPath → error, no exit', () => {
+  const result = api.compile({ outDir: '/tmp', target: 'aws' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+});
+
+test('compile: missing outDir → error, no exit', () => {
+  const result = api.compile({ policyPath: '/tmp/x.yml', target: 'aws' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /outDir is required/.test(e)));
+});
+
+test('compile: nonexistent policy file → structured error', () => {
+  const result = api.compile({
+    policyPath: '/no/such/policy.yml',
+    outDir: '/tmp/irrelevant-should-not-be-created',
+    target: 'aws',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+});
+
+// --- emitWaf ---
+
+test('emitWaf: aws emits only infra, edgeFiles empty', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.emitWaf({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.ok, true, `emitWaf failed: ${result.errors.join(' ')}`);
+    assert.deepStrictEqual(result.edgeFiles, [], 'emit-waf must NOT emit edge files');
+    assert.ok(result.infraFiles.length > 0);
+    const edgeDir = path.join(ctx.outDir, 'edge');
+    assert.ok(!fs.existsSync(edgeDir), 'emit-waf must not create dist/edge/');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('emitWaf: --format cloudformation returns ok=false with formatNotImplemented flag', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.emitWaf({
+      policyPath: ctx.policyPath,
+      outDir: ctx.outDir,
+      target: 'aws',
+      format: 'cloudformation',
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.formatNotImplemented, true);
+    assert.ok(result.errors.some((e) => /not yet implemented/i.test(e)));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('emitWaf: unknown format → structured error', () => {
+  const result = api.emitWaf({
+    policyPath: '/tmp/x.yml',
+    outDir: '/tmp/out',
+    target: 'aws',
+    format: 'pulumi',
+  });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.errors.some((e) => /unknown --format/i.test(e)));
+});
+
+// --- migratePolicy ---
+
+test('migratePolicy: v1 → v1 is ok+noop', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.migratePolicy({ policyPath: ctx.policyPath, toVersion: 1 });
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.noop, true);
+    assert.strictEqual(result.migrated, false);
+    assert.strictEqual(result.fromVersion, 1);
+    assert.strictEqual(result.toVersion, 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('migratePolicy: no version field → ok=false with guidance error', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-'));
+  try {
+    const policyPath = path.join(tmp, 'policy.yml');
+    fs.writeFileSync(policyPath, 'project: noversion\n', 'utf8');
+    const result = api.migratePolicy({ policyPath });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((e) => /no `version` field/.test(e)));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('migratePolicy: unknown forward path sets reservedExit2', () => {
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const result = api.migratePolicy({ policyPath: ctx.policyPath, toVersion: 99 });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reservedExit2, true);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('migratePolicy: downgrade rejected', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-'));
+  try {
+    const policyPath = path.join(tmp, 'policy.yml');
+    fs.writeFileSync(policyPath, 'version: 5\nproject: future\n', 'utf8');
+    const result = api.migratePolicy({ policyPath, toVersion: 1 });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((e) => /Downgrade/.test(e)));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- runDoctor re-export ---
+
+test('runDoctor: re-export is callable and returns exitCode + report', () => {
+  // Doctor needs to run in a dir with no policy to hit the "policy_exists" fail
+  // path cleanly — we don't care about pass/fail here, just the shape.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-'));
+  try {
+    const result = api.runDoctor({
+      cwd: tmp,
+      pkgRoot: repoRoot,
+      reportPath: null,
+    });
+    assert.strictEqual(typeof result.exitCode, 'number');
+    assert.ok(result.report && Array.isArray(result.report.checks));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- regression: CLI still works after refactor ---
+
+test('CLI backwards-compat: `cdn-security build --target aws` still succeeds', () => {
+  // We shell out to the CLI here precisely to verify the refactored bin/cli.js
+  // still honors the legacy exit-code + stdout contract. Isolated tmp dir.
+  const ctx = tmpProject(BASIC_AWS_POLICY);
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result = spawnSync(process.execPath, [
+      cli, 'build',
+      '-p', ctx.policyPath,
+      '-o', ctx.outDir,
+      '--target', 'aws',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.status, 0, `CLI build failed: ${result.stderr}`);
+    assert.ok(fs.existsSync(path.join(ctx.outDir, 'edge', 'viewer-request.js')));
+    assert.ok(fs.existsSync(path.join(ctx.outDir, 'infra', 'waf-rules.tf.json')));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}

--- a/scripts/security-baseline-check.js
+++ b/scripts/security-baseline-check.js
@@ -40,6 +40,22 @@ function main() {
     fail('policy/schema.json must include ja3_fingerprints and ja4_fingerprints');
   }
 
+  // Cloudflare WAF parity docs must exist and reference the fail flag, so the
+  // dual-target transparency promise is not silently deleted. The drift test
+  // (scripts/check-drift.js) separately enforces that the body matches the
+  // generator output.
+  const parityFiles = [
+    { file: 'docs/cloudflare-waf-parity.md', heading: '# Cloudflare WAF parity' },
+    { file: 'docs/cloudflare-waf-parity.ja.md', heading: '# Cloudflare WAF パリティ' },
+  ];
+  for (const p of parityFiles) {
+    if (!fs.existsSync(path.join(repoRoot, p.file))) {
+      fail(`${p.file} is missing — parity transparency (issue #68) requires this file to exist`);
+    }
+    ensureIncludes(p.file, p.heading, 'parity doc heading');
+    ensureIncludes(p.file, '--fail-on-waf-approximation', 'reference to the CI gate flag');
+  }
+
   console.log('Security baseline check passed.');
 }
 

--- a/tests/golden/archetypes/admin-panel/infra/cloudflare-waf.tf.json
+++ b/tests/golden/archetypes/admin-panel/infra/cloudflare-waf.tf.json
@@ -84,7 +84,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -94,7 +94,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -104,7 +104,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -114,7 +114,7 @@
           },
           {
             "ref": "managed_4",
-            "description": "UNMAPPED AWS managed rule: AWSManagedRulesAnonymousIpList. Review Cloudflare catalog and replace with the equivalent ruleset id.",
+            "description": "UNSUPPORTED AWS managed rule: AWSManagedRulesAnonymousIpList. No Cloudflare mapping — emitted disabled. See docs/cloudflare-waf-parity.md.",
             "enabled": false,
             "expression": "true",
             "action": "log",

--- a/tests/golden/archetypes/microservice-origin/infra/cloudflare-waf.tf.json
+++ b/tests/golden/archetypes/microservice-origin/infra/cloudflare-waf.tf.json
@@ -66,7 +66,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -76,7 +76,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -86,7 +86,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",

--- a/tests/golden/archetypes/rest-api/infra/cloudflare-waf.tf.json
+++ b/tests/golden/archetypes/rest-api/infra/cloudflare-waf.tf.json
@@ -84,7 +84,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -94,7 +94,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -104,7 +104,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesSQLiRuleSet",
+            "description": "AWS AWSManagedRulesSQLiRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -114,7 +114,7 @@
           },
           {
             "ref": "managed_4",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",

--- a/tests/golden/archetypes/spa-static-site/infra/cloudflare-waf.tf.json
+++ b/tests/golden/archetypes/spa-static-site/infra/cloudflare-waf.tf.json
@@ -66,7 +66,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -76,7 +76,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -86,7 +86,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",

--- a/tests/golden/profiles/balanced/infra/cloudflare-waf.tf.json
+++ b/tests/golden/profiles/balanced/infra/cloudflare-waf.tf.json
@@ -66,7 +66,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -76,7 +76,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -86,7 +86,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",

--- a/tests/golden/profiles/strict/infra/cloudflare-waf.tf.json
+++ b/tests/golden/profiles/strict/infra/cloudflare-waf.tf.json
@@ -96,7 +96,7 @@
         "rules": [
           {
             "ref": "managed_1",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesCommonRuleSet",
+            "description": "AWS AWSManagedRulesCommonRuleSet → Cloudflare Cloudflare Managed Ruleset (equivalent)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -106,7 +106,7 @@
           },
           {
             "ref": "managed_2",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesKnownBadInputsRuleSet",
+            "description": "AWS AWSManagedRulesKnownBadInputsRuleSet → Cloudflare Cloudflare OWASP Core Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -116,7 +116,7 @@
           },
           {
             "ref": "managed_3",
-            "description": "AWS managed rule mapped to Cloudflare: AWSManagedRulesIPReputationList",
+            "description": "AWS AWSManagedRulesIPReputationList → Cloudflare Cloudflare Exposed Credentials Check Managed Ruleset (APPROXIMATE — see docs/cloudflare-waf-parity.md)",
             "enabled": true,
             "expression": "true",
             "action": "execute",
@@ -126,7 +126,7 @@
           },
           {
             "ref": "managed_4",
-            "description": "UNMAPPED AWS managed rule: AWSManagedRulesAnonymousIpList. Review Cloudflare catalog and replace with the equivalent ruleset id.",
+            "description": "UNSUPPORTED AWS managed rule: AWSManagedRulesAnonymousIpList. No Cloudflare mapping — emitted disabled. See docs/cloudflare-waf-parity.md.",
             "enabled": false,
             "expression": "true",
             "action": "log",


### PR DESCRIPTION
## Summary

Explicit, auditable parity between AWS WAF managed rules and Cloudflare Rulesets.

- `scripts/lib/cloudflare-waf-parity.js` — single source of truth; classifies each mapping as `equivalent` / `approximate` / `unsupported` with rationale + `lastVerified` date.
- `compile-cloudflare-waf.js` — per-rule classification; non-equivalent mappings emit `[cloudflare-waf-parity]` stderr warnings. `--fail-on-waf-approximation` exits non-zero for CI gating.
- `scripts/generate-parity-doc.js` — renders `docs/cloudflare-waf-parity.{md,ja.md}` from the metadata; `check-drift.js` + unit tests enforce the committed docs match the generator output (no silent divergence).
- `scope_down_statement` untranslated shapes now surface via the same warning path and degrade to `expression: "true"`; users override with `expression_cloudflare`.
- `lib/compile.js` / `lib/emit-waf.js` / `bin/cli.js` — new `failOnWafApproximation` option on both programmatic API and CLI.
- `security-baseline-check.js` — enforces parity docs exist + reference the fail flag.
- CI (`policy-lint.yml`) — new "Cloudflare WAF parity gate" step runs `--fail-on-waf-approximation` against base policy.

Reopened from #73 (auto-closed when stacked base `feature/programmatic-api` was deleted after merge of #72). Closes #68.

## Test plan

- [x] `npm run test:unit` — 19 new parity unit tests, all green
- [x] `npm run test:runtime` — AWS + Cloudflare runtime tests pass
- [x] `npm run test:drift` — base + 3 profiles + 4 archetypes + 2 parity docs all match generator output
- [x] `npm run test:security-baseline` — parity doc existence + flag reference enforced
- [x] `npm run test:fuzz` — ReDoS fuzz passes

## Rule coverage

| AWS rule | Status | Cloudflare target |
|---|---|---|
| `AWSManagedRulesCommonRuleSet` | equivalent | Cloudflare Managed Ruleset |
| `AWSManagedRulesKnownBadInputsRuleSet` | approximate | OWASP Core Ruleset |
| `AWSManagedRulesSQLiRuleSet` | approximate | OWASP Core Ruleset (broader) |
| `AWSManagedRulesIPReputationList` | approximate | Exposed Credentials Check |
| `AWSManagedRulesBotControlRuleSet` | approximate | Bot Fight Mode / Bot Management |
| `AWSManagedRulesAnonymousIpList` | approximate | Security Level + IP Lists (rulesetId: null) |
| `AWSManagedRulesATPRuleSet` | unsupported | (none — Cloudflare has no Ruleset Engine equivalent) |

Unknown AWS rule names degrade to `unsupported` + `enabled: false` to prevent silent misbinding.