### PR TITLE
Raise infra and Cloudflare WAF coverage

### DIFF
--- a/scripts/cloudflare-waf-parity-unit-tests.js
+++ b/scripts/cloudflare-waf-parity-unit-tests.js
@@ -239,6 +239,110 @@ test('compiler: expression_cloudflare override suppresses the scope_down warning
         ctx.cleanup();
     }
 });
+test('compiler: custom Cloudflare rules include geo, IP, UA, fingerprint, rate limit, and logging resources', () => {
+    const policy = `
+version: 1
+project: cf-custom-test
+request:
+  allow_methods: [GET]
+  block:
+    ua_contains: ["BadBot"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  geo:
+    block_countries: ["RU"]
+    allow_countries: ["JP", "US"]
+  ip:
+    blocklist: ["203.0.113.0/24"]
+    allowlist: ["198.51.100.10/32"]
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1234
+    fingerprint_action: count
+    ja3_fingerprints:
+      - "0123456789abcdef0123456789abcdef"
+    ja4_fingerprints:
+      - "t13d1516h2_8daaf6152771_02713d6af862"
+    block_response:
+      status_code: 429
+      body: "slow down"
+      content_type: APPLICATION_JSON
+    rate_limit_rules:
+      - name: login-starts-with
+        aggregate_key_type: CUSTOM_KEYS
+        cloudflare_characteristics: ["ip.src", "http.request.headers[\\"x-api-key\\"]"]
+        limit: 25
+        action: count
+        scope_down_statement:
+          byte_match_statement:
+            field_to_match: { uri_path: {} }
+            positional_constraint: STARTS_WITH
+            search_string: "/login"
+    logging:
+      enabled: true
+      destination_arn_env: CLOUDFLARE_LOG_DEST
+`;
+    const ctx = tmpProject(policy);
+    try {
+        const r = runCompiler(ctx.policyPath, ctx.dir);
+        assert.strictEqual(r.status, 0, r.stderr);
+        const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+        const lists = tf.resource.cloudflare_list;
+        assert.strictEqual(lists['cf-custom-test_ip_blocklist'].item[0].value.ip, '203.0.113.0/24');
+        assert.strictEqual(lists['cf-custom-test_ip_allowlist'].item[0].value.ip, '198.51.100.10/32');
+        const custom = tf.resource.cloudflare_ruleset['cf-custom-test_custom'];
+        assert.ok(custom.rules.some((rule) => /Geo blocklist/.test(rule.description) && /"RU"/.test(rule.expression)));
+        assert.ok(custom.rules.some((rule) => /Geo allowlist/.test(rule.description) && /not/.test(rule.expression)));
+        assert.ok(custom.rules.some((rule) => /IP blocklist/.test(rule.description) && /\$cf-custom-test_ip_blocklist/.test(rule.expression)));
+        assert.ok(custom.rules.some((rule) => /User-Agent/.test(rule.description) && /badbot/.test(rule.expression)));
+        assert.ok(custom.rules.some((rule) => /JA3 fingerprint log/.test(rule.description) && rule.action === 'log'));
+        assert.ok(custom.rules.some((rule) => /JA4 fingerprint log/.test(rule.description) && rule.action === 'log'));
+        const blockedRule = custom.rules.find((rule) => /Geo blocklist/.test(rule.description));
+        assert.strictEqual(blockedRule.action_parameters.response.status_code, 429);
+        assert.strictEqual(blockedRule.action_parameters.response.content_type, 'application/json');
+        const rateRules = tf.resource.cloudflare_ruleset['cf-custom-test_ratelimit'].rules;
+        const globalRate = rateRules.find((rule) => /legacy/.test(rule.description));
+        assert.strictEqual(globalRate.ratelimit.requests_per_period, 1234);
+        const scopedRate = rateRules.find((rule) => rule.description === 'login-starts-with');
+        assert.strictEqual(scopedRate.action, 'log');
+        assert.strictEqual(scopedRate.expression, 'starts_with(http.request.uri.path, "/login")');
+        assert.deepStrictEqual(scopedRate.ratelimit.characteristics, ['ip.src', 'http.request.headers["x-api-key"]']);
+        assert.ok(tf.variable.cloudflare_log_dest);
+        const logpush = tf.resource.cloudflare_logpush_job['cf-custom-test_waf_logs'];
+        assert.strictEqual(logpush.destination_conf, '${var.cloudflare_log_dest}');
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('compiler: BotControl managed rule emits approximation warning and bot fight setting', () => {
+    const policy = `
+version: 1
+project: cf-bots-test
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    managed_rules:
+      - AWSManagedRulesBotControlRuleSet
+`;
+    const ctx = tmpProject(policy);
+    try {
+        const r = runCompiler(ctx.policyPath, ctx.dir);
+        assert.strictEqual(r.status, 0, r.stderr);
+        assert.ok(/APPROXIMATE: AWSManagedRulesBotControlRuleSet/.test(r.stderr));
+        const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+        const managed = tf.resource.cloudflare_ruleset['cf-bots-test_managed'];
+        assert.strictEqual(managed.rules[0].enabled, false);
+        assert.strictEqual(tf.resource.cloudflare_zone_settings_override['cf-bots-test_bots'].settings.bot_fight_mode, 'on');
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
 // ---- generator ----
 test('generator: EN render includes every managed rule entry', () => {
     const out = generator.renderEn();

--- a/scripts/infra-unit-tests.js
+++ b/scripts/infra-unit-tests.js
@@ -308,6 +308,83 @@ firewall:
         ctx.cleanup();
     }
 });
+test('compile-infra emits geo allowlist as a negated geo match statement', () => {
+    const ctx = runCompileInfra(`
+version: 1
+project: geo-allow-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  geo:
+    allow_countries: ["JP", "US"]
+`);
+    try {
+        const geo = ctx.read('infra/geo-restriction.tf.json');
+        const group = geo.resource.aws_wafv2_rule_group['geo-allow-test-geo-block'];
+        const rule = group.rule[0];
+        assert.ok(rule.action.block);
+        assert.deepStrictEqual(rule.statement.not_statement.statement.geo_match_statement.country_codes, ['JP', 'US']);
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('compile-infra emits separate IP allowlist and blocklist resources', () => {
+    const ctx = runCompileInfra(`
+version: 1
+project: ip-set-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  ip:
+    blocklist: ["203.0.113.0/24"]
+    allowlist: ["198.51.100.10/32"]
+`);
+    try {
+        const ipSets = ctx.read('infra/ip-sets.tf.json');
+        assert.deepStrictEqual(ipSets.resource.aws_wafv2_ip_set['ip-set-test-ip-blocklist'].addresses, ['203.0.113.0/24']);
+        assert.deepStrictEqual(ipSets.resource.aws_wafv2_ip_set['ip-set-test-ip-allowlist'].addresses, ['198.51.100.10/32']);
+        assert.ok(ipSets.resource.aws_wafv2_rule_group['ip-set-test-ip-block'].rule[0].action.block);
+        assert.ok(ipSets.resource.aws_wafv2_rule_group['ip-set-test-ip-allow'].rule[0].action.allow);
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('compile-infra emits transport and origin locals for CloudFront settings', () => {
+    const ctx = runCompileInfra(`
+version: 1
+project: transport-origin-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+transport:
+  tls:
+    security_policy: TLSv1.2_2021
+  http:
+    versions: ["http2", "http3"]
+origin:
+  timeout:
+    connect: 7
+    read: 45
+`);
+    try {
+        const transport = ctx.read('infra/cloudfront-settings.tf.json');
+        assert.strictEqual(transport.locals.cdn_security_transport.http_version, 'http2and3');
+        assert.strictEqual(transport.locals.cdn_security_transport.viewer_certificate.minimum_protocol_version, 'TLSv1.2_2021');
+        const origin = ctx.read('infra/cloudfront-origin.tf.json');
+        assert.strictEqual(origin.locals.cdn_security_origin_config.connection_timeout, 7);
+        assert.strictEqual(origin.locals.cdn_security_origin_config.read_timeout, 45);
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
 if (process.exitCode) {
     process.exit(process.exitCode);
 }

--- a/src/scripts/cloudflare-waf-parity-unit-tests.ts
+++ b/src/scripts/cloudflare-waf-parity-unit-tests.ts
@@ -261,6 +261,114 @@ test('compiler: expression_cloudflare override suppresses the scope_down warning
   }
 });
 
+test('compiler: custom Cloudflare rules include geo, IP, UA, fingerprint, rate limit, and logging resources', () => {
+  const policy = `
+version: 1
+project: cf-custom-test
+request:
+  allow_methods: [GET]
+  block:
+    ua_contains: ["BadBot"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  geo:
+    block_countries: ["RU"]
+    allow_countries: ["JP", "US"]
+  ip:
+    blocklist: ["203.0.113.0/24"]
+    allowlist: ["198.51.100.10/32"]
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1234
+    fingerprint_action: count
+    ja3_fingerprints:
+      - "0123456789abcdef0123456789abcdef"
+    ja4_fingerprints:
+      - "t13d1516h2_8daaf6152771_02713d6af862"
+    block_response:
+      status_code: 429
+      body: "slow down"
+      content_type: APPLICATION_JSON
+    rate_limit_rules:
+      - name: login-starts-with
+        aggregate_key_type: CUSTOM_KEYS
+        cloudflare_characteristics: ["ip.src", "http.request.headers[\\"x-api-key\\"]"]
+        limit: 25
+        action: count
+        scope_down_statement:
+          byte_match_statement:
+            field_to_match: { uri_path: {} }
+            positional_constraint: STARTS_WITH
+            search_string: "/login"
+    logging:
+      enabled: true
+      destination_arn_env: CLOUDFLARE_LOG_DEST
+`;
+  const ctx = tmpProject(policy);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0, r.stderr);
+    const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+
+    const lists = tf.resource.cloudflare_list;
+    assert.strictEqual(lists['cf-custom-test_ip_blocklist'].item[0].value.ip, '203.0.113.0/24');
+    assert.strictEqual(lists['cf-custom-test_ip_allowlist'].item[0].value.ip, '198.51.100.10/32');
+
+    const custom = tf.resource.cloudflare_ruleset['cf-custom-test_custom'];
+    assert.ok(custom.rules.some((rule: any) => /Geo blocklist/.test(rule.description) && /"RU"/.test(rule.expression)));
+    assert.ok(custom.rules.some((rule: any) => /Geo allowlist/.test(rule.description) && /not/.test(rule.expression)));
+    assert.ok(custom.rules.some((rule: any) => /IP blocklist/.test(rule.description) && /\$cf-custom-test_ip_blocklist/.test(rule.expression)));
+    assert.ok(custom.rules.some((rule: any) => /User-Agent/.test(rule.description) && /badbot/.test(rule.expression)));
+    assert.ok(custom.rules.some((rule: any) => /JA3 fingerprint log/.test(rule.description) && rule.action === 'log'));
+    assert.ok(custom.rules.some((rule: any) => /JA4 fingerprint log/.test(rule.description) && rule.action === 'log'));
+    const blockedRule = custom.rules.find((rule: any) => /Geo blocklist/.test(rule.description));
+    assert.strictEqual(blockedRule.action_parameters.response.status_code, 429);
+    assert.strictEqual(blockedRule.action_parameters.response.content_type, 'application/json');
+
+    const rateRules = tf.resource.cloudflare_ruleset['cf-custom-test_ratelimit'].rules;
+    const globalRate = rateRules.find((rule: any) => /legacy/.test(rule.description));
+    assert.strictEqual(globalRate.ratelimit.requests_per_period, 1234);
+    const scopedRate = rateRules.find((rule: any) => rule.description === 'login-starts-with');
+    assert.strictEqual(scopedRate.action, 'log');
+    assert.strictEqual(scopedRate.expression, 'starts_with(http.request.uri.path, "/login")');
+    assert.deepStrictEqual(scopedRate.ratelimit.characteristics, ['ip.src', 'http.request.headers["x-api-key"]']);
+
+    assert.ok(tf.variable.cloudflare_log_dest);
+    const logpush = tf.resource.cloudflare_logpush_job['cf-custom-test_waf_logs'];
+    assert.strictEqual(logpush.destination_conf, '${var.cloudflare_log_dest}');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compiler: BotControl managed rule emits approximation warning and bot fight setting', () => {
+  const policy = `
+version: 1
+project: cf-bots-test
+request:
+  allow_methods: [GET]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  waf:
+    managed_rules:
+      - AWSManagedRulesBotControlRuleSet
+`;
+  const ctx = tmpProject(policy);
+  try {
+    const r = runCompiler(ctx.policyPath, ctx.dir);
+    assert.strictEqual(r.status, 0, r.stderr);
+    assert.ok(/APPROXIMATE: AWSManagedRulesBotControlRuleSet/.test(r.stderr));
+    const tf = JSON.parse(fs.readFileSync(path.join(ctx.dir, 'infra', 'cloudflare-waf.tf.json'), 'utf8'));
+    const managed = tf.resource.cloudflare_ruleset['cf-bots-test_managed'];
+    assert.strictEqual(managed.rules[0].enabled, false);
+    assert.strictEqual(tf.resource.cloudflare_zone_settings_override['cf-bots-test_bots'].settings.bot_fight_mode, 'on');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
 // ---- generator ----
 
 test('generator: EN render includes every managed rule entry', () => {

--- a/src/scripts/infra-unit-tests.ts
+++ b/src/scripts/infra-unit-tests.ts
@@ -326,6 +326,95 @@ firewall:
   }
 });
 
+test('compile-infra emits geo allowlist as a negated geo match statement', () => {
+  const ctx = runCompileInfra(`
+version: 1
+project: geo-allow-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  geo:
+    allow_countries: ["JP", "US"]
+`);
+
+  try {
+    const geo = ctx.read('infra/geo-restriction.tf.json');
+    const group = geo.resource.aws_wafv2_rule_group['geo-allow-test-geo-block'];
+    const rule = group.rule[0];
+    assert.ok(rule.action.block);
+    assert.deepStrictEqual(rule.statement.not_statement.statement.geo_match_statement.country_codes, ['JP', 'US']);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compile-infra emits separate IP allowlist and blocklist resources', () => {
+  const ctx = runCompileInfra(`
+version: 1
+project: ip-set-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+firewall:
+  ip:
+    blocklist: ["203.0.113.0/24"]
+    allowlist: ["198.51.100.10/32"]
+`);
+
+  try {
+    const ipSets = ctx.read('infra/ip-sets.tf.json');
+    assert.deepStrictEqual(
+      ipSets.resource.aws_wafv2_ip_set['ip-set-test-ip-blocklist'].addresses,
+      ['203.0.113.0/24'],
+    );
+    assert.deepStrictEqual(
+      ipSets.resource.aws_wafv2_ip_set['ip-set-test-ip-allowlist'].addresses,
+      ['198.51.100.10/32'],
+    );
+    assert.ok(ipSets.resource.aws_wafv2_rule_group['ip-set-test-ip-block'].rule[0].action.block);
+    assert.ok(ipSets.resource.aws_wafv2_rule_group['ip-set-test-ip-allow'].rule[0].action.allow);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('compile-infra emits transport and origin locals for CloudFront settings', () => {
+  const ctx = runCompileInfra(`
+version: 1
+project: transport-origin-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=1"
+transport:
+  tls:
+    security_policy: TLSv1.2_2021
+  http:
+    versions: ["http2", "http3"]
+origin:
+  timeout:
+    connect: 7
+    read: 45
+`);
+
+  try {
+    const transport = ctx.read('infra/cloudfront-settings.tf.json');
+    assert.strictEqual(transport.locals.cdn_security_transport.http_version, 'http2and3');
+    assert.strictEqual(
+      transport.locals.cdn_security_transport.viewer_certificate.minimum_protocol_version,
+      'TLSv1.2_2021',
+    );
+    const origin = ctx.read('infra/cloudfront-origin.tf.json');
+    assert.strictEqual(origin.locals.cdn_security_origin_config.connection_timeout, 7);
+    assert.strictEqual(origin.locals.cdn_security_origin_config.read_timeout, 45);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
 if (process.exitCode) {
   process.exit(process.exitCode);
 }


### PR DESCRIPTION
## Summary
- add compile-infra coverage for geo allowlists, IP sets, transport, and origin Terraform outputs
- add Cloudflare WAF compiler coverage for custom rules, IP lists, fingerprints, rate limits, logging, and BotControl approximation output
- improve c8 coverage for the previously weakest compiler surfaces

## Coverage
- before: All files lines/statements 82.56%, branches 75.43%
- after: All files lines/statements 90.25%, branches 78.21%
- compile-infra.js lines: 60.31% -> 94.78%
- compile-cloudflare-waf.js lines: 67.62% -> 97.12%

## Verification
- npm run build:ts
- npm run typecheck:unit-tests-strict
- node scripts/infra-unit-tests.js
- node scripts/cloudflare-waf-parity-unit-tests.js
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:coverage
- git diff --check