### PR TITLE
fix(edge): fail closed on missing HS256 JWT secret

### DIFF
--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -733,6 +733,48 @@ async function runOriginRequestTests() {
     console.log('--- origin-request (enforce): ' + (originCases.length + extraAsserts - originFailed) + '/' + (originCases.length + extraAsserts) + ' passed ---');
     return { failed: originFailed, total: originCases.length + extraAsserts };
 }
+async function runOriginJwtSecretFailClosedTests() {
+    delete process.env.__MISSING_JWT_SECRET_FOR_TEST__;
+    const cfgCode = [
+        'const CFG = {',
+        '  project: "test",',
+        '  mode: "enforce",',
+        '  maxHeaderSize: 0,',
+        '  jwtGates: [{',
+        '    name: "api",',
+        '    protectedPrefixes: ["/api"],',
+        '    type: "jwt",',
+        '    algorithm: "HS256",',
+        '    jwks_url: "",',
+        '    issuer: "test-issuer",',
+        '    audience: "test-audience",',
+        '    secret_env: "__MISSING_JWT_SECRET_FOR_TEST__"',
+        '  }],',
+        '  signedUrlGates: [],',
+        '  originAuth: null,',
+        '  trustForwardedFor: false,',
+        '  obs: { logFormat: "json", correlationHeader: "" }',
+        '};',
+    ].join('\n');
+    const jwtHandler = compileOriginTemplate(cfgCode);
+    if (!jwtHandler)
+        return { failed: 1, total: 1 };
+    const previous = originHandler;
+    originHandler = jwtHandler;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const emptySecretToken = createHS256Jwt({
+        sub: 'user1',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: nowSec + 3600,
+    }, '');
+    const ok = await runAsyncCase('origin: missing HS256 JWT secret rejects empty-secret token', buildLambdaEdgeEvent('/api/data', {
+        Authorization: 'Bearer ' + emptySecretToken,
+    }), '503');
+    originHandler = previous;
+    console.log('--- origin-request jwt secret fail-closed: ' + (ok ? 1 : 0) + '/1 passed ---');
+    return { failed: ok ? 0 : 1, total: 1 };
+}
 async function runOriginAuthFailClosedTests() {
     const cfgCode = [
         'const CFG = {',
@@ -891,6 +933,9 @@ async function main() {
     const enforceResult = await runOriginRequestTests();
     totalFailed += enforceResult.failed;
     totalTests += enforceResult.total;
+    const jwtSecretResult = await runOriginJwtSecretFailClosedTests();
+    totalFailed += jwtSecretResult.failed;
+    totalTests += jwtSecretResult.total;
     const originAuthResult = await runOriginAuthFailClosedTests();
     totalFailed += originAuthResult.failed;
     totalTests += originAuthResult.total;

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -817,6 +817,55 @@ async function runOriginRequestTests() {
   return { failed: originFailed, total: originCases.length + extraAsserts };
 }
 
+async function runOriginJwtSecretFailClosedTests() {
+  delete process.env.__MISSING_JWT_SECRET_FOR_TEST__;
+  const cfgCode = [
+    'const CFG = {',
+    '  project: "test",',
+    '  mode: "enforce",',
+    '  maxHeaderSize: 0,',
+    '  jwtGates: [{',
+    '    name: "api",',
+    '    protectedPrefixes: ["/api"],',
+    '    type: "jwt",',
+    '    algorithm: "HS256",',
+    '    jwks_url: "",',
+    '    issuer: "test-issuer",',
+    '    audience: "test-audience",',
+    '    secret_env: "__MISSING_JWT_SECRET_FOR_TEST__"',
+    '  }],',
+    '  signedUrlGates: [],',
+    '  originAuth: null,',
+    '  trustForwardedFor: false,',
+    '  obs: { logFormat: "json", correlationHeader: "" }',
+    '};',
+  ].join('\n');
+
+  const jwtHandler = compileOriginTemplate(cfgCode);
+  if (!jwtHandler) return { failed: 1, total: 1 };
+
+  const previous = originHandler;
+  originHandler = jwtHandler;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const emptySecretToken = createHS256Jwt({
+    sub: 'user1',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: nowSec + 3600,
+  }, '');
+  const ok = await runAsyncCase(
+    'origin: missing HS256 JWT secret rejects empty-secret token',
+    buildLambdaEdgeEvent('/api/data', {
+      Authorization: 'Bearer ' + emptySecretToken,
+    }),
+    '503',
+  );
+  originHandler = previous;
+
+  console.log('--- origin-request jwt secret fail-closed: ' + (ok ? 1 : 0) + '/1 passed ---');
+  return { failed: ok ? 0 : 1, total: 1 };
+}
+
 async function runOriginAuthFailClosedTests() {
   const cfgCode = [
     'const CFG = {',
@@ -994,6 +1043,10 @@ async function main() {
   const enforceResult: any = await runOriginRequestTests();
   totalFailed += enforceResult.failed;
   totalTests += enforceResult.total;
+
+  const jwtSecretResult = await runOriginJwtSecretFailClosedTests();
+  totalFailed += jwtSecretResult.failed;
+  totalTests += jwtSecretResult.total;
 
   const originAuthResult = await runOriginAuthFailClosedTests();
   totalFailed += originAuthResult.failed;

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -281,6 +281,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -431,6 +435,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/archetypes/admin-panel/edge/origin-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/archetypes/microservice-origin/edge/origin-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/archetypes/rest-api/edge/origin-request.js
+++ b/tests/golden/archetypes/rest-api/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/archetypes/spa-static-site/edge/origin-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -292,6 +292,10 @@ async function verifyJwtRS256(token, gate) {
 
 // Verify JWT with HS256 (symmetric key)
 function verifyJwtHS256(token, secret, gate) {
+  if (!secret) {
+    return { valid: false, error: 'JWT secret not configured' };
+  }
+
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
 
@@ -442,6 +446,9 @@ async function checkJwtGates(request) {
       result = await verifyJwtRS256(jwt, gate);
     } else if (gate.algorithm === 'HS256' && gate.secret_env) {
       const secret = process.env[gate.secret_env] || '';
+      if (!secret) {
+        return resp(503, 'JWT gate misconfigured');
+      }
       result = verifyJwtHS256(jwt, secret, gate);
     } else {
       return resp(500, 'JWT gate misconfigured');


### PR DESCRIPTION
## Summary

- reject AWS Lambda@Edge HS256 JWT gates when the configured secret env var is unset or empty
- add a defensive empty-secret guard inside `verifyJwtHS256()`
- add runtime coverage for an empty-string-secret JWT against a missing env var
- refresh AWS origin-request golden fixtures

Closes #140.

## Verification

- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy node scripts/compile.js --policy policy/base.yml --out-dir dist && EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy node scripts/runtime-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:drift`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:unit`
