### PR TITLE
[codex] Document build-time auth token setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -144,10 +144,17 @@ npx cdn-security init
 `policy/security.yml` を編集し、次を実行します。
 
 ```bash
+# policy に static_token 認証ゲートがある場合は、参照先の build-time secret を
+# 先に設定します。組み込みの base/admin 例は EDGE_ADMIN_TOKEN を使います。
+export EDGE_ADMIN_TOKEN=replace-with-a-deploy-secret
+
 npx cdn-security build
 ```
 
 ポリシーが検証され、`dist/edge/viewer-request.js` などが生成されます。
+production ではない fixture build だけなら
+`npx cdn-security build --allow-placeholder-token` も使えますが、placeholder token
+を含む artifact はデプロイしないでください。
 
 ### 4. テスト
 
@@ -168,6 +175,8 @@ npx cdn-security explain
 ```
 
 Node バージョン、ポリシーのパース/スキーマバージョン、認証ゲートが参照する全環境変数（`EDGE_ADMIN_TOKEN`・`JWT_SECRET`・`ORIGIN_SECRET` など）、`dist/edge/` の書き込み可否、`npm ls` の健全性を一括で pass/fail 判定します。CI でアーティファクト化できる `doctor-report.json` も書き出します。詳細は [CLI リファレンス](docs/cli.ja.md)。
+CloudFront Functions の static token gate は生成 artifact に焼き込まれるため、
+`doctor` も `build` と同じ環境変数を設定した状態で実行してください。
 
 `explain` はポリシーの姿勢を読み取り専用で要約し、レビューやオンボーディングに使えます。
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Or with an archetype: `npx cdn-security init --platform aws --archetype rest-api
 Edit `policy/security.yml` as needed, then:
 
 ```bash
+# If your policy has a static_token auth gate, set the referenced build-time
+# secret first. The built-in base/admin examples use EDGE_ADMIN_TOKEN.
+export EDGE_ADMIN_TOKEN=replace-with-a-deploy-secret
+
 # AWS (default): generates viewer-request.js, viewer-response.js, origin-request.js
 npx cdn-security build
 
@@ -157,6 +161,9 @@ npx cdn-security build --rule-group-only
 ```
 
 This validates the policy and generates Edge Runtime code into `dist/edge/`.
+For non-production fixture builds, you can use
+`npx cdn-security build --allow-placeholder-token`, but never deploy artifacts
+that contain the placeholder token.
 
 ### 4. Test
 
@@ -177,6 +184,8 @@ npx cdn-security explain
 ```
 
 One-shot pass/fail report: Node version, policy parseability / schema version, every env var referenced by auth gates (`EDGE_ADMIN_TOKEN`, `JWT_SECRET`, `ORIGIN_SECRET`, ...), `dist/edge/` writability, and `npm ls` cleanliness. Writes `doctor-report.json` for CI capture. See [CLI reference](docs/cli.md) for details.
+Run it with the same env vars you will use for `build`, because CloudFront
+Functions bake static token gates into the generated artifact.
 
 `explain` prints a read-only policy posture summary for review and onboarding.
 


### PR DESCRIPTION
## Summary

Documents the build-time secret prerequisite for policies that use `static_token` auth gates.

## Why

The built-in base/admin examples reference `EDGE_ADMIN_TOKEN`, and CloudFront Functions bake static token values into generated artifacts. Without that environment variable, the documented Quick Start build and doctor flow fails locally.

## Changes

- Adds `EDGE_ADMIN_TOKEN` setup before the Quick Start build command in English and Japanese READMEs.
- Documents `--allow-placeholder-token` as a non-production fixture option.
- Clarifies that `doctor` should run with the same environment variables as `build`.

## Validation

- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run build`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy node bin/cli.js doctor --no-report`