### PR TITLE
Enable unknown catch variables

### DIFF
--- a/docs/typescript-migration-plan.ja.md
+++ b/docs/typescript-migration-plan.ja.md
@@ -37,4 +37,4 @@
 - `npm run test:api-contract` が成功する。
 - `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all` が成功する。
 - `bin/`, `lib/`, `scripts/` の手書き実装ソースは `src/` 配下の TypeScript になる。
-- `strict: true` を有効にする。暗黙 any、strict null、catch unknown の完全整理は後続フェーズで行う。
+- `strict: true` と `useUnknownInCatchVariables: true` を有効にする。暗黙 any と strict null の完全整理は後続フェーズで行う。

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -59,7 +59,7 @@ function lintPolicy(opts) {
   let policy = null;
   try {
     policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-  } catch (e) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') {
       return {
         ok: false,
@@ -81,7 +81,7 @@ function lintPolicy(opts) {
     schema = JSON.parse(
       fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'),
     );
-  } catch (e) {
+  } catch (e: any) {
     return {
       ok: false,
       errors: [`failed to load schema: ${e.message}`],
@@ -107,7 +107,7 @@ function lintPolicy(opts) {
     if (block.path_patterns !== undefined) {
       parsePathPatterns(block.path_patterns);
     }
-  } catch (e) {
+  } catch (e: any) {
     errors.push(`  - request.block.path_patterns: ${e.message}`);
   }
 
@@ -116,7 +116,7 @@ function lintPolicy(opts) {
       exitOnError: false,
       allowPlaceholderToken: true,
     });
-  } catch (e) {
+  } catch (e: any) {
     if (Array.isArray(e.validationErrors)) {
       errors.push('Auth gate validation failed:');
       e.validationErrors.forEach((msg) => errors.push('  - ' + msg));

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -82,7 +82,7 @@ function migratePolicy(opts) {
   let doc;
   try {
     doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-  } catch (e) {
+  } catch (e: any) {
     return {
       ok: false,
       errors: [`failed to parse policy YAML: ${e.message}`],

--- a/src/scripts/api-contract-tests.ts
+++ b/src/scripts/api-contract-tests.ts
@@ -9,7 +9,7 @@ function test(name, fn) {
   try {
     fn();
     console.log(`OK: ${name}`);
-  } catch (err) {
+  } catch (err: any) {
     console.error(`FAIL: ${name}`);
     console.error(err);
     process.exitCode = 1;

--- a/src/scripts/cli-doctor.ts
+++ b/src/scripts/cli-doctor.ts
@@ -99,7 +99,7 @@ function tryParsePolicy(policyPath) {
     const raw = fs.readFileSync(policyPath, 'utf8');
     const doc = yaml.load(raw);
     return { ok: true, doc };
-  } catch (e) {
+  } catch (e: any) {
     return { ok: false, error: e.message };
   }
 }
@@ -199,7 +199,7 @@ function checkDistWritable(cwd) {
     fs.writeFileSync(probe, 'ok', 'utf8');
     fs.unlinkSync(probe);
     return pass(CHECK_DIST_WRITABLE, `dist/edge/ is writable (${edgeDir}).`);
-  } catch (e) {
+  } catch (e: any) {
     return fail(
       CHECK_DIST_WRITABLE,
       `Cannot write to dist/edge/: ${e.message}. Check filesystem permissions — build will fail.`
@@ -223,7 +223,7 @@ function checkDependencies(cwd, spawnSyncImpl) {
   let parsed;
   try {
     parsed = JSON.parse(res.stdout);
-  } catch (e) {
+  } catch (e: any) {
     return warn(CHECK_DEPENDENCIES, `Could not parse \`npm ls --json\` output: ${e.message}`);
   }
   const problems = Array.isArray(parsed.problems) ? parsed.problems : [];
@@ -290,7 +290,7 @@ function runDoctor(opts) {
     const resolved = path.isAbsolute(reportPath) ? reportPath : path.join(cwd, reportPath);
     try {
       fs.writeFileSync(resolved, JSON.stringify(report, null, 2) + '\n', 'utf8');
-    } catch (e) {
+    } catch (e: any) {
       // A report-write failure must not mask the actual doctor result, but we
       // surface it on stderr so CI can notice.
       console.error(`[doctor] failed to write report to ${resolved}: ${e.message}`);

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -10,7 +10,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;
@@ -148,7 +148,7 @@ routes:
       audience: test
       allowed_algorithms: ["HS256"]
 `);
-  } catch (e) {
+  } catch (e: any) {
     caught = e;
   }
   assert.ok(caught, 'expected compile-cloudflare to fail validation');

--- a/src/scripts/cloudflare-waf-parity-unit-tests.ts
+++ b/src/scripts/cloudflare-waf-parity-unit-tests.ts
@@ -28,7 +28,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/src/scripts/compile-cloudflare-waf.ts
+++ b/src/scripts/compile-cloudflare-waf.ts
@@ -49,7 +49,7 @@ function recordParity(entry) {
 let policy;
 try {
   policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-} catch (e) {
+} catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);
     process.exit(1);

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -38,7 +38,7 @@ let policy;
 try {
   const content = fs.readFileSync(policyPath, 'utf8');
   policy = yaml.load(content);
-} catch (e) {
+} catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);
     process.exit(1);
@@ -240,7 +240,7 @@ const templatePath = path.join(repoRoot, 'templates', 'cloudflare', 'index.ts');
 let code;
 try {
   code = fs.readFileSync(templatePath, 'utf8');
-} catch (e) {
+} catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: template not found:', templatePath);
     process.exit(1);

--- a/src/scripts/compile-infra.ts
+++ b/src/scripts/compile-infra.ts
@@ -40,7 +40,7 @@ let policy;
 try {
   const content = fs.readFileSync(policyPath, 'utf8');
   policy = yaml.load(content);
-} catch (e) {
+} catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);
     process.exit(1);

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -24,7 +24,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;
@@ -517,7 +517,7 @@ test('validateAuthGates rejects allowed_algorithms that include an alg the verif
   let caught;
   try {
     validateAuthGates(policy, { exitOnError: false });
-  } catch (e) {
+  } catch (e: any) {
     caught = e;
   }
   assert.ok(caught, 'validateAuthGates should throw');

--- a/src/scripts/doctor-unit-tests.ts
+++ b/src/scripts/doctor-unit-tests.ts
@@ -26,7 +26,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/src/scripts/edge-container-attack-tests.ts
+++ b/src/scripts/edge-container-attack-tests.ts
@@ -195,7 +195,7 @@ async function startAwsEdgeHarness() {
         'x-harness-edge-auth-stripped': String(edgeAuthStripped),
       });
       res.end('origin-ok');
-    } catch (e) {
+    } catch (e: any) {
       res.writeHead(500, { 'content-type': 'text/plain' });
       res.end(e && e.stack ? e.stack : String(e));
     }
@@ -305,7 +305,7 @@ function loadCloudflareWorker() {
   vm.createContext(sandbox);
   try {
     vm.runInContext(compileCloudflareWorker(), sandbox);
-  } catch (e) {
+  } catch (e: any) {
     if (logs.length) {
       console.error('[cloudflare-worker-sandbox] captured logs before crash:');
       for (const [level, msg] of logs) console.error(`  ${level}: ${msg}`);
@@ -349,7 +349,7 @@ async function startCloudflareEdgeHarness() {
       const body = await workerRes.text();
       res.writeHead(workerRes.status, Object.fromEntries(workerRes.headers.entries()));
       res.end(body);
-    } catch (e) {
+    } catch (e: any) {
       res.writeHead(500, { 'content-type': 'text/plain' });
       res.end(e && e.stack ? e.stack : String(e));
     }

--- a/src/scripts/emit-waf-unit-tests.ts
+++ b/src/scripts/emit-waf-unit-tests.ts
@@ -21,7 +21,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/src/scripts/infra-unit-tests.ts
+++ b/src/scripts/infra-unit-tests.ts
@@ -10,7 +10,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -57,7 +57,7 @@ function compileRegexOrThrow(source, context) {
   const { pattern, flags } = extractRegex(source);
   try {
     return new RegExp(pattern, flags);
-  } catch (e) {
+  } catch (e: any) {
     throw new Error(`Invalid regex in ${context}: ${source} — ${e.message}`);
   }
 }
@@ -748,7 +748,7 @@ function main(argv = process.argv.slice(2)) {
 
   try {
     policy = loadPolicy(policyPath);
-  } catch (e) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') {
       console.error('Error: policy file not found:', policyPath);
       process.exit(1);
@@ -770,7 +770,7 @@ function main(argv = process.argv.slice(2)) {
 
   try {
     validateOriginAuth(policy, { strict: strictOriginAuth });
-  } catch (e) {
+  } catch (e: any) {
     process.exit(1);
   }
 
@@ -781,7 +781,7 @@ function main(argv = process.argv.slice(2)) {
     if (allowPlaceholderToken) {
       console.error('[WARN] Built with --allow-placeholder-token. Generated artifacts are NOT safe for production.');
     }
-  } catch (e) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') {
       console.error('Error: template not found:', e.path);
       process.exit(1);

--- a/src/scripts/policy-lint.ts
+++ b/src/scripts/policy-lint.ts
@@ -42,7 +42,7 @@ function main() {
   let policy;
   try {
     policy = loadYaml(policyPath);
-  } catch (e) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') {
       console.error('Error: policy file not found:', policyPath);
       process.exit(1);
@@ -54,7 +54,7 @@ function main() {
   let schema;
   try {
     schema = loadJson(schemaPath);
-  } catch (e) {
+  } catch (e: any) {
     console.error('Error: failed to load schema:', e.message);
     process.exit(1);
   }
@@ -77,7 +77,7 @@ function main() {
     if (block.path_patterns !== undefined) {
       parsePathPatterns(block.path_patterns);
     }
-  } catch (e) {
+  } catch (e: any) {
     errors.push(`  - request.block.path_patterns: ${e.message}`);
   }
 
@@ -85,7 +85,7 @@ function main() {
   // Allow missing token envs at lint time — they are enforced at build time.
   try {
     validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
-  } catch (e) {
+  } catch (e: any) {
     if (Array.isArray(e.validationErrors)) {
       errors.push('Auth gate validation failed:');
       e.validationErrors.forEach((msg) => errors.push('  - ' + msg));

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -26,7 +26,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/src/scripts/regex-fuzz-tests.ts
+++ b/src/scripts/regex-fuzz-tests.ts
@@ -27,7 +27,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;
@@ -62,7 +62,7 @@ function runWithTimeout(regex, input, timeoutMs) {
   const start = Date.now();
   try {
     vm.runInContext('regex.test(input)', ctx, { timeout: timeoutMs });
-  } catch (e) {
+  } catch (e: any) {
     if (/Script execution timed out/i.test(String(e && e.message))) {
       return { ok: false, elapsed: Date.now() - start, timedOut: true };
     }
@@ -95,7 +95,7 @@ function fuzzRegex(patternSource) {
     // (which Node's RegExp does not natively accept) are translated the same
     // way as at compile time.
     compiled = compileRegexOrThrow(patternSource, 'redos-fuzz');
-  } catch (e) {
+  } catch (e: any) {
     return { compile: false, reason: String(e && e.message) };
   }
   for (const input of adversarialInputs()) {
@@ -156,7 +156,7 @@ test('redos-fuzz: runtime timeout triggers on an exponentially backtracking rege
   let timedOut = false;
   try {
     vm.runInContext('regex.test(input)', ctx, { timeout: REDOS_TIMEOUT_MS });
-  } catch (e) {
+  } catch (e: any) {
     if (/Script execution timed out/i.test(String(e && e.message))) timedOut = true;
     else throw e;
   }

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -19,7 +19,7 @@ const viewerRequestPath = path.join(__dirname, '..', 'dist', 'edge', 'viewer-req
 let code;
 try {
   code = fs.readFileSync(viewerRequestPath, 'utf8');
-} catch (e) {
+} catch (e: any) {
   console.error('Could not read dist/edge/viewer-request.js. Run: npm run build');
   process.exit(1);
 }
@@ -236,7 +236,7 @@ function compileViewerTemplate(cfgCode) {
   let vrCode;
   try {
     vrCode = fs.readFileSync(templatePath, 'utf8');
-  } catch (e) {
+  } catch (e: any) {
     console.error('Could not read templates/aws/viewer-request.js');
     return null;
   }
@@ -246,7 +246,7 @@ function compileViewerTemplate(cfgCode) {
   const wrappedCode = '(function() {\n' + vrCode + '\nreturn handler;\n})()';
   try {
     return eval(wrappedCode);
-  } catch (e) {
+  } catch (e: any) {
     console.error('Failed to eval viewer-request template:', e.message);
     return null;
   }
@@ -391,7 +391,7 @@ function compileOriginTemplate(cfgCode) {
   let originCode;
   try {
     originCode = fs.readFileSync(templatePath, 'utf8');
-  } catch (e) {
+  } catch (e: any) {
     console.error('Could not read templates/aws/origin-request.js');
     return null;
   }
@@ -409,7 +409,7 @@ function compileOriginTemplate(cfgCode) {
 
   try {
     return eval(wrappedCode);
-  } catch (e) {
+  } catch (e: any) {
     console.error('Failed to eval origin-request template:', e.message);
     return null;
   }

--- a/src/scripts/schema-lint-tests.ts
+++ b/src/scripts/schema-lint-tests.ts
@@ -19,7 +19,7 @@ function test(name, fn) {
   try {
     fn();
     console.log('OK:', name);
-  } catch (e) {
+  } catch (e: any) {
     console.error('FAIL:', name);
     console.error(e && e.stack ? e.stack : e);
     process.exitCode = 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "strict": true,
     "noImplicitAny": false,
     "strictNullChecks": false,
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
## Summary
- enable TypeScript's useUnknownInCatchVariables option
- preserve existing catch-site behavior by explicitly typing legacy error variables where properties are read
- update the TypeScript migration plan to mark catch unknown handling as enabled

## Verification
- npm run typecheck
- npm run test:api-contract
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all