### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,34 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-29
+
+### セキュリティ
+
+- 署名付き URL の検証を、パスと期限だけでなく正規化済みクエリ文字列全体にバインドするようにした。署名後に未署名の selector パラメータを追加する改ざんは、AWS Lambda@Edge / Cloudflare Workers の双方で拒否される。
+- Cloudflare Workers の認証失敗レスポンス本文を汎用化した。詳細な `block_reason` は構造化ログに残しつつ、クライアントには詳細を漏らさない。
+- プロダクトレビューで見つかった edge/runtime の挙動、fixture、package smoke の不整合を修正し、リリース前品質を強化。
+- AWS CloudFront Functions で `response_headers.csp_nonce` が有効な場合、暗号学的 RNG が使えないため nonce 生成に関する警告を出すようにした。
+
+### 追加
+
+- 構造化された結果を返す `lib/` の programmatic API を追加し、CLI は公開 API 経由で処理する構成にした。
+- AWS / Cloudflare の疑似 edge 挙動を検証する edge container attack harness を追加。
+- Cloudflare WAF パリティの明示的な警告と、近似変換を失敗扱いにできる `--fail-on-waf-approximation` ガードレールを追加。
+- runtime、Cloudflare integration、compiler unit、infra/WAF、fingerprint candidate、coverage、drift、package smoke のテストを拡充。
+
+### 変更
+
+- TypeScript ソース移行を完了し、public API、shared scripts、unit tests、CLI の各領域でより厳格な TypeScript チェックを有効化。
+- Node.js engine の下限を `>=20.17.0` に更新。
+- `inquirer` を v13 に更新し、CommonJS interop を調整。
+- OSS リリース準備として package 内容とプロダクトドキュメントを整理。
+
+### 修正
+
+- package smoke と runtime fixture を生成物に合わせて修正。
+- npm release workflow を冪等にした。
+
 ## [1.1.0] - 2026-04-23
 
 ### セキュリティ / 破壊的変更
@@ -68,6 +96,7 @@
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.0.0...v1.1.0
 [0.1.0]: https://github.com/albert-einshutoin/cdn-security-framework/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-29
+
+### Security
+
+- Signed URL validation now binds signatures to the canonical query string, not only the path and expiry. Appending unsigned selector parameters after signing is rejected on AWS Lambda@Edge and Cloudflare Workers.
+- Cloudflare Workers authentication failures now return generic response bodies while preserving detailed `block_reason` values in structured logs.
+- Product-review hardening tightened edge/runtime behavior, fixtures, and package smoke coverage for release readiness.
+- AWS CloudFront Functions builds now warn when `response_headers.csp_nonce` is enabled because CloudFront Functions do not expose a cryptographic RNG for nonce generation.
+
+### Added
+
+- Programmatic API in `lib/` with structured results, with CLI commands delegating to the public API surface.
+- Edge container attack harness covering AWS and Cloudflare pseudo-edge behavior.
+- Cloudflare WAF parity transparency warnings and a `--fail-on-waf-approximation` guardrail.
+- Additional runtime, Cloudflare integration, compiler unit, infra/WAF, fingerprint candidate, coverage, drift, and package smoke tests.
+
+### Changed
+
+- Completed the TypeScript source migration and enabled stricter TypeScript checks across public API, shared scripts, unit tests, and CLI slices.
+- Raised the Node.js engine floor to `>=20.17.0`.
+- Updated `inquirer` to v13 and adjusted CommonJS interop.
+- Polished package contents and product documentation for OSS release readiness.
+
+### Fixed
+
+- Package smoke and runtime fixtures now align with generated outputs.
+- NPM release workflow is idempotent.
+
 ## [1.1.0] - 2026-04-23
 
 ### Security / Breaking
@@ -68,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.0.0...v1.1.0
 [0.1.0]: https://github.com/albert-einshutoin/cdn-security-framework/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdn-security-framework",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdn-security-framework",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdn-security-framework",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Policy-driven CDN edge security. Init YAML with npx cdn-security init, then npx cdn-security build to generate runtime code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- bump package metadata to v1.2.0
- add v1.2.0 release notes to English and Japanese changelogs
- confirm release tarball dry-run emits cdn-security-framework-1.2.0.tgz

## Verification
- npm run typecheck
- EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:coverage
- npm_config_cache=/tmp/cdn-security-npm-cache npm run test:package
- npm audit --audit-level=moderate
- npm_config_cache=/tmp/cdn-security-npm-cache npm pack --dry-run