### PR TITLE
Harden compiler typing and add Vitest contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist/
 
 # c8 coverage output
 coverage/
+reports/
 .nyc_output/
 
 # doctor subcommand report — regenerated on every run, captured as CI artifact

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -17,6 +17,7 @@
 - compiler を parser / validator / emitter の phase module に分割し、programmatic API の裏側で利用する構成にした。
 - `src/types/policy.d.ts` の schema 由来型生成と drift check を追加。
 - 注入後 AST 検証と template injection contract のドキュメントを追加。
+- compiler phase の strict typecheck と、CI report 対応の初期 Vitest contract test suite を追加。
 
 ## [1.2.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split the compiler into parser, validator, and emitter phase modules behind the programmatic API.
 - Added schema-derived policy type generation and a drift check for `src/types/policy.d.ts`.
 - Added post-injection AST validation plus a documented template injection contract.
+- Added strict compiler-phase typechecking and an initial Vitest contract test suite with CI reporting.
 
 ## [1.2.0] - 2026-04-29
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -102,11 +102,13 @@ Terraform / CloudFormation / CDK / WAF の利用例は [IaC 連携](docs/iac.ja.
 ### 運用ドキュメント
 - [CLI リファレンス](docs/cli.ja.md) — `init` / `build` / `emit-waf` / `doctor` / `explain` / `diff` / `migrate`
 - [プログラマティック API](docs/programmatic-api.ja.md) — `require('cdn-security-framework')` で CI / IaC から直接呼び出し
+- [Compiler strictness](docs/compiler-strictness.ja.md) — phase contract、strict check、残る dynamic area
 - [アーキタイプ](docs/archetypes.ja.md) — アプリ形状別プリセット（SPA / REST API / 管理画面 / マイクロサービス）
 - [シークレットローテーション runbook](docs/runbooks/secret-rotation.ja.md) — JWT / JWKS / 署名付き URL / 管理トークン / origin シークレット
 - [スキーママイグレーション](docs/schema-migration.ja.md) — `policy/schema.json` のバージョン契約と `migrate` CLI
 - [サプライチェーン](docs/supply-chain.ja.md) — SLSA v1 provenance と `npm audit signatures`
 - [テンプレート注入契約](docs/template-injection-contract.ja.md) — marker-safe かつ parse-checked な runtime config 注入
+- [テスト戦略](docs/test-strategy.ja.md) — Vitest 移行方針と release gate の test workflow
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ See [IaC integration](docs/iac.md) for Terraform / CloudFormation / CDK / WAF us
 ### Operational docs
 - [CLI reference](docs/cli.md) — `init` / `build` / `emit-waf` / `doctor` / `explain` / `diff` / `migrate`
 - [Programmatic API](docs/programmatic-api.md) — `require('cdn-security-framework')` for CI / IaC integration
+- [Compiler strictness](docs/compiler-strictness.md) — phase contracts, strict checks, and remaining dynamic areas
 - [Archetypes](docs/archetypes.md) — app-shaped policy presets (SPA, REST API, admin, microservice)
 - [Secret rotation runbook](docs/runbooks/secret-rotation.md) — JWT / JWKS / signed URL / admin token / origin secret
 - [Schema migration](docs/schema-migration.md) — how `policy/schema.json` evolves and the `migrate` CLI
 - [Supply chain](docs/supply-chain.md) — SLSA v1 provenance and `npm audit signatures`
 - [Template injection contract](docs/template-injection-contract.md) — marker-safe, parse-checked runtime config injection
+- [Test strategy](docs/test-strategy.md) — Vitest migration policy and release-gate test workflow
 
 ---
 

--- a/docs/compiler-strictness.ja.md
+++ b/docs/compiler-strictness.ja.md
@@ -1,0 +1,35 @@
+# Compiler Strictness
+
+> **Languages:** [English](./compiler-strictness.md) · 日本語
+
+compiler には、parser、validator、emitter、target compile entry point を対象にした
+専用の strict TypeScript gate を追加しています。
+
+```sh
+npm run typecheck:compiler-strict
+```
+
+この gate は `npm run test:all` に含まれます。
+
+## 型付けされた境界
+
+- `parser` は schema 由来の `CDNSecurityFrameworkPolicy` から
+  `Partial<CDNSecurityFrameworkPolicy> | null` を返します。
+- `validator` は同じ policy draft shape を受け取り、明示的な
+  `ValidatePolicyResult` を返します。
+- `emitter` は diagnostics と artifact list を型付けした
+  `CompileArtifactsResult` を返します。
+
+## 残る dynamic area
+
+一部の dynamic typing は意図的に残しています。
+
+- YAML parse の入力は untrusted data です。parser は policy draft まで狭め、
+  schema enforcement は validator が担当します。
+- 現時点の `origin.auth` は schema 上 extensible な形なので、validator は閉じた
+  object shape と断定せず、必要な string field だけを narrow helper で読みます。
+- emitter は CLI と生成物の互換性を維持するため、compiler phase split が安定するまで
+  target script を `spawnSync` 経由で呼び出します。
+
+これらは policy schema が discriminated union 化され、target emitter の in-process 化が
+進むにつれて縮小できます。

--- a/docs/compiler-strictness.md
+++ b/docs/compiler-strictness.md
@@ -1,0 +1,35 @@
+# Compiler Strictness
+
+> **Languages:** English · [日本語](./compiler-strictness.ja.md)
+
+The compiler now has a dedicated strict TypeScript gate for parser, validator,
+emitter, and target compile entry points:
+
+```sh
+npm run typecheck:compiler-strict
+```
+
+This gate is part of `npm run test:all`.
+
+## Typed boundaries
+
+- `parser` returns `Partial<CDNSecurityFrameworkPolicy> | null` from the
+  schema-derived policy type.
+- `validator` accepts the same policy draft shape and returns an explicit
+  `ValidatePolicyResult`.
+- `emitter` returns `CompileArtifactsResult`, with typed diagnostics and
+  artifact lists.
+
+## Remaining dynamic areas
+
+Some dynamic typing remains intentionally:
+
+- YAML parsing starts as untrusted data. The parser narrows it to a policy draft,
+  and the validator owns schema enforcement.
+- `origin.auth` is schema-extensible today, so the validator reads selected
+  string fields with a narrow helper instead of asserting a closed object shape.
+- The emitter still calls target scripts through `spawnSync` to preserve CLI and
+  output compatibility while the compiler phase split stabilizes.
+
+These areas should shrink as the policy schema becomes more discriminated and
+target emitters move further in-process.

--- a/docs/test-strategy.ja.md
+++ b/docs/test-strategy.ja.md
@@ -1,0 +1,30 @@
+# テスト戦略
+
+> **Languages:** [English](./test-strategy.md) · 日本語
+
+このプロジェクトでは、セキュリティ上重要な smoke / integration test は
+独立した Node script として維持しつつ、compiler contract のような絞り込んだ
+テストには Vitest を導入します。
+
+## runner の選定
+
+- focused unit / contract test の移行先は Vitest を標準とします。TypeScript の
+  test file、watch mode、test name filter、CI 向け structured report を扱いやすいためです。
+- Jest も候補ですが、この repository では transform 設定と CommonJS/ESM 境界の
+  複雑さが増えます。
+- 既存の script harness は、package smoke、drift check、ReDoS fuzzing、
+  edge-container attack test のように process-level の挙動が重要なテストで維持します。
+
+## local workflow
+
+- Vitest の focused check: `npm run test:vitest`
+- 既存 unit suite: `npm run test:unit`
+- release gate 全体: `npm run test:all`
+
+`CI=true` の場合、Vitest は `reports/vitest-junit.xml` に JUnit output を出します。
+
+## 移行方針
+
+focused run、watch mode、明瞭な assertion structure の恩恵があるテストは Vitest
+へ移行します。CLI process behavior、package install、generated artifact drift、
+fuzzing、container-style attack flow を検証するものは standalone script として残します。

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1,0 +1,33 @@
+# Test Strategy
+
+> **Languages:** English · [日本語](./test-strategy.ja.md)
+
+The project keeps security-critical smoke and integration tests as standalone
+Node scripts, while introducing Vitest for focused compiler contract tests.
+
+## Runner choice
+
+- Vitest is the default migration target for focused unit and contract tests.
+  It supports TypeScript test files, watch mode, name filtering, and structured
+  CI reporting without forcing the runtime smoke tests into a browser-like
+  model.
+- Jest was considered, but it adds more transformation and CommonJS/ESM
+  surface area for this repository.
+- The existing script harness remains useful for package smoke tests, drift
+  checks, ReDoS fuzzing, and edge-container attack tests where process-level
+  behavior matters.
+
+## Local workflow
+
+- Run focused Vitest checks with `npm run test:vitest`.
+- Run legacy unit coverage with `npm run test:unit`.
+- Run the full release gate with `npm run test:all`.
+
+Vitest writes JUnit output to `reports/vitest-junit.xml` when `CI=true`.
+
+## Migration policy
+
+Move tests into Vitest when they benefit from focused runs, watch mode, or
+clear assertion structure. Keep tests as standalone scripts when they verify
+CLI process behavior, package installation, generated artifact drift, fuzzing,
+or container-style attack flows.

--- a/emitter/index.d.ts
+++ b/emitter/index.d.ts
@@ -18,15 +18,11 @@ export type CompileResultBase = {
     outDir: string | null;
     target: string;
 };
-export declare function resolveAbsolute(inputPath: string, cwd: string): string;
-export declare function listInfraArtifacts(outDir: string, sinceMs?: number): string[];
-export declare function compileArtifacts(opts?: CompileArtifactsOptions): {
-    edgeFiles: string[];
-    infraFiles: string[];
-    policyPath: string | null;
-    outDir: string | null;
-    target: string;
+export type CompileArtifactsResult = CompileResultBase & {
     ok: boolean;
     errors: string[];
     warnings: string[];
 };
+export declare function resolveAbsolute(inputPath: string, cwd: string): string;
+export declare function listInfraArtifacts(outDir: string, sinceMs?: number): string[];
+export declare function compileArtifacts(opts?: CompileArtifactsOptions): CompileArtifactsResult;

--- a/emitter/index.js
+++ b/emitter/index.js
@@ -23,6 +23,16 @@ function listInfraArtifacts(outDir, sinceMs = 0) {
         .map((name) => path.join(infraDir, name))
         .filter((filePath) => sinceMs <= 0 || fs.statSync(filePath).mtimeMs >= sinceMs);
 }
+function collectStderrWarnings(result, warnings) {
+    if (result.stderr) {
+        warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+    }
+}
+function collectFailedSpawn(label, result, errors) {
+    errors.push(`${label} failed (status ${result.status})`);
+    if (result.stderr)
+        errors.push(result.stderr.trim());
+}
 function compileArtifacts(opts = {}) {
     opts = opts || {};
     const cwd = opts.cwd || process.cwd();
@@ -83,14 +93,10 @@ function compileArtifacts(opts = {}) {
             ...permissiveFlag,
         ], { cwd, encoding: 'utf8', env });
         if (compileResult.status !== 0) {
-            errors.push(`edge compile failed (status ${compileResult.status})`);
-            if (compileResult.stderr)
-                errors.push(compileResult.stderr.trim());
+            collectFailedSpawn('edge compile', compileResult, errors);
             return { ok: false, errors, warnings, ...baseResult };
         }
-        if (compileResult.stderr) {
-            warnings.push(...compileResult.stderr.trim().split('\n').filter(Boolean));
-        }
+        collectStderrWarnings(compileResult, warnings);
         baseResult.edgeFiles = AWS_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
         const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
         const infraResult = spawnSync(process.execPath, [
@@ -101,14 +107,10 @@ function compileArtifacts(opts = {}) {
             ...(opts.ruleGroupOnly ? ['--rule-group-only'] : []),
         ], { cwd, encoding: 'utf8', env });
         if (infraResult.status !== 0) {
-            errors.push(`infra compile failed (status ${infraResult.status})`);
-            if (infraResult.stderr)
-                errors.push(infraResult.stderr.trim());
+            collectFailedSpawn('infra compile', infraResult, errors);
             return { ok: false, errors, warnings, ...baseResult };
         }
-        if (infraResult.stderr) {
-            warnings.push(...infraResult.stderr.trim().split('\n').filter(Boolean));
-        }
+        collectStderrWarnings(infraResult, warnings);
         baseResult.infraFiles = listInfraArtifacts(outDir, compileStartedAt);
     }
     else {
@@ -120,14 +122,10 @@ function compileArtifacts(opts = {}) {
             ...permissiveFlag,
         ], { cwd, encoding: 'utf8', env });
         if (cfResult.status !== 0) {
-            errors.push(`cloudflare edge compile failed (status ${cfResult.status})`);
-            if (cfResult.stderr)
-                errors.push(cfResult.stderr.trim());
+            collectFailedSpawn('cloudflare edge compile', cfResult, errors);
             return { ok: false, errors, warnings, ...baseResult };
         }
-        if (cfResult.stderr) {
-            warnings.push(...cfResult.stderr.trim().split('\n').filter(Boolean));
-        }
+        collectStderrWarnings(cfResult, warnings);
         baseResult.edgeFiles = CF_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
         const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
         const cfWafResult = spawnSync(process.execPath, [
@@ -137,14 +135,10 @@ function compileArtifacts(opts = {}) {
             ...(opts.failOnWafApproximation ? ['--fail-on-waf-approximation'] : []),
         ], { cwd, encoding: 'utf8', env });
         if (cfWafResult.status !== 0) {
-            errors.push(`cloudflare waf compile failed (status ${cfWafResult.status})`);
-            if (cfWafResult.stderr)
-                errors.push(cfWafResult.stderr.trim());
+            collectFailedSpawn('cloudflare waf compile', cfWafResult, errors);
             return { ok: false, errors, warnings, ...baseResult };
         }
-        if (cfWafResult.stderr) {
-            warnings.push(...cfWafResult.stderr.trim().split('\n').filter(Boolean));
-        }
+        collectStderrWarnings(cfWafResult, warnings);
         baseResult.infraFiles = listInfraArtifacts(outDir, compileStartedAt);
     }
     return { ok: true, errors, warnings, ...baseResult };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "c8": "^10.1.3",
         "esbuild": "^0.28.0",
         "json-schema-to-typescript": "^15.0.4",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.17.0"
@@ -56,6 +57,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -976,6 +1011,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -986,6 +1050,313 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1023,6 +1394,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1085,6 +1569,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1140,6 +1634,16 @@
         "monocart-coverage-reports": {
           "optional": true
         }
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chardet": {
@@ -1241,6 +1745,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1252,6 +1766,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1305,6 +1826,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1403,6 +1944,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -1666,6 +2222,267 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1695,6 +2512,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -1756,6 +2583,36 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -1833,6 +2690,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -1844,6 +2715,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prettier": {
@@ -1879,6 +2779,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/run-async": {
@@ -1941,6 +2875,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1952,6 +2893,30 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2039,6 +3004,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2054,6 +3036,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2098,6 +3090,174 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2112,6 +3272,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi-cjs": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
     "typecheck:scripts-lib-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/scripts/lib/*.ts",
     "typecheck:unit-tests-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/scripts/*-unit-tests.ts",
     "typecheck:cli-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/bin/cli.ts",
+    "typecheck:compiler-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/parser/*.ts src/validator/*.ts src/emitter/*.ts src/scripts/compile.ts src/scripts/compile-cloudflare.ts src/scripts/compile-infra.ts src/scripts/compile-cloudflare-waf.ts src/scripts/policy-lint.ts",
     "build": "npm run build:ts && node scripts/compile.js",
     "lint:policy": "npm run build:ts && node scripts/policy-lint.js",
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
+    "test:vitest": "npm run build:ts && node scripts/ensure-report-dir.js && vitest run",
     "test:runtime": "npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
     "test:unit": "npm run build:ts && node scripts/compiler-phase-unit-tests.js && node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js && node scripts/fingerprint-candidates-unit-tests.js",
     "test:drift": "npm run build:ts && node scripts/check-drift.js",
@@ -52,7 +54,7 @@
     "test:edge-container": "npm run build:ts && node scripts/edge-container-attack-tests.js",
     "test:package": "npm run build:ts && node scripts/package-smoke-tests.js",
     "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --include='parser/**/*.js' --include='validator/**/*.js' --include='emitter/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
-    "test:all": "npm run build && npm run test:types && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run typecheck:unit-tests-strict && npm run typecheck:cli-strict && npm run test:api-contract && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
+    "test:all": "npm run build && npm run test:types && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run typecheck:compiler-strict && npm run typecheck:unit-tests-strict && npm run typecheck:cli-strict && npm run test:api-contract && npm run test:vitest && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
     "fingerprints:candidates": "npm run build:ts && node scripts/fingerprint-candidates.js"
   },
   "keywords": [
@@ -116,6 +118,7 @@
     "c8": "^10.1.3",
     "esbuild": "^0.28.0",
     "json-schema-to-typescript": "^15.0.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/parser/index.d.ts
+++ b/parser/index.d.ts
@@ -1,9 +1,10 @@
+import type { CDNSecurityFrameworkPolicy } from '../types/policy';
 export type ParsePolicyOptions = {
     policyPath?: string;
 };
 export type ParsePolicyResult = {
     ok: boolean;
     errors: string[];
-    policy: any | null;
+    policy: Partial<CDNSecurityFrameworkPolicy> | null;
 };
 export declare function parsePolicyFile(opts?: ParsePolicyOptions): ParsePolicyResult;

--- a/parser/index.js
+++ b/parser/index.js
@@ -13,12 +13,13 @@ function parsePolicyFile(opts = {}) {
         return { ok: true, errors: [], policy };
     }
     catch (e) {
-        if (e && e.code === 'ENOENT') {
+        if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
             return { ok: false, errors: [`policy file not found: ${policyPath}`], policy: null };
         }
+        const message = e instanceof Error ? e.message : String(e);
         return {
             ok: false,
-            errors: [`failed to parse policy YAML: ${e && e.message ? e.message : String(e)}`],
+            errors: [`failed to parse policy YAML: ${message}`],
             policy: null,
         };
     }

--- a/scripts/ensure-report-dir.d.ts
+++ b/scripts/ensure-report-dir.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/scripts/ensure-report-dir.js
+++ b/scripts/ensure-report-dir.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require('fs');
+const path = require('path');
+const reportDir = path.join(process.cwd(), 'reports');
+fs.mkdirSync(reportDir, { recursive: true });

--- a/src/emitter/index.ts
+++ b/src/emitter/index.ts
@@ -4,6 +4,8 @@ const { spawnSync } = require('child_process');
 
 const { lintPolicy } = require('../lib/lint');
 
+import type { SpawnSyncReturns } from 'child_process';
+
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 
 const AWS_EDGE_FILES = ['viewer-request.js', 'viewer-response.js', 'origin-request.js'];
@@ -32,6 +34,12 @@ export type CompileResultBase = {
   target: string;
 };
 
+export type CompileArtifactsResult = CompileResultBase & {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+};
+
 export function resolveAbsolute(inputPath: string, cwd: string): string {
   return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
@@ -46,7 +54,22 @@ export function listInfraArtifacts(outDir: string, sinceMs = 0): string[] {
     .filter((filePath: string) => sinceMs <= 0 || fs.statSync(filePath).mtimeMs >= sinceMs);
 }
 
-export function compileArtifacts(opts: CompileArtifactsOptions = {}) {
+function collectStderrWarnings(result: SpawnSyncReturns<string>, warnings: string[]): void {
+  if (result.stderr) {
+    warnings.push(...result.stderr.trim().split('\n').filter(Boolean));
+  }
+}
+
+function collectFailedSpawn(
+  label: string,
+  result: SpawnSyncReturns<string>,
+  errors: string[],
+): void {
+  errors.push(`${label} failed (status ${result.status})`);
+  if (result.stderr) errors.push(result.stderr.trim());
+}
+
+export function compileArtifacts(opts: CompileArtifactsOptions = {}): CompileArtifactsResult {
   opts = opts || {};
   const cwd = opts.cwd || process.cwd();
   const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
@@ -117,13 +140,10 @@ export function compileArtifacts(opts: CompileArtifactsOptions = {}) {
       { cwd, encoding: 'utf8', env },
     );
     if (compileResult.status !== 0) {
-      errors.push(`edge compile failed (status ${compileResult.status})`);
-      if (compileResult.stderr) errors.push(compileResult.stderr.trim());
+      collectFailedSpawn('edge compile', compileResult, errors);
       return { ok: false, errors, warnings, ...baseResult };
     }
-    if (compileResult.stderr) {
-      warnings.push(...compileResult.stderr.trim().split('\n').filter(Boolean));
-    }
+    collectStderrWarnings(compileResult, warnings);
     baseResult.edgeFiles = AWS_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
 
     const infraPath = path.join(pkgRoot, 'scripts', 'compile-infra.js');
@@ -139,13 +159,10 @@ export function compileArtifacts(opts: CompileArtifactsOptions = {}) {
       { cwd, encoding: 'utf8', env },
     );
     if (infraResult.status !== 0) {
-      errors.push(`infra compile failed (status ${infraResult.status})`);
-      if (infraResult.stderr) errors.push(infraResult.stderr.trim());
+      collectFailedSpawn('infra compile', infraResult, errors);
       return { ok: false, errors, warnings, ...baseResult };
     }
-    if (infraResult.stderr) {
-      warnings.push(...infraResult.stderr.trim().split('\n').filter(Boolean));
-    }
+    collectStderrWarnings(infraResult, warnings);
     baseResult.infraFiles = listInfraArtifacts(outDir, compileStartedAt);
   } else {
     const compileCfPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare.js');
@@ -160,13 +177,10 @@ export function compileArtifacts(opts: CompileArtifactsOptions = {}) {
       { cwd, encoding: 'utf8', env },
     );
     if (cfResult.status !== 0) {
-      errors.push(`cloudflare edge compile failed (status ${cfResult.status})`);
-      if (cfResult.stderr) errors.push(cfResult.stderr.trim());
+      collectFailedSpawn('cloudflare edge compile', cfResult, errors);
       return { ok: false, errors, warnings, ...baseResult };
     }
-    if (cfResult.stderr) {
-      warnings.push(...cfResult.stderr.trim().split('\n').filter(Boolean));
-    }
+    collectStderrWarnings(cfResult, warnings);
     baseResult.edgeFiles = CF_EDGE_FILES.map((f) => path.join(outDir, 'edge', f));
 
     const cfWafPath = path.join(pkgRoot, 'scripts', 'compile-cloudflare-waf.js');
@@ -181,13 +195,10 @@ export function compileArtifacts(opts: CompileArtifactsOptions = {}) {
       { cwd, encoding: 'utf8', env },
     );
     if (cfWafResult.status !== 0) {
-      errors.push(`cloudflare waf compile failed (status ${cfWafResult.status})`);
-      if (cfWafResult.stderr) errors.push(cfWafResult.stderr.trim());
+      collectFailedSpawn('cloudflare waf compile', cfWafResult, errors);
       return { ok: false, errors, warnings, ...baseResult };
     }
-    if (cfWafResult.stderr) {
-      warnings.push(...cfWafResult.stderr.trim().split('\n').filter(Boolean));
-    }
+    collectStderrWarnings(cfWafResult, warnings);
     baseResult.infraFiles = listInfraArtifacts(outDir, compileStartedAt);
   }
 

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -12,9 +12,24 @@ const path = require('path');
 const { parsePolicyFile } = require('../parser');
 const { validatePolicy } = require('../validator');
 
+import type { CDNSecurityFrameworkPolicy } from '../types/policy';
+
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 
-function lintPolicy(opts: any = {}) {
+type LintPolicyOptions = {
+  policyPath?: string;
+  pkgRoot?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+type LintPolicyResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  policy: Partial<CDNSecurityFrameworkPolicy> | null;
+};
+
+function lintPolicy(opts: LintPolicyOptions = {}): LintPolicyResult {
   opts = opts || {};
   const pkgRoot = opts.pkgRoot || DEFAULT_PKG_ROOT;
   const policyPath = opts.policyPath;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 
+import type { CDNSecurityFrameworkPolicy } from '../types/policy';
+
 export type ParsePolicyOptions = {
   policyPath?: string;
 };
@@ -8,7 +10,7 @@ export type ParsePolicyOptions = {
 export type ParsePolicyResult = {
   ok: boolean;
   errors: string[];
-  policy: any | null;
+  policy: Partial<CDNSecurityFrameworkPolicy> | null;
 };
 
 export function parsePolicyFile(opts: ParsePolicyOptions = {}): ParsePolicyResult {
@@ -18,15 +20,16 @@ export function parsePolicyFile(opts: ParsePolicyOptions = {}): ParsePolicyResul
   }
 
   try {
-    const policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+    const policy = yaml.load(fs.readFileSync(policyPath, 'utf8')) as Partial<CDNSecurityFrameworkPolicy>;
     return { ok: true, errors: [], policy };
-  } catch (e: any) {
-    if (e && e.code === 'ENOENT') {
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
       return { ok: false, errors: [`policy file not found: ${policyPath}`], policy: null };
     }
+    const message = e instanceof Error ? e.message : String(e);
     return {
       ok: false,
-      errors: [`failed to parse policy YAML: ${e && e.message ? e.message : String(e)}`],
+      errors: [`failed to parse policy YAML: ${message}`],
       policy: null,
     };
   }

--- a/src/scripts/ensure-report-dir.ts
+++ b/src/scripts/ensure-report-dir.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const reportDir = path.join(process.cwd(), 'reports');
+fs.mkdirSync(reportDir, { recursive: true });

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -2,20 +2,31 @@ const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
 
+import type { ErrorObject } from 'ajv';
+import type { CDNSecurityFrameworkPolicy } from '../types/policy';
+
 const {
   validateAuthGates,
   parsePathPatterns,
 } = require('../scripts/lib/compile-core');
 
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
+export type PolicyDraft = Partial<CDNSecurityFrameworkPolicy>;
+type StringRecord = Record<string, unknown>;
 
 export type ValidatePolicyOptions = {
-  policy: any;
+  policy: PolicyDraft | null;
   pkgRoot?: string;
   env?: NodeJS.ProcessEnv;
 };
 
-export function formatAjvErrors(errors: any[]): string[] {
+export type ValidatePolicyResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+};
+
+export function formatAjvErrors(errors: ErrorObject[] = []): string[] {
   return errors.map((err) => {
     const loc = err.instancePath || '(root)';
     const key =
@@ -26,7 +37,7 @@ export function formatAjvErrors(errors: any[]): string[] {
   });
 }
 
-export function validateCorsCredentials(policy: any): string[] {
+export function validateCorsCredentials(policy: PolicyDraft | null): string[] {
   const cors = policy && policy.response_headers && policy.response_headers.cors;
   if (!cors || cors.allow_credentials !== true || !Array.isArray(cors.allow_origins)) {
     return [];
@@ -39,22 +50,29 @@ export function validateCorsCredentials(policy: any): string[] {
   ];
 }
 
-export function validatePolicy(opts: ValidatePolicyOptions) {
+function getStringProp(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const entry = (value as StringRecord)[key];
+  return typeof entry === 'string' ? entry : undefined;
+}
+
+export function validatePolicy(opts: ValidatePolicyOptions): ValidatePolicyResult {
   const pkgRoot = (opts && opts.pkgRoot) || DEFAULT_PKG_ROOT;
   const policy = opts ? opts.policy : null;
   const env = (opts && opts.env) || process.env;
   const errors: string[] = [];
   const warnings: string[] = [];
 
-  let schema: any;
+  let schema: unknown;
   try {
     schema = JSON.parse(
       fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'),
     );
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
     return {
       ok: false,
-      errors: [`failed to load schema: ${e.message}`],
+      errors: [`failed to load schema: ${message}`],
       warnings,
     };
   }
@@ -78,8 +96,9 @@ export function validatePolicy(opts: ValidatePolicyOptions) {
     if (block.path_patterns !== undefined) {
       parsePathPatterns(block.path_patterns);
     }
-  } catch (e: any) {
-    errors.push(`  - request.block.path_patterns: ${e.message}`);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    errors.push(`  - request.block.path_patterns: ${message}`);
   }
 
   try {
@@ -87,12 +106,18 @@ export function validatePolicy(opts: ValidatePolicyOptions) {
       exitOnError: false,
       allowPlaceholderToken: true,
     });
-  } catch (e: any) {
-    if (Array.isArray(e.validationErrors)) {
+  } catch (e: unknown) {
+    if (
+      e &&
+      typeof e === 'object' &&
+      'validationErrors' in e &&
+      Array.isArray(e.validationErrors)
+    ) {
       errors.push('Auth gate validation failed:');
       e.validationErrors.forEach((msg: string) => errors.push('  - ' + msg));
     } else {
-      errors.push('Auth gate validation error: ' + e.message);
+      const message = e instanceof Error ? e.message : String(e);
+      errors.push('Auth gate validation error: ' + message);
     }
   }
 
@@ -132,12 +157,14 @@ export function validatePolicy(opts: ValidatePolicyOptions) {
   }
 
   const originAuth = policy && policy.origin && policy.origin.auth;
-  if (originAuth && originAuth.type === 'custom_header' && originAuth.secret_env) {
-    const envVal = env[originAuth.secret_env];
+  const originAuthType = getStringProp(originAuth, 'type');
+  const originSecretEnv = getStringProp(originAuth, 'secret_env');
+  if (originAuthType === 'custom_header' && originSecretEnv) {
+    const envVal = env[originSecretEnv];
     if (envVal !== undefined && envVal.length === 0) {
       warnings.push(
         'origin.auth.secret_env "' +
-          originAuth.secret_env +
+          originSecretEnv +
           '" is set but empty in the current shell. The edge will refuse to forward the origin-auth header, breaking origin trust. Unset the env or supply a value.',
       );
     }

--- a/test/compiler-contract.test.ts
+++ b/test/compiler-contract.test.ts
@@ -1,0 +1,43 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const requireFromRepo = createRequire(path.join(process.cwd(), 'package.json'));
+
+describe('compiler public contracts', () => {
+  test('phase modules expose callable contracts', () => {
+    const parser = requireFromRepo('./parser');
+    const validator = requireFromRepo('./validator');
+    const emitter = requireFromRepo('./emitter');
+
+    expect(parser.parsePolicyFile).toEqual(expect.any(Function));
+    expect(validator.validatePolicy).toEqual(expect.any(Function));
+    expect(emitter.compileArtifacts).toEqual(expect.any(Function));
+  });
+
+  test('validator accepts schema-derived policy shape without emitting artifacts', () => {
+    const { validatePolicy } = requireFromRepo('./validator');
+    const result = validatePolicy({
+      pkgRoot: process.cwd(),
+      policy: {
+        version: 1,
+        request: { allow_methods: ['GET'] },
+        response_headers: {},
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      errors: [],
+    });
+    expect(result.warnings).toEqual(expect.any(Array));
+  });
+
+  test('template injection rejects duplicate top-level config declarations', () => {
+    const { assertInjectedConstDeclarations } = requireFromRepo('./scripts/lib/template-inject');
+
+    expect(() => {
+      assertInjectedConstDeclarations('const CFG = {};\nconst CFG = {};', ['CFG']);
+    }).toThrow();
+  });
+});

--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -1,12 +1,16 @@
+import type { ErrorObject } from 'ajv';
+import type { CDNSecurityFrameworkPolicy } from '../types/policy';
+export type PolicyDraft = Partial<CDNSecurityFrameworkPolicy>;
 export type ValidatePolicyOptions = {
-    policy: any;
+    policy: PolicyDraft | null;
     pkgRoot?: string;
     env?: NodeJS.ProcessEnv;
 };
-export declare function formatAjvErrors(errors: any[]): string[];
-export declare function validateCorsCredentials(policy: any): string[];
-export declare function validatePolicy(opts: ValidatePolicyOptions): {
+export type ValidatePolicyResult = {
     ok: boolean;
     errors: string[];
     warnings: string[];
 };
+export declare function formatAjvErrors(errors?: ErrorObject[]): string[];
+export declare function validateCorsCredentials(policy: PolicyDraft | null): string[];
+export declare function validatePolicy(opts: ValidatePolicyOptions): ValidatePolicyResult;

--- a/validator/index.js
+++ b/validator/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 const Ajv = require('ajv');
 const { validateAuthGates, parsePathPatterns, } = require('../scripts/lib/compile-core');
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
-function formatAjvErrors(errors) {
+function formatAjvErrors(errors = []) {
     return errors.map((err) => {
         const loc = err.instancePath || '(root)';
         const key = err.params && err.params.additionalProperty
@@ -29,6 +29,12 @@ function validateCorsCredentials(policy) {
         '  - response_headers.cors: allow_origins cannot include "*" when allow_credentials is true',
     ];
 }
+function getStringProp(value, key) {
+    if (!value || typeof value !== 'object')
+        return undefined;
+    const entry = value[key];
+    return typeof entry === 'string' ? entry : undefined;
+}
 function validatePolicy(opts) {
     const pkgRoot = (opts && opts.pkgRoot) || DEFAULT_PKG_ROOT;
     const policy = opts ? opts.policy : null;
@@ -40,9 +46,10 @@ function validatePolicy(opts) {
         schema = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'policy', 'schema.json'), 'utf8'));
     }
     catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
         return {
             ok: false,
-            errors: [`failed to load schema: ${e.message}`],
+            errors: [`failed to load schema: ${message}`],
             warnings,
         };
     }
@@ -65,7 +72,8 @@ function validatePolicy(opts) {
         }
     }
     catch (e) {
-        errors.push(`  - request.block.path_patterns: ${e.message}`);
+        const message = e instanceof Error ? e.message : String(e);
+        errors.push(`  - request.block.path_patterns: ${message}`);
     }
     try {
         validateAuthGates(policy, {
@@ -74,12 +82,16 @@ function validatePolicy(opts) {
         });
     }
     catch (e) {
-        if (Array.isArray(e.validationErrors)) {
+        if (e &&
+            typeof e === 'object' &&
+            'validationErrors' in e &&
+            Array.isArray(e.validationErrors)) {
             errors.push('Auth gate validation failed:');
             e.validationErrors.forEach((msg) => errors.push('  - ' + msg));
         }
         else {
-            errors.push('Auth gate validation error: ' + e.message);
+            const message = e instanceof Error ? e.message : String(e);
+            errors.push('Auth gate validation error: ' + message);
         }
     }
     const waf = (policy && policy.firewall && policy.firewall.waf) || {};
@@ -105,11 +117,13 @@ function validatePolicy(opts) {
         }
     }
     const originAuth = policy && policy.origin && policy.origin.auth;
-    if (originAuth && originAuth.type === 'custom_header' && originAuth.secret_env) {
-        const envVal = env[originAuth.secret_env];
+    const originAuthType = getStringProp(originAuth, 'type');
+    const originSecretEnv = getStringProp(originAuth, 'secret_env');
+    if (originAuthType === 'custom_header' && originSecretEnv) {
+        const envVal = env[originSecretEnv];
         if (envVal !== undefined && envVal.length === 0) {
             warnings.push('origin.auth.secret_env "' +
-                originAuth.secret_env +
+                originSecretEnv +
                 '" is set but empty in the current shell. The edge will refuse to forward the origin-auth header, breaking origin trust. Unset the env or supply a value.');
         }
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    reporters: process.env.CI ? ['default', 'junit'] : ['default'],
+    outputFile: process.env.CI ? { junit: 'reports/vitest-junit.xml' } : undefined,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a strict compiler typecheck gate for parser, validator, emitter, and target compiler entry points.
- Replaces phase boundary `any` usage with schema-derived policy/result contracts where practical.
- Adds an initial Vitest contract suite, CI JUnit reporting, and docs for test migration + compiler strictness.

## Verification
- `npm run typecheck:compiler-strict`
- `npm run test:types`
- `npm run test:api-contract`
- `npm run test:vitest`
- `CI=true npm run test:vitest`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:all`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:coverage`
- `npm_config_cache=/tmp/cdn-security-npm-cache EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:package`
- `npm_config_cache=/tmp/cdn-security-npm-cache npm audit --audit-level=moderate`

Closes #101
Closes #106