### PR TITLE
fix(edge): check raw paths before normalization

### DIFF
--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -89,6 +89,35 @@ async function runGeneratedWorker(generated, query, options = {}) {
         fs.rmSync(tempDir, { recursive: true, force: true });
     }
 }
+async function runGeneratedWorkerRequest(generated, request, options = {}) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-'));
+    const modPath = path.join(tempDir, 'worker.cjs');
+    const compiled = esbuild.transformSync(generated, {
+        loader: 'ts',
+        format: 'cjs',
+        target: 'es2022',
+    }).code;
+    const previousFetch = globalThis.fetch;
+    const fetchCalls = [];
+    globalThis.fetch = async (input) => {
+        fetchCalls.push(input);
+        return new Response(options.originBody || 'origin-ok', {
+            status: options.originStatus || 200,
+            headers: options.originHeaders || {},
+        });
+    };
+    try {
+        fs.writeFileSync(modPath, compiled, 'utf8');
+        delete require.cache[modPath];
+        const worker = require(modPath).default;
+        const res = await worker.fetch(request, options.env || {});
+        return { res, fetchCalls };
+    }
+    finally {
+        globalThis.fetch = previousFetch;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
 test('cloudflare compile injects jwt, signed_url, and origin auth config', () => {
     const generated = compileCloudflare(`
 version: 1
@@ -144,6 +173,40 @@ test('cloudflare template contains auth enforcement logic', () => {
     assert.ok(template.includes('Missing exp claim'), 'JWT exp-required guard missing');
     assert.ok(/nowSec\s*>=\s*Number\(payload\.exp\)\s*\+\s*skewSec/.test(template), 'JWT clock skew tolerance missing');
     assert.ok(template.includes('function shouldBlockAuth'), 'auth fail-closed helper missing');
+});
+test('cloudflare blocks raw traversal before dot-segment normalization', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-raw-path-test
+request:
+  allow_methods: ["GET"]
+  limits:
+    max_query_length: 1024
+    max_query_params: 30
+    max_uri_length: 2048
+  block:
+    path_patterns:
+      contains:
+        - "/../"
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+response_headers:
+  hsts: "max-age=31536000"
+`);
+    const headers = new Headers({ 'user-agent': 'runtime-test' });
+    const request = {
+        url: 'https://edge.example.com/public/../private',
+        method: 'GET',
+        headers,
+        body: null,
+        redirect: 'manual',
+        clone: () => new Request('https://edge.example.com/private', { method: 'GET', headers }),
+    };
+    const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, request);
+    assert.strictEqual(res.status, 400);
+    assert.strictEqual(fetchCalls.length, 0, 'raw traversal should block before origin fetch');
 });
 test('cloudflare compile emits experimental challenge config', () => {
     const generated = compileCloudflare(`

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -1145,6 +1145,44 @@ test('viewer-request enforces max_header_count with 431', () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
 });
+test('viewer-request checks raw traversal before dot-segment normalization', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-raw-traversal-'));
+    try {
+        build({
+            version: 1,
+            request: {
+                allow_methods: ['GET'],
+                block: { path_patterns: { contains: ['/../'] } },
+                normalize: { path: { collapse_slashes: true, remove_dot_segments: true } },
+            },
+            response_headers: {},
+            routes: [],
+        }, { outDir: tmpDir, allowPlaceholderToken: true });
+        const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-request.js'), 'utf8');
+        const handler = new Function(code + '\nreturn handler;')();
+        const blocked = handler({
+            request: {
+                method: 'GET',
+                uri: '/public/../private',
+                querystring: '',
+                headers: { 'user-agent': { value: 'Mozilla' } },
+            },
+        });
+        assert.strictEqual(blocked.statusCode, 400);
+        const benign = handler({
+            request: {
+                method: 'GET',
+                uri: '/public/./asset',
+                querystring: '',
+                headers: { 'user-agent': { value: 'Mozilla' } },
+            },
+        });
+        assert.strictEqual(benign.uri, '/public/asset');
+    }
+    finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
 test('response_headers.clear_site_data_paths emits directive + no-store on 2xx', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-csd-'));
     try {

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -101,6 +101,37 @@ async function runGeneratedWorker(generated: string, query: string, options: any
   }
 }
 
+async function runGeneratedWorkerRequest(generated: string, request: any, options: any = {}) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-'));
+  const modPath = path.join(tempDir, 'worker.cjs');
+  const compiled = esbuild.transformSync(generated, {
+    loader: 'ts',
+    format: 'cjs',
+    target: 'es2022',
+  }).code;
+
+  const previousFetch = globalThis.fetch;
+  const fetchCalls: any[] = [];
+  (globalThis as any).fetch = async (input: any) => {
+    fetchCalls.push(input);
+    return new Response(options.originBody || 'origin-ok', {
+      status: options.originStatus || 200,
+      headers: options.originHeaders || {},
+    });
+  };
+
+  try {
+    fs.writeFileSync(modPath, compiled, 'utf8');
+    delete require.cache[modPath];
+    const worker = require(modPath).default;
+    const res = await worker.fetch(request, options.env || {});
+    return { res, fetchCalls };
+  } finally {
+    (globalThis as any).fetch = previousFetch;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 test('cloudflare compile injects jwt, signed_url, and origin auth config', () => {
   const generated = compileCloudflare(`
 version: 1
@@ -161,6 +192,43 @@ test('cloudflare template contains auth enforcement logic', () => {
   assert.ok(/nowSec\s*>=\s*Number\(payload\.exp\)\s*\+\s*skewSec/.test(template),
     'JWT clock skew tolerance missing');
   assert.ok(template.includes('function shouldBlockAuth'), 'auth fail-closed helper missing');
+});
+
+test('cloudflare blocks raw traversal before dot-segment normalization', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-raw-path-test
+request:
+  allow_methods: ["GET"]
+  limits:
+    max_query_length: 1024
+    max_query_params: 30
+    max_uri_length: 2048
+  block:
+    path_patterns:
+      contains:
+        - "/../"
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+response_headers:
+  hsts: "max-age=31536000"
+`);
+
+  const headers = new Headers({ 'user-agent': 'runtime-test' });
+  const request = {
+    url: 'https://edge.example.com/public/../private',
+    method: 'GET',
+    headers,
+    body: null,
+    redirect: 'manual',
+    clone: () => new Request('https://edge.example.com/private', { method: 'GET', headers }),
+  };
+
+  const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, request);
+  assert.strictEqual(res.status, 400);
+  assert.strictEqual(fetchCalls.length, 0, 'raw traversal should block before origin fetch');
 });
 
 test('cloudflare compile emits experimental challenge config', () => {

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -1329,6 +1329,46 @@ test('viewer-request enforces max_header_count with 431', () => {
   }
 });
 
+test('viewer-request checks raw traversal before dot-segment normalization', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-raw-traversal-'));
+  try {
+    build({
+      version: 1,
+      request: {
+        allow_methods: ['GET'],
+        block: { path_patterns: { contains: ['/../'] } },
+        normalize: { path: { collapse_slashes: true, remove_dot_segments: true } },
+      },
+      response_headers: {},
+      routes: [],
+    }, { outDir: tmpDir, allowPlaceholderToken: true });
+    const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-request.js'), 'utf8');
+    const handler = new Function(code + '\nreturn handler;')();
+
+    const blocked = handler({
+      request: {
+        method: 'GET',
+        uri: '/public/../private',
+        querystring: '',
+        headers: { 'user-agent': { value: 'Mozilla' } },
+      },
+    });
+    assert.strictEqual(blocked.statusCode, 400);
+
+    const benign = handler({
+      request: {
+        method: 'GET',
+        uri: '/public/./asset',
+        querystring: '',
+        headers: { 'user-agent': { value: 'Mozilla' } },
+      },
+    });
+    assert.strictEqual(benign.uri, '/public/asset');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('response_headers.clear_site_data_paths emits directive + no-store on 2xx', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-csd-'));
   try {

--- a/templates/aws/viewer-request.js
+++ b/templates/aws/viewer-request.js
@@ -395,10 +395,17 @@
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -122,6 +122,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -980,6 +1016,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1017,7 +1054,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1033,21 +1070,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/archetypes/admin-panel/edge/viewer-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/archetypes/rest-api/edge/viewer-request.js
+++ b/tests/golden/archetypes/rest-api/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/base/edge/viewer-request.js
+++ b/tests/golden/base/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/profiles/balanced/edge/viewer-request.js
+++ b/tests/golden/profiles/balanced/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/profiles/permissive/edge/viewer-request.js
+++ b/tests/golden/profiles/permissive/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -169,6 +169,42 @@ function normalizePath(pathname: string): string {
   return p;
 }
 
+function rawPathnameFromRequestUrl(rawUrl: string): string {
+  const text = String(rawUrl || '');
+  const schemeIdx = text.indexOf('://');
+  let pathStart = -1;
+  if (schemeIdx !== -1) {
+    pathStart = text.indexOf('/', schemeIdx + 3);
+  } else if (text.startsWith('/')) {
+    pathStart = 0;
+  }
+  if (pathStart === -1) return '/';
+
+  let pathEnd = text.length;
+  const queryStart = text.indexOf('?', pathStart);
+  const hashStart = text.indexOf('#', pathStart);
+  if (queryStart !== -1 && queryStart < pathEnd) pathEnd = queryStart;
+  if (hashStart !== -1 && hashStart < pathEnd) pathEnd = hashStart;
+  return text.slice(pathStart, pathEnd) || '/';
+}
+
+function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
+  const pathLower = pathname.toLowerCase();
+  for (const m of CFG.blockPathContains) {
+    if (pathLower.includes(m)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  for (const re of CFG.blockPathRegexes) {
+    if (re.test(pathname)) {
+      const r = shouldBlock(400, 'Bad Request', ctx);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1027,6 +1063,7 @@ async function applyResponseDlp(out: Response, ctx: ReqCtx): Promise<Response> {
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const rawPathname = rawPathnameFromRequestUrl(request.url);
     const ctx = reqCtx(request);
 
     const preflight = handleCorsPreflight(request);
@@ -1064,7 +1101,7 @@ export default {
       if (r) return r;
     }
 
-    if (url.pathname.length > CFG.maxUriLength) {
+    if (rawPathname.length > CFG.maxUriLength) {
       const r = shouldBlock(414, 'URI Too Long', ctx);
       if (r) return r;
     }
@@ -1080,21 +1117,13 @@ export default {
       }
     }
 
+    const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
+    if (rawPathBlock) return rawPathBlock;
+
     url.pathname = normalizePath(url.pathname);
 
-    const pathLower = url.pathname.toLowerCase();
-    for (const m of CFG.blockPathContains) {
-      if (pathLower.includes(m)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
-    for (const re of CFG.blockPathRegexes) {
-      if (re.test(url.pathname)) {
-        const r = shouldBlock(400, 'Bad Request', ctx);
-        if (r) return r;
-      }
-    }
+    const normalizedPathBlock = blockIfPathPattern(url.pathname, ctx);
+    if (normalizedPathBlock) return normalizedPathBlock;
 
     for (const h of CFG.requiredHeaders) {
       const val = request.headers.get(h);

--- a/tests/golden/profiles/strict/edge/viewer-request.js
+++ b/tests/golden/profiles/strict/edge/viewer-request.js
@@ -413,10 +413,17 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Path normalization
+    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // suspicious input like /public/../private cannot be rewritten to /private
+    // before the block patterns see it.
+    const rawTraversal = shouldBlock(blockIfTraversal(req), req);
+    if (rawTraversal) return rawTraversal;
+
+    // 4) Path normalization
     normalizePath(req);
 
-    // 4) Path traversal (coarse)
+    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 


### PR DESCRIPTION
## Summary

- check AWS viewer-request path block patterns before dot-segment normalization, then preserve the existing normalized-path check
- add Cloudflare raw pathname extraction from `request.url` before normalizing `url.pathname`
- share Cloudflare path-block matching between raw and normalized paths
- add AWS unit coverage and Cloudflare runtime coverage for raw traversal before normalization
- refresh AWS viewer-request and Cloudflare Worker golden fixtures

Closes #141.

## Non-overlap note

This PR intentionally avoids the `origin-request` and `runtime-tests` files touched by #147 / #140. #142 is left out because its JWKS hardening would overlap with both `templates/aws/origin-request.js` and `templates/cloudflare/index.ts`.

## Verification

- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy node scripts/compile.js --policy policy/base.yml --out-dir dist && EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy node scripts/runtime-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy node scripts/cloudflare-runtime-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:unit`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:drift`
