### PR TITLE
Enable strict TypeScript baseline

### DIFF
--- a/docs/typescript-migration-plan.ja.md
+++ b/docs/typescript-migration-plan.ja.md
@@ -13,7 +13,7 @@
   - `main`: `lib/index.js`
   - 既存テスト: `node scripts/*-tests.js`
 - CloudFront Functions 向けの runtime template と golden fixture は生成・配布対象なので、移行対象から除外する。
-- 型安全性は段階的に強める。初期移行では `strict: false` で挙動互換を優先し、移行完了後に `strict` 化を別PRで進める。
+- 型安全性は段階的に強める。移行完了後は `strict: true` を有効にし、既存JS由来の大きな整理が必要な項目だけ明示的に緩和する。
 
 ## 実装ステップ
 
@@ -37,4 +37,4 @@
 - `npm run test:api-contract` が成功する。
 - `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all` が成功する。
 - `bin/`, `lib/`, `scripts/` の手書き実装ソースは `src/` 配下の TypeScript になる。
-- `strict: true` 化は、暗黙 any と unknown catch の整理を別フェーズで行う。
+- `strict: true` を有効にする。暗黙 any、strict null、catch unknown の完全整理は後続フェーズで行う。

--- a/scripts/fingerprint-candidates.js
+++ b/scripts/fingerprint-candidates.js
@@ -48,9 +48,9 @@ function main() {
         const ja3 = row?.httpRequest?.ja3Fingerprint || row?.ja3Fingerprint || row?.ja3;
         const ja4 = row?.httpRequest?.ja4Fingerprint || row?.ja4Fingerprint || row?.ja4;
         if (ja3)
-            ja3Map.set(ja3, (ja3Map.get(ja3) || 0) + 1);
+            ja3Map.set(String(ja3), (ja3Map.get(String(ja3)) || 0) + 1);
         if (ja4)
-            ja4Map.set(ja4, (ja4Map.get(ja4) || 0) + 1);
+            ja4Map.set(String(ja4), (ja4Map.get(String(ja4)) || 0) + 1);
     }
     function pick(map) {
         return Array.from(map.entries())

--- a/src/scripts/fingerprint-candidates.ts
+++ b/src/scripts/fingerprint-candidates.ts
@@ -39,8 +39,8 @@ function main() {
   const inputPath = path.resolve(process.cwd(), input);
   const lines = readJsonLines(inputPath);
 
-  const ja3Map = new Map();
-  const ja4Map = new Map();
+  const ja3Map = new Map<string, number>();
+  const ja4Map = new Map<string, number>();
 
   for (const line of lines) {
     let row;
@@ -53,11 +53,11 @@ function main() {
     const ja3 = row?.httpRequest?.ja3Fingerprint || row?.ja3Fingerprint || row?.ja3;
     const ja4 = row?.httpRequest?.ja4Fingerprint || row?.ja4Fingerprint || row?.ja4;
 
-    if (ja3) ja3Map.set(ja3, (ja3Map.get(ja3) || 0) + 1);
-    if (ja4) ja4Map.set(ja4, (ja4Map.get(ja4) || 0) + 1);
+    if (ja3) ja3Map.set(String(ja3), (ja3Map.get(String(ja3)) || 0) + 1);
+    if (ja4) ja4Map.set(String(ja4), (ja4Map.get(String(ja4)) || 0) + 1);
   }
 
-  function pick(map) {
+  function pick(map: Map<string, number>) {
     return Array.from(map.entries())
       .filter(([, count]) => count >= minCount)
       .sort((a, b) => b[1] - a[1])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "moduleDetection": "force",
     "ignoreDeprecations": "6.0",
     "types": ["node"],
-    "strict": false,
+    "strict": true,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "useUnknownInCatchVariables": false,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
## Summary
- enable the TypeScript strict baseline while explicitly preserving the remaining legacy relaxations
- type the fingerprint candidate maps so strict mode can validate the generated candidate pipeline
- update the TypeScript migration plan to reflect the new baseline and remaining follow-up work

## Verification
- npm run typecheck
- npm run test:api-contract
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all