### PR TITLE
[codex] Document response DLP rollout

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,7 @@ Terraform / CloudFormation / CDK / WAF の利用例は [IaC 連携](docs/iac.ja.
 - [プログラマティック API](docs/programmatic-api.ja.md) — `require('cdn-security-framework')` で CI / IaC から直接呼び出し
 - [Compiler strictness](docs/compiler-strictness.ja.md) — phase contract、strict check、残る dynamic area
 - [アーキタイプ](docs/archetypes.ja.md) — アプリ形状別プリセット（SPA / REST API / 管理画面 / マイクロサービス）
+- [レスポンス DLP](docs/response-dlp.ja.md) — Cloudflare Workers で高信頼の漏えい値を mask/block する設定
 - [シークレットローテーション runbook](docs/runbooks/secret-rotation.ja.md) — JWT / JWKS / 署名付き URL / 管理トークン / origin シークレット
 - [スキーママイグレーション](docs/schema-migration.ja.md) — `policy/schema.json` のバージョン契約と `migrate` CLI
 - [サプライチェーン](docs/supply-chain.ja.md) — SLSA v1 provenance と `npm audit signatures`

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ See [IaC integration](docs/iac.md) for Terraform / CloudFormation / CDK / WAF us
 - [Programmatic API](docs/programmatic-api.md) — `require('cdn-security-framework')` for CI / IaC integration
 - [Compiler strictness](docs/compiler-strictness.md) — phase contracts, strict checks, and remaining dynamic areas
 - [Archetypes](docs/archetypes.md) — app-shaped policy presets (SPA, REST API, admin, microservice)
+- [Response DLP](docs/response-dlp.md) — Cloudflare Workers response masking/blocking for high-confidence data leaks
 - [Secret rotation runbook](docs/runbooks/secret-rotation.md) — JWT / JWKS / signed URL / admin token / origin secret
 - [Schema migration](docs/schema-migration.md) — how `policy/schema.json` evolves and the `migrate` CLI
 - [Supply chain](docs/supply-chain.md) — SLSA v1 provenance and `npm audit signatures`

--- a/docs/SECURITY-FEATURE-MATRIX.ja.md
+++ b/docs/SECURITY-FEATURE-MATRIX.ja.md
@@ -131,6 +131,8 @@ built-in detector は API key prefix（`sk-live-`、`sk_test_`、`ghp_`）と、
 
 body inspection は設定されたテキスト系 `Content-Type` と `body.max_bytes`（既定 32768、最大 131072）に限定します。上限超過または非テキストレスポンスは変更せず通します。CloudFront Functions はレスポンス body を検査できないため、`response_dlp.enabled: true` の AWS compile では unsupported warning を出します。
 
+policy shape、rollout guidance、target support、performance constraints は [レスポンス DLP](./response-dlp.ja.md) を参照してください。
+
 ---
 
 ## 使用例

--- a/docs/SECURITY-FEATURE-MATRIX.md
+++ b/docs/SECURITY-FEATURE-MATRIX.md
@@ -129,6 +129,8 @@ Built-in detectors cover API-key prefixes (`sk-live-`, `sk_test_`, `ghp_`) and c
 
 Body inspection is limited to configured text-like `Content-Type` values and `body.max_bytes` (default 32768, maximum 131072). Larger or non-text responses pass through unchanged. CloudFront Functions cannot inspect response bodies; the AWS compiler emits an unsupported warning when `response_dlp.enabled: true`.
 
+See [Response DLP](./response-dlp.md) for the policy shape, rollout guidance, target support, and performance constraints.
+
 ---
 
 ## Usage Examples

--- a/docs/response-dlp.ja.md
+++ b/docs/response-dlp.ja.md
@@ -70,7 +70,7 @@ header inspection は `headers.names` に限定されます。未設定の場合
 ## 運用メモ
 
 - response DLP を secret 保護の唯一の手段にしないでください。可能な限り origin response に sensitive value を出さない設計を優先します。
-- まず `report_only` を使い、`response_dlp_report_only` log event を確認してから `mask` または `block` に切り替えてください。
+- まず `report_only` を使い、`event` が `monitor`、`block_reason` が `response_dlp_report_only` の DLP finding を確認してから `mask` または `block` に切り替えてください。
 - `max_bytes` は、実際に検査したい最大レスポンスサイズに近い値にしてください。
 - 広いテキストに曖昧な wildcard を当てる custom regex は避けてください。build-time guard は一般的な ReDoS 形状を拒否しますが、狭い pattern の方が安全で高速です。
 - 圧縮または暗号化された payload は、runtime が readable decoded body として露出しない限り decode しません。

--- a/docs/response-dlp.ja.md
+++ b/docs/response-dlp.ja.md
@@ -1,0 +1,76 @@
+# レスポンス DLP
+
+> **言語:** [English](./response-dlp.md) - 日本語
+
+`response_dlp` は、レスポンスヘッダーとサイズ上限内のテキスト系レスポンスボディを検査する opt-in のデータ漏えい防止ガードです。現時点で enforcement する target は Cloudflare Workers です。
+
+```yaml
+response_dlp:
+  enabled: true
+  action: report_only       # report_only | mask | block
+  mask: "[REDACTED]"
+  block_status: 451
+  block_body: "Response blocked by edge DLP"
+  body:
+    enabled: true
+    max_bytes: 32768
+    content_types:
+      - "text/"
+      - "application/json"
+  headers:
+    enabled: true
+    names:
+      - "set-cookie"
+      - "authorization"
+      - "x-api-key"
+  detectors:
+    built_in:
+      - "api_key"
+      - "credit_card"
+    custom_regex:
+      - name: "internal_token"
+        pattern: "internal_[A-Za-z0-9]{16,}"
+```
+
+## 対応 target
+
+Cloudflare Workers は、設定されたレスポンスヘッダーと、テキスト系レスポンスボディの clone を検査できます。有効化すると、compiler は DLP 設定と detector regex を `dist/edge/cloudflare/index.ts` に注入します。
+
+CloudFront Functions はレスポンス body を検査できません。AWS target で `response_dlp.enabled: true` の場合は unsupported warning を出し、レスポンス DLP の mask/block は enforcement しません。AWS 配備では Cloudflare Workers、Lambda/origin 側の制御、またはアプリケーション層の DLP を使ってください。
+
+## action
+
+| Action | 動作 |
+|--------|------|
+| `report_only` | DLP finding をログに出し、`X-Edge-DLP: report_only` を付け、レスポンス本体は変更しません。 |
+| `mask` | 検出値を `mask` に置換し、body 書き換え時は `content-length` を削除し、`X-Edge-DLP: mask` を付けます。 |
+| `block` | `block_status`、`block_body`、`Cache-Control: no-store`、`X-Edge-DLP: block` を持つ合成レスポンスを返します。 |
+
+最初は `report_only` で開始し、本番に近い traffic に対して detector を調整してから mask/block に切り替えてください。
+
+## detector
+
+built-in detector は高信頼なものに限定しています。
+
+- `api_key`: `sk-live-`、`sk_test_`、`ghp_` などの一般的な key prefix。
+- `credit_card`: Luhn 検証に通る 13-19 桁の card-like 値。
+
+custom regex detector は build 時に compile され、最大 10 件、1 pattern 256 文字までに制限されます。既知の nested quantifier 系 ReDoS 形状は拒否されます。custom detector は狭くし、anchor や prefix を使った pattern を優先してください。
+
+## body の制限
+
+body inspection は `body.enabled` が false ではなく、レスポンス `Content-Type` が設定された `content_types` のいずれかの部分文字列を含む場合だけ実行されます。既定値は text / JSON / XML 系レスポンスを対象にします。
+
+`body.max_bytes` の既定は `32768`、上限は `131072` です。`Content-Length` が上限を超える場合、または clone した body を読んだ結果が上限を超える場合、Worker はレスポンスを変更せず通します。これにより edge の CPU とメモリコストを bounded に保ちます。
+
+## header の制限
+
+header inspection は `headers.names` に限定されます。未設定の場合の既定値は `set-cookie`、`authorization`、`x-api-key` です。レスポンス DLP は Cookie を意味的に parse せず、設定された header value を文字列として scan します。
+
+## 運用メモ
+
+- response DLP を secret 保護の唯一の手段にしないでください。可能な限り origin response に sensitive value を出さない設計を優先します。
+- まず `report_only` を使い、`response_dlp_report_only` log event を確認してから `mask` または `block` に切り替えてください。
+- `max_bytes` は、実際に検査したい最大レスポンスサイズに近い値にしてください。
+- 広いテキストに曖昧な wildcard を当てる custom regex は避けてください。build-time guard は一般的な ReDoS 形状を拒否しますが、狭い pattern の方が安全で高速です。
+- 圧縮または暗号化された payload は、runtime が readable decoded body として露出しない限り decode しません。

--- a/docs/response-dlp.md
+++ b/docs/response-dlp.md
@@ -70,7 +70,7 @@ Header inspection is limited to `headers.names`. If no names are configured, the
 ## Operational Notes
 
 - Do not use response DLP as the only protection for secrets. Prevent sensitive values from reaching the origin response whenever possible.
-- Use `report_only` first and monitor `response_dlp_report_only` log events before switching to `mask` or `block`.
+- Use `report_only` first and monitor DLP findings where `event` is `monitor` and `block_reason` is `response_dlp_report_only` before switching to `mask` or `block`.
 - Keep `max_bytes` close to the largest response shape you intentionally inspect.
 - Avoid custom regexes that scan broad text with ambiguous wildcards. Build-time guards catch common ReDoS shapes, but narrow patterns are still safer and faster.
 - Compressed or encrypted payloads are not decoded by this feature unless the runtime exposes a readable decoded body.

--- a/docs/response-dlp.md
+++ b/docs/response-dlp.md
@@ -1,0 +1,76 @@
+# Response DLP
+
+> **Languages:** English - [日本語](./response-dlp.ja.md)
+
+`response_dlp` is an opt-in response data-loss prevention guard for targets that can inspect response headers and bounded text-like response bodies. The current enforcement target is Cloudflare Workers.
+
+```yaml
+response_dlp:
+  enabled: true
+  action: report_only       # report_only | mask | block
+  mask: "[REDACTED]"
+  block_status: 451
+  block_body: "Response blocked by edge DLP"
+  body:
+    enabled: true
+    max_bytes: 32768
+    content_types:
+      - "text/"
+      - "application/json"
+  headers:
+    enabled: true
+    names:
+      - "set-cookie"
+      - "authorization"
+      - "x-api-key"
+  detectors:
+    built_in:
+      - "api_key"
+      - "credit_card"
+    custom_regex:
+      - name: "internal_token"
+        pattern: "internal_[A-Za-z0-9]{16,}"
+```
+
+## Target Support
+
+Cloudflare Workers can inspect configured response headers and clone text-like response bodies before returning the response. When enabled, the compiler injects DLP configuration and detector regexes into `dist/edge/cloudflare/index.ts`.
+
+CloudFront Functions cannot inspect response bodies. The AWS target emits an unsupported warning when `response_dlp.enabled: true` and does not enforce response DLP masking or blocking. Use Cloudflare Workers, Lambda/origin-side controls, or an application-layer DLP control for AWS deployments.
+
+## Actions
+
+| Action | Behavior |
+|--------|----------|
+| `report_only` | Logs a DLP finding, adds `X-Edge-DLP: report_only`, and leaves the response unchanged. |
+| `mask` | Replaces matched values with `mask`, removes `content-length` for body rewrites, and adds `X-Edge-DLP: mask`. |
+| `block` | Returns a synthetic response with `block_status`, `block_body`, `Cache-Control: no-store`, and `X-Edge-DLP: block`. |
+
+Start with `report_only` so you can tune detectors against production-shaped traffic before mutating or blocking responses.
+
+## Detectors
+
+Built-in detectors are intentionally high-confidence:
+
+- `api_key`: common key prefixes such as `sk-live-`, `sk_test_`, and `ghp_`.
+- `credit_card`: 13-19 digit card-like values that pass Luhn validation.
+
+Custom regex detectors are compiled at build time, capped at 10 patterns and 256 characters per pattern, and rejected when they match known nested-quantifier ReDoS shapes. Keep custom detectors narrow and prefer anchored or prefix-specific patterns.
+
+## Body Limits
+
+Body inspection only runs when `body.enabled` is not false and the response `Content-Type` contains one of the configured `content_types` substrings. The default list covers text and JSON/XML-like responses.
+
+`body.max_bytes` defaults to `32768` and is capped at `131072`. If `Content-Length` is above the limit, or the cloned body exceeds the limit after reading, the Worker passes the response through unchanged. This keeps edge CPU and memory cost bounded.
+
+## Header Limits
+
+Header inspection is limited to `headers.names`. If no names are configured, the default set is `set-cookie`, `authorization`, and `x-api-key`. Response DLP does not parse cookies semantically; it scans configured header values as strings.
+
+## Operational Notes
+
+- Do not use response DLP as the only protection for secrets. Prevent sensitive values from reaching the origin response whenever possible.
+- Use `report_only` first and monitor `response_dlp_report_only` log events before switching to `mask` or `block`.
+- Keep `max_bytes` close to the largest response shape you intentionally inspect.
+- Avoid custom regexes that scan broad text with ambiguous wildcards. Build-time guards catch common ReDoS shapes, but narrow patterns are still safer and faster.
+- Compressed or encrypted payloads are not decoded by this feature unless the runtime exposes a readable decoded body.

--- a/examples/cloudflare/README.ja.md
+++ b/examples/cloudflare/README.ja.md
@@ -31,6 +31,21 @@ npm run init
 
 `policy/security.yml` を編集し、許可メソッド・ブロックルール・ルート・レスポンスヘッダーなどを調整します。
 
+Cloudflare Workers ではレスポンス DLP も enforcement できます。mask/block の前に `report_only` で開始してください。
+
+```yaml
+response_dlp:
+  enabled: true
+  action: report_only
+  body:
+    max_bytes: 32768
+    content_types: ["text/", "application/json"]
+  headers:
+    names: ["set-cookie", "authorization", "x-api-key"]
+```
+
+detector の挙動と rollout メモは [レスポンス DLP](../../docs/response-dlp.ja.md) を参照してください。
+
 ### 3. ビルド
 
 ```bash
@@ -92,3 +107,4 @@ curl -i "https://YOUR_WORKER_DOMAIN/foo/../bar"
 - [Cloudflare Workers ランタイム](../../runtimes/cloudflare-workers/README.ja.md)
 - [クイックスタート](../../docs/quickstart.ja.md)
 - [ポリシーとランタイムの同期](../../docs/policy-runtime-sync.ja.md)
+- [レスポンス DLP](../../docs/response-dlp.ja.md)

--- a/examples/cloudflare/README.md
+++ b/examples/cloudflare/README.md
@@ -31,6 +31,21 @@ This installs the framework from the repo root (`file:../..`) and creates `polic
 
 Edit `policy/security.yml` to adjust allowed methods, block rules, routes, response headers, etc.
 
+Cloudflare Workers can also enforce response DLP. Start in `report_only` mode before masking or blocking:
+
+```yaml
+response_dlp:
+  enabled: true
+  action: report_only
+  body:
+    max_bytes: 32768
+    content_types: ["text/", "application/json"]
+  headers:
+    names: ["set-cookie", "authorization", "x-api-key"]
+```
+
+See [Response DLP](../../docs/response-dlp.md) for detector behavior and rollout notes.
+
 ### 3. Build
 
 ```bash
@@ -92,3 +107,4 @@ curl -i "https://YOUR_WORKER_DOMAIN/foo/../bar"
 - [Cloudflare Workers Runtime](../../runtimes/cloudflare-workers/README.md)
 - [Quick Start](../../docs/quickstart.md)
 - [Policy and runtime sync](../../docs/policy-runtime-sync.md)
+- [Response DLP](../../docs/response-dlp.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Add dedicated English/Japanese Response DLP docs covering policy shape, target support, actions, detectors, limits, and rollout guidance.
- Link the new docs from the README, security feature matrix, and Cloudflare example.
- Add a Cloudflare example snippet that starts `response_dlp` in `report_only` before mask/block enforcement.

## Why
Issue #104 is the highest-priority open issue (`priority/p1`, `severity/high`). The latest `develop` already contains the runtime/schema/test implementation, but the operational documentation and discoverable example path were still thin. This PR closes that remaining product/documentation gap without duplicating the existing implementation.

Closes #104

## Validation
- `npm run test:cloudflare-integration`
- `npm run test:unit`
