### PR TITLE
Tighten unit test TypeScript checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:lib-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks false --useUnknownInCatchVariables true src/lib/*.ts",
     "typecheck:scripts-lib-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks false --useUnknownInCatchVariables true src/scripts/lib/*.ts",
+    "typecheck:unit-tests-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks false --useUnknownInCatchVariables true src/scripts/*-unit-tests.ts",
     "build": "npm run build:ts && node scripts/compile.js",
     "lint:policy": "npm run build:ts && node scripts/policy-lint.js",
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
@@ -22,7 +23,7 @@
     "test:cloudflare-integration": "npm run build:ts && node scripts/cloudflare-integration-tests.js",
     "test:edge-container": "npm run build:ts && node scripts/edge-container-attack-tests.js",
     "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
-    "test:all": "npm run build && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run test:api-contract && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
+    "test:all": "npm run build && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run typecheck:unit-tests-strict && npm run test:api-contract && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
     "fingerprints:candidates": "npm run build:ts && node scripts/fingerprint-candidates.js"
   },
   "keywords": [

--- a/src/scripts/cloudflare-waf-parity-unit-tests.ts
+++ b/src/scripts/cloudflare-waf-parity-unit-tests.ts
@@ -24,7 +24,7 @@ const parityLib = require(path.join(repoRoot, 'scripts', 'lib', 'cloudflare-waf-
 const generator = require(path.join(repoRoot, 'scripts', 'generate-parity-doc'));
 const compilerPath = path.join(repoRoot, 'scripts', 'compile-cloudflare-waf.js');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -35,7 +35,7 @@ function test(name, fn) {
   }
 }
 
-function tmpProject(policy) {
+function tmpProject(policy: string) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-parity-'));
   const policyPath = path.join(dir, 'policy.yml');
   fs.writeFileSync(policyPath, policy, 'utf8');
@@ -46,7 +46,7 @@ function tmpProject(policy) {
   };
 }
 
-function runCompiler(policyPath, outDir, extraArgs = []) {
+function runCompiler(policyPath: string, outDir: string, extraArgs: string[] = []) {
   return spawnSync(
     process.execPath,
     [compilerPath, '--policy', policyPath, '--out-dir', outDir, ...extraArgs],
@@ -220,7 +220,7 @@ test('compiler: unknown AWS managed rule treated as unsupported (disabled, warne
     assert.ok(/UNSUPPORTED: AWSManagedRulesTotallyFake/.test(r.stderr));
     const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
     const managed = tf.resource.cloudflare_ruleset['parity-unit_managed'];
-    const rule = managed.rules.find((r) => /Fake/.test(r.description));
+    const rule = managed.rules.find((r: any) => /Fake/.test(r.description));
     assert.ok(rule, 'expected managed rule emitted');
     assert.strictEqual(rule.enabled, false);
   } finally {
@@ -237,7 +237,7 @@ test('compiler: untranslated scope_down emits parity warning and degrades expres
     assert.ok(/match-all/.test(r.stderr));
     const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
     const rl = tf.resource.cloudflare_ruleset['parity-unit_ratelimit'];
-    const rule = rl.rules.find((r) => r.description === 'exact-match');
+    const rule = rl.rules.find((r: any) => r.description === 'exact-match');
     assert.strictEqual(rule.expression, 'true');
   } finally {
     ctx.cleanup();
@@ -254,7 +254,7 @@ test('compiler: expression_cloudflare override suppresses the scope_down warning
     assert.ok(!/scope_down_statement.*match-all/.test(r.stderr), `unexpected warning: ${r.stderr}`);
     const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
     const rl = tf.resource.cloudflare_ruleset['parity-unit_ratelimit'];
-    const rule = rl.rules.find((r) => r.description === 'exact-match');
+    const rule = rl.rules.find((r: any) => r.description === 'exact-match');
     assert.strictEqual(rule.expression, 'http.request.uri.path eq "/login"');
   } finally {
     ctx.cleanup();

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -20,7 +20,7 @@ const {
   validateOriginAuth,
 } = require('./lib/compile-core');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -31,7 +31,7 @@ function test(name, fn) {
   }
 }
 
-function withEnv(key, value, fn) {
+function withEnv(key: string, value: string | undefined, fn: () => void) {
   const prev = process.env[key];
   if (value === undefined) {
     delete process.env[key];
@@ -62,7 +62,7 @@ test('parsePathPatterns expands known legacy regex entries as contains (lowercas
   assert.ok(contains.includes('..'));
   assert.ok(contains.includes('%2e%2e'));
   // Runtime lowercases the URI before `includes()`, so we only need the lower form.
-  assert.ok(contains.every((c) => c === c.toLowerCase()));
+  assert.ok(contains.every((c: string) => c === c.toLowerCase()));
   assert.deepStrictEqual(regexSources, []);
 });
 
@@ -150,7 +150,7 @@ test('parsePathPatterns lowercases contains entries so uppercase policy survives
 
   const fromLegacy = parsePathPatterns(['/INTERNAL/', '(?i)\\.{2}/']);
   assert.ok(fromLegacy.contains.includes('/internal/'), 'plain upper entry normalized');
-  assert.ok(fromLegacy.contains.every((c) => c === c.toLowerCase()), 'mapped entries normalized');
+  assert.ok(fromLegacy.contains.every((c: string) => c === c.toLowerCase()), 'mapped entries normalized');
 });
 
 test('regexesLiteralCode emits real RegExp literals with flags', () => {
@@ -284,11 +284,11 @@ test('validateAuthGates reports missing required auth fields', () => {
 
   assert.throws(
     () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
-    (err) => Array.isArray(err.validationErrors)
+    (err: any) => Array.isArray(err.validationErrors)
       && err.validationErrors.length === 3
-      && err.validationErrors.some((e) => e.includes('broken-rs'))
-      && err.validationErrors.some((e) => e.includes('broken-hs'))
-      && err.validationErrors.some((e) => e.includes('broken-signed')),
+      && err.validationErrors.some((e: string) => e.includes('broken-rs'))
+      && err.validationErrors.some((e: string) => e.includes('broken-hs'))
+      && err.validationErrors.some((e: string) => e.includes('broken-signed')),
   );
 });
 
@@ -300,8 +300,8 @@ test('validateAuthGates reports missing static_token env at build time', () => {
 
     assert.throws(
       () => validateAuthGates(policy, { exitOnError: false }),
-      (err) => Array.isArray(err.validationErrors)
-        && err.validationErrors.some((e) => e.includes('EDGE_ADMIN_TOKEN')),
+      (err: any) => Array.isArray(err.validationErrors)
+        && err.validationErrors.some((e: string) => e.includes('EDGE_ADMIN_TOKEN')),
     );
   });
 });
@@ -594,8 +594,8 @@ test('hasFailOnPermissiveFlag detects the flag', () => {
 });
 
 test('warnIfPermissive returns no-op when metadata.risk_level is not permissive', () => {
-  const captured = [];
-  const logger = { error: (msg) => captured.push(msg) };
+  const captured: string[] = [];
+  const logger = { error: (msg: string) => captured.push(msg) };
   const r1 = warnIfPermissive({}, { logger });
   const r2 = warnIfPermissive({ metadata: { risk_level: 'strict' } }, { logger });
   const r3 = warnIfPermissive({ metadata: { risk_level: 'balanced' } }, { logger });
@@ -608,8 +608,8 @@ test('warnIfPermissive returns no-op when metadata.risk_level is not permissive'
 });
 
 test('warnIfPermissive warns but does not fail when failOnPermissive is false', () => {
-  const captured = [];
-  const logger = { error: (msg) => captured.push(msg) };
+  const captured: string[] = [];
+  const logger = { error: (msg: string) => captured.push(msg) };
   const result: any = warnIfPermissive({ metadata: { risk_level: 'permissive' } }, { logger });
   assert.deepStrictEqual(result, { warned: true, failed: false });
   assert.strictEqual(captured.length, 1);
@@ -618,8 +618,8 @@ test('warnIfPermissive warns but does not fail when failOnPermissive is false', 
 });
 
 test('warnIfPermissive fails when failOnPermissive is true', () => {
-  const captured = [];
-  const logger = { error: (msg) => captured.push(msg) };
+  const captured: string[] = [];
+  const logger = { error: (msg: string) => captured.push(msg) };
   const result: any = warnIfPermissive(
     { metadata: { risk_level: 'permissive' } },
     { logger, failOnPermissive: true },
@@ -695,8 +695,8 @@ test('validateAuthGates rejects jwks_url in private/loopback ranges', () => {
   };
   assert.throws(
     () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
-    (err) => Array.isArray(err.validationErrors)
-      && err.validationErrors.some((e) => /metadata-ssrf/.test(e) && /private\/loopback/.test(e)),
+    (err: any) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e: string) => /metadata-ssrf/.test(e) && /private\/loopback/.test(e)),
   );
 });
 
@@ -712,8 +712,8 @@ test('validateAuthGates rejects jwks_url outside firewall.jwks.allowed_hosts', (
   };
   assert.throws(
     () => validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true }),
-    (err) => Array.isArray(err.validationErrors)
-      && err.validationErrors.some((e) => /wrong-idp/.test(e) && /allowed_hosts/.test(e)),
+    (err: any) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e: string) => /wrong-idp/.test(e) && /allowed_hosts/.test(e)),
   );
 });
 
@@ -731,8 +731,8 @@ test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', (
 });
 
 test('warnSignedUrlReplay flags write-like signed_url gates missing nonce_param', () => {
-  const captured = [];
-  const logger = { error: (m) => captured.push(m) };
+  const captured: string[] = [];
+  const logger = { error: (m: string) => captured.push(m) };
   const policy = {
     routes: [
       {
@@ -750,8 +750,8 @@ test('warnSignedUrlReplay flags write-like signed_url gates missing nonce_param'
 });
 
 test('warnSignedUrlReplay stays silent for read-only paths', () => {
-  const captured = [];
-  const logger = { error: (m) => captured.push(m) };
+  const captured: string[] = [];
+  const logger = { error: (m: string) => captured.push(m) };
   const policy = {
     routes: [
       {
@@ -767,8 +767,8 @@ test('warnSignedUrlReplay stays silent for read-only paths', () => {
 });
 
 test('warnSignedUrlReplay stays silent when nonce_param is set', () => {
-  const captured = [];
-  const logger = { error: (m) => captured.push(m) };
+  const captured: string[] = [];
+  const logger = { error: (m: string) => captured.push(m) };
   const policy = {
     routes: [
       {
@@ -1049,7 +1049,7 @@ test('response_headers: emits COOP/COEP/CORP/Reporting-Endpoints when configured
         corp: 'same-origin',
         reporting_endpoints: 'csp="https://r.example.com/csp"',
       },
-      routes: [],
+      routes: [] as any[],
     };
     build(policy, { outDir: tmpDir, allowPlaceholderToken: true });
     const resp = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
@@ -1073,7 +1073,7 @@ test('response_headers: csp_nonce=true emits substitution hook and Report-Only c
         csp_public: "default-src 'self'; script-src 'self' 'nonce-PLACEHOLDER'",
         csp_report_only: "default-src 'self'; report-to csp",
       },
-      routes: [],
+      routes: [] as any[],
     };
     build(policy, { outDir: tmpDir, allowPlaceholderToken: true });
     const resp = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
@@ -1090,7 +1090,7 @@ test('response_headers: csp_nonce=true emits substitution hook and Report-Only c
 test('request.limits.max_header_count defaults to 64 and is clamped to 1..500', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-hc-'));
   try {
-    const base = { version: 1, request: { allow_methods: ['GET'] }, response_headers: {}, routes: [] };
+    const base = { version: 1, request: { allow_methods: ['GET'] }, response_headers: {}, routes: [] as any[] };
 
     // Default
     build(base, { outDir: tmpDir, allowPlaceholderToken: true });
@@ -1274,9 +1274,9 @@ test('viewer-request: structured JSON block log includes status, block_reason, u
     }, { outDir: tmpDir, allowPlaceholderToken: true });
     const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-request.js'), 'utf8');
 
-    const captured = [];
+    const captured: string[] = [];
     const origLog = console.log;
-    console.log = (line) => { captured.push(String(line)); };
+    console.log = (line: any) => { captured.push(String(line)); };
     let handler;
     try {
       // Evaluate compiled CFF function and capture its handler.
@@ -1288,7 +1288,7 @@ test('viewer-request: structured JSON block log includes status, block_reason, u
       console.log = origLog;
     }
 
-    const jsonLine = captured.find((l) => l.indexOf('"event":"block"') !== -1);
+    const jsonLine = captured.find((l: string) => l.indexOf('"event":"block"') !== -1);
     assert.ok(jsonLine, 'expected a block JSON log; got: ' + captured.join('\n'));
     const parsed = JSON.parse(jsonLine);
     assert.strictEqual(parsed.event, 'block');
@@ -1304,12 +1304,12 @@ test('viewer-request: structured JSON block log includes status, block_reason, u
 
 test('validateOriginAuth warns when secret_env is unset (non-strict)', () => {
   const policy = { origin: { auth: { type: 'custom_header', header: 'X-Origin-Verify', secret_env: 'NONEXISTENT_FOR_TEST' } } };
-  const warnings = [];
-  const logger = { warn: (s) => warnings.push(String(s)), error: () => {} };
+  const warnings: string[] = [];
+  const logger = { warn: (s: string) => warnings.push(String(s)), error: () => {} };
   const result: any = validateOriginAuth(policy, { env: {}, strict: false, logger });
   assert.strictEqual(result.errors.length, 0);
-  assert.ok(result.warnings.some((w) => /NONEXISTENT_FOR_TEST/.test(w)));
-  assert.ok(warnings.some((w) => /origin-auth/.test(w)));
+  assert.ok(result.warnings.some((w: string) => /NONEXISTENT_FOR_TEST/.test(w)));
+  assert.ok(warnings.some((w: string) => /origin-auth/.test(w)));
 });
 
 test('validateOriginAuth errors in strict mode when secret_env is unset', () => {

--- a/src/scripts/doctor-unit-tests.ts
+++ b/src/scripts/doctor-unit-tests.ts
@@ -22,7 +22,7 @@ const {
   SCHEMA_CURRENT_VERSION,
 } = require('./cli-doctor.js');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -200,7 +200,7 @@ test('checkSchemaVersion: skip on null policyDoc', () => {
 // ---- checkEnvVars --------------------------------------------------------
 
 test('checkEnvVars: pass when policy references no env vars', () => {
-  const env = () => undefined;
+  const env = (): undefined => undefined;
   const r = checkEnvVars({ routes: [] }, env);
   assert.strictEqual(r.status, 'pass');
 });
@@ -209,7 +209,7 @@ test('checkEnvVars: fail when referenced env is missing', () => {
   const doc = {
     routes: [{ name: 'a', match: {}, auth_gate: { type: 'static_token', token_env: 'EDGE_ADMIN_TOKEN' } }],
   };
-  const r = checkEnvVars(doc, () => undefined);
+  const r = checkEnvVars(doc, (): undefined => undefined);
   assert.strictEqual(r.status, 'fail');
   assert.deepStrictEqual(r.missing, ['EDGE_ADMIN_TOKEN']);
 });
@@ -218,7 +218,7 @@ test('checkEnvVars: fail when referenced env is empty string', () => {
   const doc = {
     routes: [{ name: 'a', match: {}, auth_gate: { type: 'static_token', token_env: 'EDGE_ADMIN_TOKEN' } }],
   };
-  const r = checkEnvVars(doc, (name) => (name === 'EDGE_ADMIN_TOKEN' ? '' : undefined));
+  const r = checkEnvVars(doc, (name: string) => (name === 'EDGE_ADMIN_TOKEN' ? '' : undefined));
   assert.strictEqual(r.status, 'fail');
 });
 
@@ -227,7 +227,7 @@ test('checkEnvVars: pass when all referenced env vars are set', () => {
     routes: [{ name: 'a', match: {}, auth_gate: { type: 'jwt', algorithm: 'HS256', secret_env: 'JWT_SECRET' } }],
     origin: { auth: { type: 'custom_header', header: 'X', secret_env: 'ORIGIN_SECRET' } },
   };
-  const env = (name) => ({ JWT_SECRET: 'x', ORIGIN_SECRET: 'y' }[name]);
+  const env = (name: string) => ({ JWT_SECRET: 'x', ORIGIN_SECRET: 'y' } as Record<string, string>)[name];
   const r = checkEnvVars(doc, env);
   assert.strictEqual(r.status, 'pass');
   assert.deepStrictEqual(r.missing, []);
@@ -253,24 +253,24 @@ test('checkDistWritable: pass when cwd is writable', () => {
 // ---- checkDependencies ---------------------------------------------------
 
 test('checkDependencies: pass when npm ls has no problems', () => {
-  const fakeSpawn = () => ({ stdout: JSON.stringify({ problems: [] }) });
+  const fakeSpawn = (): { stdout: string } => ({ stdout: JSON.stringify({ problems: [] }) });
   assert.strictEqual(checkDependencies('/tmp', fakeSpawn).status, 'pass');
 });
 
 test('checkDependencies: fail when npm ls reports problems', () => {
-  const fakeSpawn = () => ({
+  const fakeSpawn = (): { stdout: string } => ({
     stdout: JSON.stringify({ problems: ['missing: ajv@^8.0.0, required by cdn-security-framework@1.0.0'] }),
   });
   assert.strictEqual(checkDependencies('/tmp', fakeSpawn).status, 'fail');
 });
 
 test('checkDependencies: warn when npm is absent / empty stdout', () => {
-  const fakeSpawn = () => ({ stdout: '' });
+  const fakeSpawn = (): { stdout: string } => ({ stdout: '' });
   assert.strictEqual(checkDependencies('/tmp', fakeSpawn).status, 'warn');
 });
 
 test('checkDependencies: warn when npm output is not valid JSON', () => {
-  const fakeSpawn = () => ({ stdout: 'not json' });
+  const fakeSpawn = (): { stdout: string } => ({ stdout: 'not json' });
   assert.strictEqual(checkDependencies('/tmp', fakeSpawn).status, 'warn');
 });
 
@@ -332,14 +332,14 @@ routes:
   const result: any = runDoctor({
     cwd: tmp,
     pkgRoot: repoRoot,
-    envProvider: (n) => (n === 'ADMIN_TOKEN_FOR_TEST' ? 'ci-test' : undefined),
-    spawnSync: () => ({ stdout: JSON.stringify({ problems: [] }) }),
+    envProvider: (n: string) => (n === 'ADMIN_TOKEN_FOR_TEST' ? 'ci-test' : undefined),
+    spawnSync: (): { stdout: string } => ({ stdout: JSON.stringify({ problems: [] }) }),
     log: false,
     reportPath: 'doctor-report.json',
   });
   try {
     assert.strictEqual(result.exitCode, 0);
-    const envCheck = result.report.checks.find((c) => c.name === 'env_vars_referenced_by_policy');
+    const envCheck = result.report.checks.find((c: any) => c.name === 'env_vars_referenced_by_policy');
     assert.strictEqual(envCheck.status, 'pass');
     const written = JSON.parse(fs.readFileSync(path.join(tmp, 'doctor-report.json'), 'utf8'));
     assert.strictEqual(written.exitCode, 0);
@@ -365,14 +365,14 @@ routes:
   const result: any = runDoctor({
     cwd: tmp,
     pkgRoot: repoRoot,
-    envProvider: () => undefined,
-    spawnSync: () => ({ stdout: JSON.stringify({ problems: [] }) }),
+    envProvider: (): undefined => undefined,
+    spawnSync: (): { stdout: string } => ({ stdout: JSON.stringify({ problems: [] }) }),
     log: false,
     reportPath: null,
   });
   try {
     assert.strictEqual(result.exitCode, 1);
-    const envCheck = result.report.checks.find((c) => c.name === 'env_vars_referenced_by_policy');
+    const envCheck = result.report.checks.find((c: any) => c.name === 'env_vars_referenced_by_policy');
     assert.strictEqual(envCheck.status, 'fail');
     assert.deepStrictEqual(envCheck.missing, ['MISSING_JWT_SECRET_XYZ']);
   } finally {
@@ -385,16 +385,16 @@ test('runDoctor: fails when policy is missing', () => {
   const result: any = runDoctor({
     cwd: tmp,
     pkgRoot: repoRoot,
-    envProvider: () => undefined,
-    spawnSync: () => ({ stdout: JSON.stringify({ problems: [] }) }),
+    envProvider: (): undefined => undefined,
+    spawnSync: (): { stdout: string } => ({ stdout: JSON.stringify({ problems: [] }) }),
     log: false,
     reportPath: null,
   });
   try {
     assert.strictEqual(result.exitCode, 1);
-    const existsCheck = result.report.checks.find((c) => c.name === 'policy_exists');
+    const existsCheck = result.report.checks.find((c: any) => c.name === 'policy_exists');
     assert.strictEqual(existsCheck.status, 'fail');
-    const parseCheck = result.report.checks.find((c) => c.name === 'policy_parses');
+    const parseCheck = result.report.checks.find((c: any) => c.name === 'policy_parses');
     assert.strictEqual(parseCheck.status, 'skip');
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
@@ -408,8 +408,8 @@ test('runDoctor: reportPath: null skips file write', () => {
   const result: any = runDoctor({
     cwd: tmp,
     pkgRoot: repoRoot,
-    envProvider: () => undefined,
-    spawnSync: () => ({ stdout: JSON.stringify({ problems: [] }) }),
+    envProvider: (): undefined => undefined,
+    spawnSync: (): { stdout: string } => ({ stdout: JSON.stringify({ problems: [] }) }),
     log: false,
     reportPath: null,
   });

--- a/src/scripts/emit-waf-unit-tests.ts
+++ b/src/scripts/emit-waf-unit-tests.ts
@@ -17,7 +17,7 @@ const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -59,7 +59,7 @@ firewall:
     rate_limit: 1000
 `;
 
-function runEmitWaf(policyYaml, extraArgs) {
+function runEmitWaf(policyYaml: string, extraArgs: string[]) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emit-waf-'));
   const policyDir = path.join(tmp, 'policy');
   fs.mkdirSync(policyDir);

--- a/src/scripts/fingerprint-candidates-unit-tests.ts
+++ b/src/scripts/fingerprint-candidates-unit-tests.ts
@@ -6,7 +6,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -20,7 +20,7 @@ function test(name, fn) {
 const repoRoot = path.join(__dirname, '..');
 const scriptPath = path.join(repoRoot, 'scripts', 'fingerprint-candidates.js');
 
-function withJsonl(lines, fn) {
+function withJsonl(lines: string[], fn: (inputPath: string) => void) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fingerprint-candidates-'));
   const inputPath = path.join(tempDir, 'waf-log.jsonl');
   fs.writeFileSync(inputPath, lines.join('\n') + '\n', 'utf8');
@@ -31,7 +31,7 @@ function withJsonl(lines, fn) {
   }
 }
 
-function runCandidates(inputPath, args = []) {
+function runCandidates(inputPath: string, args: string[] = []) {
   const stdout = execFileSync(
     process.execPath,
     [scriptPath, '--input', inputPath, ...args],
@@ -86,7 +86,7 @@ test('fingerprint-candidates applies min-count and top limits', () => {
 test('fingerprint-candidates prints usage and exits non-zero without input', () => {
   assert.throws(
     () => execFileSync(process.execPath, [scriptPath], { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' }),
-    (err) => {
+    (err: any) => {
       assert.strictEqual(err.status, 1);
       assert.match(String(err.stderr), /Usage: node scripts\/fingerprint-candidates\.js --input/);
       return true;

--- a/src/scripts/infra-unit-tests.ts
+++ b/src/scripts/infra-unit-tests.ts
@@ -6,7 +6,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -19,7 +19,7 @@ function test(name, fn) {
 
 const repoRoot = path.join(__dirname, '..');
 
-function runCompileInfra(policyContent, options: any = {}) {
+function runCompileInfra(policyContent: string, options: any = {}) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'infra-unit-'));
   const policyPath = path.join(tempDir, 'policy.yml');
   const outDir = path.join(tempDir, 'out');
@@ -36,7 +36,7 @@ function runCompileInfra(policyContent, options: any = {}) {
 
   return {
     tempDir,
-    read(rel) {
+    read(rel: string) {
       return JSON.parse(fs.readFileSync(path.join(outDir, rel), 'utf8'));
     },
     cleanup() {
@@ -67,7 +67,7 @@ firewall:
     assert.ok(group);
     assert.ok(Array.isArray(group.rule));
 
-    const ja3Rules = group.rule.filter((r) => r.statement && r.statement.byte_match_statement);
+    const ja3Rules = group.rule.filter((r: any) => r.statement && r.statement.byte_match_statement);
     assert.strictEqual(ja3Rules.length, 2);
     assert.strictEqual(ja3Rules[0].statement.byte_match_statement.field_to_match.ja3_fingerprint.constructor, Object);
     assert.strictEqual(ja3Rules[0].statement.byte_match_statement.positional_constraint, 'EXACTLY');
@@ -94,7 +94,7 @@ firewall:
   try {
     const waf = ctx.read('infra/waf-rules.tf.json');
     const group = waf.resource.aws_wafv2_rule_group['ja4-test-rate-limit'];
-    const ja4Rules = group.rule.filter((r) =>
+    const ja4Rules = group.rule.filter((r: any) =>
       r.statement &&
       r.statement.byte_match_statement &&
       r.statement.byte_match_statement.field_to_match &&
@@ -126,7 +126,7 @@ firewall:
   try {
     const waf = ctx.read('infra/waf-rules.tf.json');
     const group = waf.resource.aws_wafv2_rule_group['waf-test-rate-limit'];
-    assert.ok(group.rule.some((r) => r.statement && r.statement.rate_based_statement));
+    assert.ok(group.rule.some((r: any) => r.statement && r.statement.rate_based_statement));
 
     const acl = waf.resource.aws_wafv2_web_acl['waf-test-waf-acl'];
     assert.ok(acl.rule.length === 1);
@@ -216,7 +216,7 @@ firewall:
   try {
     const waf = ctx.read('infra/waf-rules.tf.json');
     const group = waf.resource.aws_wafv2_rule_group['rlr-test-rate-limit'];
-    const rateRules = group.rule.filter((r) => r.statement && r.statement.rate_based_statement);
+    const rateRules = group.rule.filter((r: any) => r.statement && r.statement.rate_based_statement);
     assert.strictEqual(rateRules.length, 2);
     assert.strictEqual(rateRules[0].name, 'global');
     assert.strictEqual(rateRules[0].priority, 1);
@@ -256,7 +256,7 @@ firewall:
     assert.strictEqual(group.custom_response_body[0].key, 'cdn_sec_block');
     assert.strictEqual(group.custom_response_body[0].content, 'unavailable for legal reasons');
 
-    const rateRule = group.rule.find((r) => r.statement.rate_based_statement);
+    const rateRule = group.rule.find((r: any) => r.statement.rate_based_statement);
     assert.strictEqual(rateRule.action.block.custom_response.response_code, 451);
     assert.strictEqual(rateRule.action.block.custom_response.custom_response_body_key, 'cdn_sec_block');
 

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -22,7 +22,7 @@ const path = require('path');
 
 const api = require('../lib');
 
-function test(name, fn) {
+function test(name: string, fn: () => void) {
   try {
     fn();
     console.log('OK:', name);
@@ -59,7 +59,7 @@ response_headers:
 unknown_top_level_key: true
 `;
 
-function tmpProject(yamlBody) {
+function tmpProject(yamlBody: string) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
   const policyDir = path.join(tmp, 'policy');
   fs.mkdirSync(policyDir);
@@ -108,14 +108,14 @@ test('lintPolicy: returns ok=true for valid policy', () => {
 test('lintPolicy: missing policyPath → structured error, no throw', () => {
   const result = api.lintPolicy({});
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+  assert.ok(result.errors.some((e: string) => /policyPath is required/.test(e)));
   assert.strictEqual(result.policy, null);
 });
 
 test('lintPolicy: nonexistent file → structured error', () => {
   const result = api.lintPolicy({ policyPath: '/no/such/file.yml' });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+  assert.ok(result.errors.some((e: string) => /not found/i.test(e)));
 });
 
 test('lintPolicy: invalid policy surfaces schema errors', () => {
@@ -155,9 +155,9 @@ test('compile: aws target writes edge + infra, returns file lists', () => {
     assert.strictEqual(result.ok, true, `compile failed: ${result.errors.join(' ')}`);
     assert.strictEqual(result.target, 'aws');
     assert.ok(result.edgeFiles.length >= 3, 'aws target emits 3 edge files');
-    assert.ok(result.edgeFiles.every((f) => fs.existsSync(f)), 'all edge files must exist');
+    assert.ok(result.edgeFiles.every((f: string) => fs.existsSync(f)), 'all edge files must exist');
     assert.ok(result.infraFiles.length > 0, 'aws target emits infra files');
-    assert.ok(result.infraFiles.every((f) => fs.existsSync(f)));
+    assert.ok(result.infraFiles.every((f: string) => fs.existsSync(f)));
   } finally {
     ctx.cleanup();
   }
@@ -170,19 +170,19 @@ test('compile: unknown target returns structured error', () => {
     target: 'gcp',
   });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /unknown target/i.test(e)));
+  assert.ok(result.errors.some((e: string) => /unknown target/i.test(e)));
 });
 
 test('compile: missing policyPath → error, no exit', () => {
   const result = api.compile({ outDir: '/tmp', target: 'aws' });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /policyPath is required/.test(e)));
+  assert.ok(result.errors.some((e: string) => /policyPath is required/.test(e)));
 });
 
 test('compile: missing outDir → error, no exit', () => {
   const result = api.compile({ policyPath: '/tmp/x.yml', target: 'aws' });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /outDir is required/.test(e)));
+  assert.ok(result.errors.some((e: string) => /outDir is required/.test(e)));
 });
 
 test('compile: nonexistent policy file → structured error', () => {
@@ -192,7 +192,7 @@ test('compile: nonexistent policy file → structured error', () => {
     target: 'aws',
   });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /not found/i.test(e)));
+  assert.ok(result.errors.some((e: string) => /not found/i.test(e)));
 });
 
 // --- emitWaf ---
@@ -230,7 +230,7 @@ test('emitWaf: --format cloudformation returns ok=false with formatNotImplemente
     });
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.formatNotImplemented, true);
-    assert.ok(result.errors.some((e) => /not yet implemented/i.test(e)));
+    assert.ok(result.errors.some((e: string) => /not yet implemented/i.test(e)));
   } finally {
     ctx.cleanup();
   }
@@ -244,7 +244,7 @@ test('emitWaf: unknown format → structured error', () => {
     format: 'pulumi',
   });
   assert.strictEqual(result.ok, false);
-  assert.ok(result.errors.some((e) => /unknown --format/i.test(e)));
+  assert.ok(result.errors.some((e: string) => /unknown --format/i.test(e)));
 });
 
 // --- migratePolicy ---
@@ -270,7 +270,7 @@ test('migratePolicy: no version field → ok=false with guidance error', () => {
     fs.writeFileSync(policyPath, 'project: noversion\n', 'utf8');
     const result = api.migratePolicy({ policyPath });
     assert.strictEqual(result.ok, false);
-    assert.ok(result.errors.some((e) => /no `version` field/.test(e)));
+    assert.ok(result.errors.some((e: string) => /no `version` field/.test(e)));
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -294,7 +294,7 @@ test('migratePolicy: downgrade rejected', () => {
     fs.writeFileSync(policyPath, 'version: 5\nproject: future\n', 'utf8');
     const result = api.migratePolicy({ policyPath, toVersion: 1 });
     assert.strictEqual(result.ok, false);
-    assert.ok(result.errors.some((e) => /Downgrade/.test(e)));
+    assert.ok(result.errors.some((e: string) => /Downgrade/.test(e)));
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a strict noImplicitAny typecheck slice for src/scripts/*-unit-tests.ts
- annotate unit-test helpers and callbacks so the new check passes
- include the new strict check in test:all

## Verification
- npm run typecheck:unit-tests-strict
- npm run typecheck
- npm run build:ts
- npm run test:unit
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all
- git diff --check