### PR TITLE
[codex] Document local test fixture secrets

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -152,6 +152,9 @@ npx cdn-security build
 ### 4. テスト
 
 ```bash
+export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
+export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
+
 npm run test:runtime
 npm run test:unit
 npm run test:drift
@@ -159,6 +162,8 @@ npm run test:security-baseline
 ```
 
 CI と同じ runtime / unit / drift / security-baseline チェックを実行します。
+`EDGE_ADMIN_TOKEN` は組み込み admin `static_token` gate を含む生成 artifact に必要です。
+`ORIGIN_SECRET` は origin-auth fixture policy を含む drift / release 系チェックで必要です。
 
 ### 4.5 環境診断（初回デプロイ前の任意実行、推奨）
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ This validates the policy and generates Edge Runtime code into `dist/edge/`.
 ### 4. Test
 
 ```bash
+export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
+export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
+
 npm run test:runtime
 npm run test:unit
 npm run test:drift
@@ -168,6 +171,9 @@ npm run test:security-baseline
 ```
 
 Runs runtime, unit, drift, and security-baseline checks used by CI.
+`EDGE_ADMIN_TOKEN` is required by generated artifacts that include the built-in
+admin `static_token` gate. `ORIGIN_SECRET` is required by origin-auth fixture
+policies used by the broader drift/release checks.
 
 ### 4.5 Diagnose (optional but recommended before first deploy)
 

--- a/docs/test-strategy.ja.md
+++ b/docs/test-strategy.ja.md
@@ -17,9 +17,22 @@
 
 ## local workflow
 
+- generated artifact や release gate 系チェックを実行する前に、CI と同じ用途の
+  fixture secret を設定します。
+
+  ```bash
+  export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
+  export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
+  ```
+
 - Vitest の focused check: `npm run test:vitest`
 - 既存 unit suite: `npm run test:unit`
 - release gate 全体: `npm run test:all`
+
+`EDGE_ADMIN_TOKEN` は `static_token` 認証ゲートを含む CloudFront Functions artifact
+に焼き込まれます。`ORIGIN_SECRET` は drift / release gate で使う origin-auth fixture
+向けです。これらの値は local / CI 検証専用であり、production build では deploy 用の
+secret を使ってください。
 
 `CI=true` の場合、Vitest は `reports/vitest-junit.xml` に JUnit output を出します。
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -19,9 +19,22 @@ Node scripts, while introducing Vitest for focused compiler contract tests.
 
 ## Local workflow
 
+- Export the CI-style fixture secrets before running generated-artifact or
+  release-gate checks:
+
+  ```bash
+  export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
+  export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
+  ```
+
 - Run focused Vitest checks with `npm run test:vitest`.
 - Run legacy unit coverage with `npm run test:unit`.
 - Run the full release gate with `npm run test:all`.
+
+`EDGE_ADMIN_TOKEN` is baked into CloudFront Function artifacts for policies
+with `static_token` auth gates. `ORIGIN_SECRET` covers origin-auth fixtures used
+by drift and release-gate checks. These fixture values are for local/CI
+validation only; production builds must use deployment secrets.
 
 Vitest writes JUnit output to `reports/vitest-junit.xml` when `CI=true`.
 


### PR DESCRIPTION
## Summary

Documents the fixture secrets required for local generated-artifact and release-gate test workflows.

## Why

The local README test commands previously omitted the environment variables that CI sets. `EDGE_ADMIN_TOKEN` is needed for generated artifacts with the built-in admin `static_token` gate, and `ORIGIN_SECRET` is needed by origin-auth fixture policies in broader drift/release checks.

## Changes

- Adds fixture secret exports before the README local test commands in English and Japanese.
- Expands the test strategy docs with the same local workflow prerequisite.
- Clarifies that these values are only for local/CI validation and production builds must use deployment secrets.

## Validation

- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:runtime`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:drift`