### PR TITLE
[codex] Add deployment workflow templates

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -157,6 +157,191 @@ function printReadinessReport(report) {
         stream(`       ${finding.recommendation}`);
     }
 }
+function renderAwsDeploymentWorkflow() {
+    return `name: CDN Security AWS Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'policy/**'
+      - 'templates/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/cdn-security-aws.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-cdn-security:
+    runs-on: ubuntu-latest
+    env:
+      # Configure these as repository secrets. Do not commit production values.
+      EDGE_ADMIN_TOKEN: \${{ secrets.EDGE_ADMIN_TOKEN }}
+      ORIGIN_SECRET: \${{ secrets.ORIGIN_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Diagnose environment
+        run: npx cdn-security doctor --no-report --strict
+
+      - name: Check production readiness
+        run: npx cdn-security readiness --target aws --strict --report readiness-report.json
+
+      - name: Build AWS edge and WAF artifacts
+        run: npx cdn-security build --target aws --out-dir dist
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdn-security-aws-artifacts
+          path: |
+            dist/edge/
+            dist/infra/
+            readiness-report.json
+
+      # Deployment is intentionally left explicit. Wire dist/edge/*.js and
+      # dist/infra/*.tf.json into your Terraform/CDK/CloudFront release flow.
+`;
+}
+function renderCloudflareDeploymentWorkflow() {
+    return `name: CDN Security Cloudflare Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'policy/**'
+      - 'templates/**'
+      - 'wrangler.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/cdn-security-cloudflare.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-cdn-security:
+    runs-on: ubuntu-latest
+    env:
+      # Configure these as repository secrets. Do not commit production values.
+      EDGE_ADMIN_TOKEN: \${{ secrets.EDGE_ADMIN_TOKEN }}
+      BASIC_AUTH_CREDS: \${{ secrets.BASIC_AUTH_CREDS }}
+      URL_SIGNING_SECRET: \${{ secrets.URL_SIGNING_SECRET }}
+      JWT_SECRET: \${{ secrets.JWT_SECRET }}
+      ORIGIN_SECRET: \${{ secrets.ORIGIN_SECRET }}
+      CHALLENGE_SECRET: \${{ secrets.CHALLENGE_SECRET }}
+      CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CDN_SECURITY_WORKER_SECRET_NAMES: EDGE_ADMIN_TOKEN,BASIC_AUTH_CREDS,URL_SIGNING_SECRET,JWT_SECRET,ORIGIN_SECRET,CHALLENGE_SECRET
+      CDN_SECURITY_WORKER_SECRETS_FILE: \${{ runner.temp }}/cdn-security-worker-secrets.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Diagnose environment
+        run: npx cdn-security doctor --no-report --strict
+
+      - name: Check production readiness
+        run: npx cdn-security readiness --target cloudflare --strict --report readiness-report.json
+
+      - name: Build Cloudflare Worker and WAF artifacts
+        run: npx cdn-security build --target cloudflare --out-dir dist
+
+      - name: Prepare Worker runtime secrets
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const secretsFile = process.env.CDN_SECURITY_WORKER_SECRETS_FILE || '/tmp/cdn-security-worker-secrets.json';
+          const names = (process.env.CDN_SECURITY_WORKER_SECRET_NAMES || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const secrets = {};
+          for (const name of names) {
+            const value = process.env[name];
+            if (value) secrets[name] = value;
+          }
+          if (Object.keys(secrets).length === 0) {
+            console.log('[INFO] No Worker runtime secrets configured; deploying without --secrets-file.');
+            process.exit(0);
+          }
+          fs.writeFileSync(secretsFile, JSON.stringify(secrets));
+          NODE
+
+      - name: Deploy Worker with Wrangler
+        run: |
+          if [ -f "$CDN_SECURITY_WORKER_SECRETS_FILE" ]; then
+            trap 'rm -f "$CDN_SECURITY_WORKER_SECRETS_FILE"' EXIT
+            npx wrangler deploy dist/edge/cloudflare/index.ts --secrets-file "$CDN_SECURITY_WORKER_SECRETS_FILE"
+          else
+            npx wrangler deploy dist/edge/cloudflare/index.ts
+          fi
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdn-security-cloudflare-artifacts
+          path: |
+            dist/edge/cloudflare/
+            dist/infra/
+            readiness-report.json
+
+      # Configure wrangler.toml, routes, account-specific bindings, and any
+      # extra policy secret env names before enabling production deploys.
+`;
+}
+function writeDeploymentTemplates(opts, cwd) {
+    const target = opts.target || 'all';
+    if (!['aws', 'cloudflare', 'all'].includes(target)) {
+        throw new Error('Invalid --target. Use aws, cloudflare, or all.');
+    }
+    const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
+    fs.mkdirSync(outDir, { recursive: true });
+    const templates = [];
+    if (target === 'aws' || target === 'all') {
+        templates.push({ file: 'cdn-security-aws.yml', content: renderAwsDeploymentWorkflow() });
+    }
+    if (target === 'cloudflare' || target === 'all') {
+        templates.push({ file: 'cdn-security-cloudflare.yml', content: renderCloudflareDeploymentWorkflow() });
+    }
+    const existing = templates
+        .map((template) => path.join(outDir, template.file))
+        .filter((filePath) => fs.existsSync(filePath));
+    if (existing.length > 0 && !opts.force) {
+        throw new Error(`${existing.join(', ')} already exists. Use --force to overwrite.`);
+    }
+    const written = [];
+    for (const template of templates) {
+        const filePath = path.join(outDir, template.file);
+        fs.writeFileSync(filePath, template.content, 'utf8');
+        written.push(filePath);
+    }
+    return written;
+}
 function collectFiles(root) {
     if (!fs.existsSync(root))
         return [];
@@ -406,6 +591,22 @@ program
         printReadinessReport(report);
     }
     process.exit(exitCode);
+});
+program
+    .command('deploy-template')
+    .description('Generate GitHub Actions deployment workflow templates for generated CDN security artifacts')
+    .option('-o, --out-dir <dir>', 'Workflow output directory', '.github/workflows')
+    .option('-t, --target <platform>', 'Target platform: aws | cloudflare | all', 'all')
+    .option('-f, --force', 'Overwrite existing generated workflow templates')
+    .action((opts) => {
+    try {
+        const files = writeDeploymentTemplates(opts, process.cwd());
+        files.forEach((filePath) => console.log('[SUCCESS] Generated ' + filePath));
+    }
+    catch (e) {
+        console.error('[ERROR]', e.message);
+        process.exit(1);
+    }
 });
 program
     .command('explain')

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -15,6 +15,7 @@ npx cdn-security <subcommand> [options]
 | `emit-waf` | インフラ設定のみ生成（エッジは生成しない）。エッジはそのままで WAF ルールだけ再デプロイしたいとき。 |
 | `doctor` | 環境診断をワンショット実行。失敗チェックがあれば非ゼロ終了。 |
 | `readiness` | 環境診断と policy posture を統合する本番リリースゲート。 |
+| `deploy-template` | AWS / Cloudflare の artifact deployment 用 GitHub Actions workflow template を生成。 |
 | `explain` | レビューやオンボーディング向けにポリシーの要点を表示。 |
 | `diff` | 現在の `dist/` と再生成結果を比較し、drift があれば失敗。 |
 | `migrate` | スキーマのバージョン間マイグレーション（現状 v1 のみの stub）。 |
@@ -117,6 +118,19 @@ npx cdn-security readiness --report readiness-report.json
 選択した policy に対して、本番向けのリリースゲートを実行します。環境診断と policy validation を再利用し、そのうえで risk level、enforce mode、HTTP method 制限、レスポンスヘッダー、WAF rate limit、managed rule のカバレッジ、target 固有の未対応機能を確認します。
 
 `fail` finding が 1 件でもあれば exit `1` です。`--strict` では warning finding も失敗扱いになります。`--json` は stdout に JSON を出力し、`--report <path>` は人間向け summary を出しつつ同じ machine-readable report をファイルに書き出します。
+
+## `deploy-template`
+
+```bash
+npx cdn-security deploy-template
+npx cdn-security deploy-template --target aws
+npx cdn-security deploy-template --target cloudflare
+npx cdn-security deploy-template --out-dir .github/workflows --force
+```
+
+生成された edge / infra artifact のための GitHub Actions workflow starter を書き出します。AWS template は `dist/edge/` と `dist/infra/` を build して upload し、後続の Terraform / CDK / CloudFront release flow に渡せる形にします。Cloudflare template は Worker を build し、`wrangler deploy --secrets-file` で設定済み runtime secret を code と一緒に渡して artifact も upload します。
+
+template は `EDGE_ADMIN_TOKEN`、`BASIC_AUTH_CREDS`、`URL_SIGNING_SECRET`、`JWT_SECRET`、`ORIGIN_SECRET`、`CHALLENGE_SECRET`、`CLOUDFLARE_API_TOKEN`、`CLOUDFLARE_ACCOUNT_ID` などの GitHub Secrets 名だけを参照し、secret 値は含みません。Cloudflare で policy が追加の `*_env` 名を使う場合は `CDN_SECURITY_WORKER_SECRET_NAMES` を拡張してください。既存ファイルは `--force` を付けない限り上書きしません。
 
 ## `explain`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ npx cdn-security <subcommand> [options]
 | `emit-waf` | Emit infra config only (no edge code). For redeploying firewall rules without touching edge. |
 | `doctor` | One-shot environment diagnostics. Exits non-zero on any failing check. |
 | `readiness` | Production release gate that combines diagnostics and policy posture findings. |
+| `deploy-template` | Generate GitHub Actions workflow templates for AWS and Cloudflare artifact deployment. |
 | `explain` | Print a concise policy posture summary for review and onboarding. |
 | `diff` | Compare generated output against the current `dist/` tree and fail on drift. |
 | `migrate` | Migrate a policy file between schema versions (stub — v1 is the only shipped version today). |
@@ -117,6 +118,19 @@ npx cdn-security readiness --report readiness-report.json
 Runs a production-oriented release gate over the selected policy. It reuses environment diagnostics and policy validation, then adds production posture checks for risk level, enforce mode, method restrictions, response headers, WAF rate limits, managed-rule coverage, and target-specific unsupported controls.
 
 Exit code is `1` when any finding has severity `fail`. With `--strict`, warning findings also fail the command. Use `--json` for stdout JSON, or `--report <path>` to write the same machine-readable report while keeping the human summary on stdout/stderr.
+
+## `deploy-template`
+
+```bash
+npx cdn-security deploy-template
+npx cdn-security deploy-template --target aws
+npx cdn-security deploy-template --target cloudflare
+npx cdn-security deploy-template --out-dir .github/workflows --force
+```
+
+Writes starter GitHub Actions workflows for generated edge and infra artifacts. The AWS template builds and uploads `dist/edge/` and `dist/infra/` for a downstream Terraform/CDK/CloudFront release. The Cloudflare template builds the Worker, passes configured runtime secrets through `wrangler deploy --secrets-file`, and uploads generated artifacts.
+
+The templates reference GitHub Secrets such as `EDGE_ADMIN_TOKEN`, `BASIC_AUTH_CREDS`, `URL_SIGNING_SECRET`, `JWT_SECRET`, `ORIGIN_SECRET`, `CHALLENGE_SECRET`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID`; they never include secret values. For Cloudflare, extend `CDN_SECURITY_WORKER_SECRET_NAMES` when your policy uses additional `*_env` names. Existing files are not overwritten unless `--force` is provided.
 
 ## `explain`
 

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -536,6 +536,100 @@ test('CLI authoring DX: readiness strict mode fails on warnings', () => {
         ctx.cleanup();
     }
 });
+test('CLI authoring DX: deploy-template emits AWS and Cloudflare workflow templates', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const outDir = path.join(tmp, '.github', 'workflows');
+        const result = spawnSync(process.execPath, [
+            cli, 'deploy-template',
+            '--target', 'all',
+            '--out-dir', outDir,
+        ], {
+            cwd: tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 0, `deploy-template failed: ${result.stderr}`);
+        const aws = fs.readFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'utf8');
+        const cloudflare = fs.readFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'utf8');
+        assert.ok(aws.includes('cdn-security readiness --target aws --strict'));
+        assert.ok(aws.includes('${{ secrets.EDGE_ADMIN_TOKEN }}'));
+        assert.ok(aws.includes('cdn-security build --target aws --out-dir dist'));
+        assert.ok(cloudflare.includes('cdn-security readiness --target cloudflare --strict'));
+        assert.ok(cloudflare.includes('CDN_SECURITY_WORKER_SECRET_NAMES'));
+        assert.ok(cloudflare.includes('CDN_SECURITY_WORKER_SECRETS_FILE'));
+        assert.ok(cloudflare.includes('npx wrangler deploy dist/edge/cloudflare/index.ts --secrets-file'));
+        assert.ok(cloudflare.includes('${{ secrets.CLOUDFLARE_API_TOKEN }}'));
+        assert.ok(cloudflare.includes("'wrangler.toml'"));
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+test('CLI authoring DX: deploy-template refuses overwrite without --force', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const outDir = path.join(tmp, '.github', 'workflows');
+        fs.mkdirSync(outDir, { recursive: true });
+        fs.writeFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'existing\n', 'utf8');
+        const result = spawnSync(process.execPath, [
+            cli, 'deploy-template',
+            '--target', 'aws',
+            '--out-dir', outDir,
+        ], {
+            cwd: tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 1);
+        assert.ok(/already exists/.test(result.stderr));
+        const forced = spawnSync(process.execPath, [
+            cli, 'deploy-template',
+            '--target', 'aws',
+            '--out-dir', outDir,
+            '--force',
+        ], {
+            cwd: tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(forced.status, 0, `forced deploy-template failed: ${forced.stderr}`);
+        assert.ok(fs.readFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'utf8').includes('CDN Security AWS Build'));
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+test('CLI authoring DX: deploy-template does not partially write on overwrite refusal', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const outDir = path.join(tmp, '.github', 'workflows');
+        fs.mkdirSync(outDir, { recursive: true });
+        fs.writeFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'existing\n', 'utf8');
+        const result = spawnSync(process.execPath, [
+            cli, 'deploy-template',
+            '--target', 'all',
+            '--out-dir', outDir,
+        ], {
+            cwd: tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 1);
+        assert.ok(/already exists/.test(result.stderr));
+        assert.ok(!fs.existsSync(path.join(outDir, 'cdn-security-aws.yml')));
+        assert.strictEqual(fs.readFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'utf8'), 'existing\n');
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
 test('CLI authoring DX: diff detects generated output drift', () => {
     const ctx = tmpProject(BASIC_AWS_POLICY);
     const { spawnSync } = require('child_process');

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -44,6 +44,12 @@ type ReadinessOptions = {
   strict?: boolean;
 };
 
+type DeployTemplateOptions = {
+  outDir: string;
+  target: string;
+  force?: boolean;
+};
+
 type EmitWafOptions = {
   policy?: string | null;
   outDir: string;
@@ -330,6 +336,197 @@ function printReadinessReport(report: any): void {
   }
 }
 
+function renderAwsDeploymentWorkflow(): string {
+  return `name: CDN Security AWS Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'policy/**'
+      - 'templates/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/cdn-security-aws.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-cdn-security:
+    runs-on: ubuntu-latest
+    env:
+      # Configure these as repository secrets. Do not commit production values.
+      EDGE_ADMIN_TOKEN: \${{ secrets.EDGE_ADMIN_TOKEN }}
+      ORIGIN_SECRET: \${{ secrets.ORIGIN_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Diagnose environment
+        run: npx cdn-security doctor --no-report --strict
+
+      - name: Check production readiness
+        run: npx cdn-security readiness --target aws --strict --report readiness-report.json
+
+      - name: Build AWS edge and WAF artifacts
+        run: npx cdn-security build --target aws --out-dir dist
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdn-security-aws-artifacts
+          path: |
+            dist/edge/
+            dist/infra/
+            readiness-report.json
+
+      # Deployment is intentionally left explicit. Wire dist/edge/*.js and
+      # dist/infra/*.tf.json into your Terraform/CDK/CloudFront release flow.
+`;
+}
+
+function renderCloudflareDeploymentWorkflow(): string {
+  return `name: CDN Security Cloudflare Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'policy/**'
+      - 'templates/**'
+      - 'wrangler.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/cdn-security-cloudflare.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-cdn-security:
+    runs-on: ubuntu-latest
+    env:
+      # Configure these as repository secrets. Do not commit production values.
+      EDGE_ADMIN_TOKEN: \${{ secrets.EDGE_ADMIN_TOKEN }}
+      BASIC_AUTH_CREDS: \${{ secrets.BASIC_AUTH_CREDS }}
+      URL_SIGNING_SECRET: \${{ secrets.URL_SIGNING_SECRET }}
+      JWT_SECRET: \${{ secrets.JWT_SECRET }}
+      ORIGIN_SECRET: \${{ secrets.ORIGIN_SECRET }}
+      CHALLENGE_SECRET: \${{ secrets.CHALLENGE_SECRET }}
+      CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CDN_SECURITY_WORKER_SECRET_NAMES: EDGE_ADMIN_TOKEN,BASIC_AUTH_CREDS,URL_SIGNING_SECRET,JWT_SECRET,ORIGIN_SECRET,CHALLENGE_SECRET
+      CDN_SECURITY_WORKER_SECRETS_FILE: \${{ runner.temp }}/cdn-security-worker-secrets.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Diagnose environment
+        run: npx cdn-security doctor --no-report --strict
+
+      - name: Check production readiness
+        run: npx cdn-security readiness --target cloudflare --strict --report readiness-report.json
+
+      - name: Build Cloudflare Worker and WAF artifacts
+        run: npx cdn-security build --target cloudflare --out-dir dist
+
+      - name: Prepare Worker runtime secrets
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const secretsFile = process.env.CDN_SECURITY_WORKER_SECRETS_FILE || '/tmp/cdn-security-worker-secrets.json';
+          const names = (process.env.CDN_SECURITY_WORKER_SECRET_NAMES || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const secrets = {};
+          for (const name of names) {
+            const value = process.env[name];
+            if (value) secrets[name] = value;
+          }
+          if (Object.keys(secrets).length === 0) {
+            console.log('[INFO] No Worker runtime secrets configured; deploying without --secrets-file.');
+            process.exit(0);
+          }
+          fs.writeFileSync(secretsFile, JSON.stringify(secrets));
+          NODE
+
+      - name: Deploy Worker with Wrangler
+        run: |
+          if [ -f "$CDN_SECURITY_WORKER_SECRETS_FILE" ]; then
+            trap 'rm -f "$CDN_SECURITY_WORKER_SECRETS_FILE"' EXIT
+            npx wrangler deploy dist/edge/cloudflare/index.ts --secrets-file "$CDN_SECURITY_WORKER_SECRETS_FILE"
+          else
+            npx wrangler deploy dist/edge/cloudflare/index.ts
+          fi
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdn-security-cloudflare-artifacts
+          path: |
+            dist/edge/cloudflare/
+            dist/infra/
+            readiness-report.json
+
+      # Configure wrangler.toml, routes, account-specific bindings, and any
+      # extra policy secret env names before enabling production deploys.
+`;
+}
+
+function writeDeploymentTemplates(opts: DeployTemplateOptions, cwd: string): string[] {
+  const target = opts.target || 'all';
+  if (!['aws', 'cloudflare', 'all'].includes(target)) {
+    throw new Error('Invalid --target. Use aws, cloudflare, or all.');
+  }
+  const outDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const templates: Array<{ file: string; content: string }> = [];
+  if (target === 'aws' || target === 'all') {
+    templates.push({ file: 'cdn-security-aws.yml', content: renderAwsDeploymentWorkflow() });
+  }
+  if (target === 'cloudflare' || target === 'all') {
+    templates.push({ file: 'cdn-security-cloudflare.yml', content: renderCloudflareDeploymentWorkflow() });
+  }
+
+  const existing = templates
+    .map((template) => path.join(outDir, template.file))
+    .filter((filePath) => fs.existsSync(filePath));
+  if (existing.length > 0 && !opts.force) {
+    throw new Error(`${existing.join(', ')} already exists. Use --force to overwrite.`);
+  }
+
+  const written: string[] = [];
+  for (const template of templates) {
+    const filePath = path.join(outDir, template.file);
+    fs.writeFileSync(filePath, template.content, 'utf8');
+    written.push(filePath);
+  }
+  return written;
+}
+
 function collectFiles(root: string): string[] {
   if (!fs.existsSync(root)) return [];
   const out: string[] = [];
@@ -611,6 +808,22 @@ program
     }
 
     process.exit(exitCode);
+  });
+
+program
+  .command('deploy-template')
+  .description('Generate GitHub Actions deployment workflow templates for generated CDN security artifacts')
+  .option('-o, --out-dir <dir>', 'Workflow output directory', '.github/workflows')
+  .option('-t, --target <platform>', 'Target platform: aws | cloudflare | all', 'all')
+  .option('-f, --force', 'Overwrite existing generated workflow templates')
+  .action((opts: DeployTemplateOptions) => {
+    try {
+      const files = writeDeploymentTemplates(opts, process.cwd());
+      files.forEach((filePath) => console.log('[SUCCESS] Generated ' + filePath));
+    } catch (e: any) {
+      console.error('[ERROR]', e.message);
+      process.exit(1);
+    }
   });
 
 program

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -560,6 +560,101 @@ test('CLI authoring DX: readiness strict mode fails on warnings', () => {
   }
 });
 
+test('CLI authoring DX: deploy-template emits AWS and Cloudflare workflow templates', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const outDir = path.join(tmp, '.github', 'workflows');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'deploy-template',
+      '--target', 'all',
+      '--out-dir', outDir,
+    ], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 0, `deploy-template failed: ${result.stderr}`);
+    const aws = fs.readFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'utf8');
+    const cloudflare = fs.readFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'utf8');
+    assert.ok(aws.includes('cdn-security readiness --target aws --strict'));
+    assert.ok(aws.includes('${{ secrets.EDGE_ADMIN_TOKEN }}'));
+    assert.ok(aws.includes('cdn-security build --target aws --out-dir dist'));
+    assert.ok(cloudflare.includes('cdn-security readiness --target cloudflare --strict'));
+    assert.ok(cloudflare.includes('CDN_SECURITY_WORKER_SECRET_NAMES'));
+    assert.ok(cloudflare.includes('CDN_SECURITY_WORKER_SECRETS_FILE'));
+    assert.ok(cloudflare.includes('npx wrangler deploy dist/edge/cloudflare/index.ts --secrets-file'));
+    assert.ok(cloudflare.includes('${{ secrets.CLOUDFLARE_API_TOKEN }}'));
+    assert.ok(cloudflare.includes("'wrangler.toml'"));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('CLI authoring DX: deploy-template refuses overwrite without --force', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const outDir = path.join(tmp, '.github', 'workflows');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'existing\n', 'utf8');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'deploy-template',
+      '--target', 'aws',
+      '--out-dir', outDir,
+    ], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 1);
+    assert.ok(/already exists/.test(result.stderr));
+
+    const forced: any = spawnSync(process.execPath, [
+      cli, 'deploy-template',
+      '--target', 'aws',
+      '--out-dir', outDir,
+      '--force',
+    ], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(forced.status, 0, `forced deploy-template failed: ${forced.stderr}`);
+    assert.ok(fs.readFileSync(path.join(outDir, 'cdn-security-aws.yml'), 'utf8').includes('CDN Security AWS Build'));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('CLI authoring DX: deploy-template does not partially write on overwrite refusal', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-template-'));
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const outDir = path.join(tmp, '.github', 'workflows');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'existing\n', 'utf8');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'deploy-template',
+      '--target', 'all',
+      '--out-dir', outDir,
+    ], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 1);
+    assert.ok(/already exists/.test(result.stderr));
+    assert.ok(!fs.existsSync(path.join(outDir, 'cdn-security-aws.yml')));
+    assert.strictEqual(fs.readFileSync(path.join(outDir, 'cdn-security-cloudflare.yml'), 'utf8'), 'existing\n');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('CLI authoring DX: diff detects generated output drift', () => {
   const ctx = tmpProject(BASIC_AWS_POLICY);
   const { spawnSync } = require('child_process');


### PR DESCRIPTION
Fixes #127.

## Summary
- Add cdn-security deploy-template for generating GitHub Actions deployment workflow starters.
- Emit AWS and Cloudflare templates with readiness gates, build steps, artifact upload, and Wrangler deploy for Cloudflare.
- Reference only GitHub Secrets placeholders; no secret values are written.
- Document the command in English and Japanese CLI docs and cover it with CLI regression tests.

## Test plan
- npm run build:ts && node scripts/programmatic-api-unit-tests.js
- npm run typecheck:cli-strict
- npm run lint:policy -- policy/base.yml
- EDGE_ADMIN_TOKEN=test-token npm run test:all

Note: policy/base.yml still reports the existing managed-rules coverage warning during lint, but the command exits successfully.