### PR TITLE
Cover fingerprint candidate generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:policy": "npm run build:ts && node scripts/policy-lint.js",
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
     "test:runtime": "npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
-    "test:unit": "npm run build:ts && node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js",
+    "test:unit": "npm run build:ts && node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js && node scripts/fingerprint-candidates-unit-tests.js",
     "test:drift": "npm run build:ts && node scripts/check-drift.js",
     "test:security-baseline": "npm run build:ts && node scripts/security-baseline-check.js",
     "test:fuzz": "npm run build:ts && node scripts/regex-fuzz-tests.js",

--- a/scripts/fingerprint-candidates-unit-tests.d.ts
+++ b/scripts/fingerprint-candidates-unit-tests.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/scripts/fingerprint-candidates-unit-tests.js
+++ b/scripts/fingerprint-candidates-unit-tests.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+function test(name, fn) {
+    try {
+        fn();
+        console.log('OK:', name);
+    }
+    catch (e) {
+        console.error('FAIL:', name);
+        console.error(e && e.stack ? e.stack : e);
+        process.exitCode = 1;
+    }
+}
+const repoRoot = path.join(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'fingerprint-candidates.js');
+function withJsonl(lines, fn) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fingerprint-candidates-'));
+    const inputPath = path.join(tempDir, 'waf-log.jsonl');
+    fs.writeFileSync(inputPath, lines.join('\n') + '\n', 'utf8');
+    try {
+        return fn(inputPath);
+    }
+    finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+function runCandidates(inputPath, args = []) {
+    const stdout = execFileSync(process.execPath, [scriptPath, '--input', inputPath, ...args], { cwd: repoRoot, encoding: 'utf8' });
+    return JSON.parse(stdout);
+}
+test('fingerprint-candidates aggregates nested and top-level JA3/JA4 values', () => {
+    withJsonl([
+        JSON.stringify({ httpRequest: { ja3Fingerprint: 'ja3-a', ja4Fingerprint: 'ja4-a' } }),
+        JSON.stringify({ httpRequest: { ja3Fingerprint: 'ja3-a', ja4Fingerprint: 'ja4-a' } }),
+        JSON.stringify({ ja3Fingerprint: 'ja3-b', ja4Fingerprint: 'ja4-b' }),
+        JSON.stringify({ ja3: 'ja3-b', ja4: 'ja4-b' }),
+        'not-json',
+    ], (inputPath) => {
+        const result = runCandidates(inputPath, ['--min-count', '2', '--top', '10']);
+        assert.strictEqual(result.min_count, 2);
+        assert.strictEqual(result.top, 10);
+        assert.deepStrictEqual(result.ja3_candidates, [
+            { fingerprint: 'ja3-a', count: 2 },
+            { fingerprint: 'ja3-b', count: 2 },
+        ]);
+        assert.deepStrictEqual(result.ja4_candidates, [
+            { fingerprint: 'ja4-a', count: 2 },
+            { fingerprint: 'ja4-b', count: 2 },
+        ]);
+        assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja3_fingerprints, ['ja3-a', 'ja3-b']);
+        assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja4_fingerprints, ['ja4-a', 'ja4-b']);
+    });
+});
+test('fingerprint-candidates applies min-count and top limits', () => {
+    withJsonl([
+        JSON.stringify({ ja3: 'high', ja4: 'one' }),
+        JSON.stringify({ ja3: 'high', ja4: 'one' }),
+        JSON.stringify({ ja3: 'high', ja4: 'two' }),
+        JSON.stringify({ ja3: 'medium', ja4: 'two' }),
+        JSON.stringify({ ja3: 'medium', ja4: 'two' }),
+        JSON.stringify({ ja3: 'low', ja4: 'three' }),
+    ], (inputPath) => {
+        const result = runCandidates(inputPath, ['--min-count', '2', '--top', '1']);
+        assert.deepStrictEqual(result.ja3_candidates, [{ fingerprint: 'high', count: 3 }]);
+        assert.deepStrictEqual(result.ja4_candidates, [{ fingerprint: 'two', count: 3 }]);
+        assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja3_fingerprints, ['high']);
+        assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja4_fingerprints, ['two']);
+    });
+});
+test('fingerprint-candidates prints usage and exits non-zero without input', () => {
+    assert.throws(() => execFileSync(process.execPath, [scriptPath], { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' }), (err) => {
+        assert.strictEqual(err.status, 1);
+        assert.match(String(err.stderr), /Usage: node scripts\/fingerprint-candidates\.js --input/);
+        return true;
+    });
+});

--- a/src/scripts/fingerprint-candidates-unit-tests.ts
+++ b/src/scripts/fingerprint-candidates-unit-tests.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('OK:', name);
+  } catch (e: any) {
+    console.error('FAIL:', name);
+    console.error(e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  }
+}
+
+const repoRoot = path.join(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'fingerprint-candidates.js');
+
+function withJsonl(lines, fn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fingerprint-candidates-'));
+  const inputPath = path.join(tempDir, 'waf-log.jsonl');
+  fs.writeFileSync(inputPath, lines.join('\n') + '\n', 'utf8');
+  try {
+    return fn(inputPath);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runCandidates(inputPath, args = []) {
+  const stdout = execFileSync(
+    process.execPath,
+    [scriptPath, '--input', inputPath, ...args],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  return JSON.parse(stdout);
+}
+
+test('fingerprint-candidates aggregates nested and top-level JA3/JA4 values', () => {
+  withJsonl([
+    JSON.stringify({ httpRequest: { ja3Fingerprint: 'ja3-a', ja4Fingerprint: 'ja4-a' } }),
+    JSON.stringify({ httpRequest: { ja3Fingerprint: 'ja3-a', ja4Fingerprint: 'ja4-a' } }),
+    JSON.stringify({ ja3Fingerprint: 'ja3-b', ja4Fingerprint: 'ja4-b' }),
+    JSON.stringify({ ja3: 'ja3-b', ja4: 'ja4-b' }),
+    'not-json',
+  ], (inputPath) => {
+    const result = runCandidates(inputPath, ['--min-count', '2', '--top', '10']);
+
+    assert.strictEqual(result.min_count, 2);
+    assert.strictEqual(result.top, 10);
+    assert.deepStrictEqual(result.ja3_candidates, [
+      { fingerprint: 'ja3-a', count: 2 },
+      { fingerprint: 'ja3-b', count: 2 },
+    ]);
+    assert.deepStrictEqual(result.ja4_candidates, [
+      { fingerprint: 'ja4-a', count: 2 },
+      { fingerprint: 'ja4-b', count: 2 },
+    ]);
+    assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja3_fingerprints, ['ja3-a', 'ja3-b']);
+    assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja4_fingerprints, ['ja4-a', 'ja4-b']);
+  });
+});
+
+test('fingerprint-candidates applies min-count and top limits', () => {
+  withJsonl([
+    JSON.stringify({ ja3: 'high', ja4: 'one' }),
+    JSON.stringify({ ja3: 'high', ja4: 'one' }),
+    JSON.stringify({ ja3: 'high', ja4: 'two' }),
+    JSON.stringify({ ja3: 'medium', ja4: 'two' }),
+    JSON.stringify({ ja3: 'medium', ja4: 'two' }),
+    JSON.stringify({ ja3: 'low', ja4: 'three' }),
+  ], (inputPath) => {
+    const result = runCandidates(inputPath, ['--min-count', '2', '--top', '1']);
+
+    assert.deepStrictEqual(result.ja3_candidates, [{ fingerprint: 'high', count: 3 }]);
+    assert.deepStrictEqual(result.ja4_candidates, [{ fingerprint: 'two', count: 3 }]);
+    assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja3_fingerprints, ['high']);
+    assert.deepStrictEqual(result.recommended_policy_patch.firewall.waf.ja4_fingerprints, ['two']);
+  });
+});
+
+test('fingerprint-candidates prints usage and exits non-zero without input', () => {
+  assert.throws(
+    () => execFileSync(process.execPath, [scriptPath], { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' }),
+    (err) => {
+      assert.strictEqual(err.status, 1);
+      assert.match(String(err.stderr), /Usage: node scripts\/fingerprint-candidates\.js --input/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add unit coverage for scripts/fingerprint-candidates.js
- verify nested and top-level JA3/JA4 aggregation, min-count/top filtering, recommended policy patch output, and missing-input usage handling
- include the new test in npm run test:unit

## Verification
- npm run typecheck
- node scripts/fingerprint-candidates-unit-tests.js
- npm run test:unit
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all