### PR TITLE
Tighten public API TypeScript checks

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -53,7 +53,7 @@ function listInfraArtifacts(outDir) {
         .filter((name) => name.endsWith('.tf.json'))
         .map((name) => path.join(infraDir, name));
 }
-function compile(opts) {
+function compile(opts = {}) {
     opts = opts || {};
     const cwd = opts.cwd || process.cwd();
     const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;

--- a/lib/emit-waf.js
+++ b/lib/emit-waf.js
@@ -43,7 +43,7 @@ function listInfraArtifacts(outDir) {
         .filter((name) => name.endsWith('.tf.json'))
         .map((name) => path.join(infraDir, name));
 }
-function emitWaf(opts) {
+function emitWaf(opts = {}) {
     opts = opts || {};
     const cwd = opts.cwd || process.cwd();
     const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -31,7 +31,7 @@ function formatAjvErrors(errors) {
         return `  - ${loc} ${err.message}${key}`;
     });
 }
-function lintPolicy(opts) {
+function lintPolicy(opts = {}) {
     opts = opts || {};
     const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
     const policyPath = opts.policyPath;

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -33,7 +33,7 @@ const yaml = require('js-yaml');
 function resolveAbsolute(inputPath, cwd) {
     return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
-function migratePolicy(opts) {
+function migratePolicy(opts = {}) {
     opts = opts || {};
     const cwd = opts.cwd || process.cwd();
     const toVersionRaw = opts.toVersion === undefined ? 1 : opts.toVersion;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build:ts": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:lib-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks false --useUnknownInCatchVariables true src/lib/*.ts",
     "build": "npm run build:ts && node scripts/compile.js",
     "lint:policy": "npm run build:ts && node scripts/policy-lint.js",
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
@@ -20,7 +21,7 @@
     "test:cloudflare-integration": "npm run build:ts && node scripts/cloudflare-integration-tests.js",
     "test:edge-container": "npm run build:ts && node scripts/edge-container-attack-tests.js",
     "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
-    "test:all": "npm run build && npm run test:api-contract && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
+    "test:all": "npm run build && npm run typecheck:lib-strict && npm run test:api-contract && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
     "fingerprints:candidates": "npm run build:ts && node scripts/fingerprint-candidates.js"
   },
   "keywords": [

--- a/src/lib/compile.ts
+++ b/src/lib/compile.ts
@@ -44,28 +44,51 @@ const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 const AWS_EDGE_FILES = ['viewer-request.js', 'viewer-response.js', 'origin-request.js'];
 const CF_EDGE_FILES = [path.join('cloudflare', 'index.ts')];
 
-function resolveAbsolute(inputPath, cwd) {
+type CompileTarget = 'aws' | 'cloudflare';
+
+interface CompileOptions {
+  policyPath?: string;
+  outDir?: string;
+  target?: CompileTarget;
+  failOnPermissive?: boolean;
+  failOnWafApproximation?: boolean;
+  outputMode?: string;
+  ruleGroupOnly?: boolean;
+  cwd?: string;
+  pkgRoot?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface CompileResultBase {
+  edgeFiles: string[];
+  infraFiles: string[];
+  policyPath: string | null;
+  outDir: string | null;
+  target: string;
+}
+
+function resolveAbsolute(inputPath: string, cwd: string): string {
   return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
 
-function listInfraArtifacts(outDir) {
+function listInfraArtifacts(outDir: string): string[] {
   const infraDir = path.join(outDir, 'infra');
   if (!fs.existsSync(infraDir)) return [];
   return fs
     .readdirSync(infraDir)
-    .filter((name) => name.endsWith('.tf.json'))
-    .map((name) => path.join(infraDir, name));
+    .filter((name: string) => name.endsWith('.tf.json'))
+    .map((name: string) => path.join(infraDir, name));
 }
 
-function compile(opts) {
+function compile(opts: CompileOptions = {}) {
   opts = opts || {};
   const cwd = opts.cwd || process.cwd();
   const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
   const env = opts.env || process.env;
 
-  const errors = [];
-  const warnings = [];
-  const baseResult = {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const baseResult: CompileResultBase = {
     edgeFiles: [],
     infraFiles: [],
     policyPath: null,

--- a/src/lib/emit-waf.ts
+++ b/src/lib/emit-waf.ts
@@ -33,20 +33,46 @@ const { lintPolicy } = require('./lint');
 
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 
-function resolveAbsolute(inputPath, cwd) {
+type EmitWafTarget = 'aws' | 'cloudflare';
+type EmitWafFormat = 'terraform' | 'cloudformation' | 'cdk';
+
+interface EmitWafOptions {
+  policyPath?: string;
+  outDir?: string;
+  target?: EmitWafTarget;
+  format?: EmitWafFormat;
+  outputMode?: string;
+  ruleGroupOnly?: boolean;
+  failOnWafApproximation?: boolean;
+  cwd?: string;
+  pkgRoot?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface EmitWafResultBase {
+  edgeFiles: string[];
+  infraFiles: string[];
+  policyPath: string | null;
+  outDir: string | null;
+  target: string;
+  format: string;
+  formatNotImplemented: boolean;
+}
+
+function resolveAbsolute(inputPath: string, cwd: string): string {
   return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
 
-function listInfraArtifacts(outDir) {
+function listInfraArtifacts(outDir: string): string[] {
   const infraDir = path.join(outDir, 'infra');
   if (!fs.existsSync(infraDir)) return [];
   return fs
     .readdirSync(infraDir)
-    .filter((name) => name.endsWith('.tf.json'))
-    .map((name) => path.join(infraDir, name));
+    .filter((name: string) => name.endsWith('.tf.json'))
+    .map((name: string) => path.join(infraDir, name));
 }
 
-function emitWaf(opts) {
+function emitWaf(opts: EmitWafOptions = {}) {
   opts = opts || {};
   const cwd = opts.cwd || process.cwd();
   const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
@@ -54,9 +80,9 @@ function emitWaf(opts) {
   const format = opts.format || 'terraform';
   const target = opts.target || 'aws';
 
-  const errors = [];
-  const warnings = [];
-  const baseResult = {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const baseResult: EmitWafResultBase = {
     edgeFiles: [],
     infraFiles: [],
     policyPath: null,

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -27,7 +27,7 @@ const {
 
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 
-function formatAjvErrors(errors) {
+function formatAjvErrors(errors: any[]): string[] {
   return errors.map((err) => {
     const loc = err.instancePath || '(root)';
     const key =
@@ -38,14 +38,14 @@ function formatAjvErrors(errors) {
   });
 }
 
-function lintPolicy(opts) {
+function lintPolicy(opts: any = {}) {
   opts = opts || {};
   const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
   const policyPath = opts.policyPath;
   const env = opts.env || process.env;
 
-  const errors = [];
-  const warnings = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
 
   if (!policyPath) {
     return {
@@ -56,7 +56,7 @@ function lintPolicy(opts) {
     };
   }
 
-  let policy = null;
+  let policy: any = null;
   try {
     policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
   } catch (e: any) {
@@ -76,7 +76,7 @@ function lintPolicy(opts) {
     };
   }
 
-  let schema;
+  let schema: any;
   try {
     schema = JSON.parse(
       fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'),
@@ -119,7 +119,7 @@ function lintPolicy(opts) {
   } catch (e: any) {
     if (Array.isArray(e.validationErrors)) {
       errors.push('Auth gate validation failed:');
-      e.validationErrors.forEach((msg) => errors.push('  - ' + msg));
+      e.validationErrors.forEach((msg: string) => errors.push('  - ' + msg));
     } else {
       errors.push('Auth gate validation error: ' + e.message);
     }
@@ -141,7 +141,7 @@ function lintPolicy(opts) {
   if (isEnforce && hasWaf) {
     const managed = Array.isArray(waf.managed_rules) ? waf.managed_rules : [];
     const hasCoreSignal = managed.some(
-      (r) =>
+      (r: string) =>
         r === 'AWSManagedRulesBotControlRuleSet' ||
         r === 'AWSManagedRulesATPRuleSet' ||
         r === 'AWSManagedRulesIPReputationList' ||

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -30,17 +30,23 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-function resolveAbsolute(inputPath, cwd) {
+interface MigratePolicyOptions {
+  policyPath?: string;
+  toVersion?: number | string;
+  cwd?: string;
+}
+
+function resolveAbsolute(inputPath: string, cwd: string): string {
   return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
 
-function migratePolicy(opts) {
+function migratePolicy(opts: MigratePolicyOptions = {}) {
   opts = opts || {};
   const cwd = opts.cwd || process.cwd();
   const toVersionRaw = opts.toVersion === undefined ? 1 : opts.toVersion;
   const toVersion = Number(toVersionRaw);
 
-  const warnings = [];
+  const warnings: string[] = [];
 
   if (!opts.policyPath) {
     return {
@@ -79,7 +85,7 @@ function migratePolicy(opts) {
     };
   }
 
-  let doc;
+  let doc: any;
   try {
     doc = yaml.load(fs.readFileSync(policyPath, 'utf8'));
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- add explicit option/result typing for the public programmatic API modules under src/lib
- add typecheck:lib-strict to enforce noImplicitAny for src/lib/*.ts
- include the stricter public API check in test:all

## Verification
- npm run typecheck
- npm run typecheck:lib-strict
- npm run test:api-contract
- npm run test:unit
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all