### PR TITLE
fix(edge): harden JWKS fetches

### DIFF
--- a/docs/auth.ja.md
+++ b/docs/auth.ja.md
@@ -35,6 +35,14 @@ firewall:
     negative_cache_sec: 60
 ```
 
+Cloudflare Workers 向け build では、RS256 JWT ゲートがある場合
+`firewall.jwks.allowed_hosts` が必須。Workers は `fetch` 前に DNS
+解決先を検査できないため、コンパイラが JWKS ホストを build 時に固定する。
+Lambda@Edge も allowlist がある場合は利用し、さらにランタイムで JWKS
+ホストの DNS 解決先が loopback / private / link-local 範囲なら拒否する。
+
+JWKS レスポンスは parse / cache の前に 256 KiB、100 keys で上限をかける。
+
 ### 挙動マトリクス
 
 | 状態 | ネットワーク呼び出し | 結果 |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -43,6 +43,14 @@ firewall:
     negative_cache_sec: 60
 ```
 
+For Cloudflare Worker builds, `firewall.jwks.allowed_hosts` is required when
+any RS256 JWT gate is configured. Workers cannot inspect DNS resolution targets
+before `fetch`, so the compiler pins JWKS hosts at build time. Lambda@Edge also
+uses the allowlist when present and additionally rejects DNS-resolved JWKS IPs
+in loopback, private, or link-local ranges at runtime.
+
+JWKS responses are capped at 256 KiB and 100 keys before parsing/caching.
+
 ### Behaviour Matrix
 
 | State | Network call? | Outcome |

--- a/docs/threat-model.ja.md
+++ b/docs/threat-model.ja.md
@@ -100,12 +100,15 @@ Edge / WAF / Origin のどのレイヤーが担当するかを明確にします
 | 脅威 | Edge の責務 | WAF / Origin |
 |------|-------------|--------------|
 | クラウドメタデータ（`169.254.169.254`）、ループバック、RFC1918、リンクローカルを指す悪意ある／誤った `jwks_url` | ビルド時に拒否、ランタイムで再検証 | — |
+| JWKS ホストの DNS 解決先がクラウドメタデータ、ループバック、RFC1918、リンクローカル IP | Lambda@Edge は custom lookup で解決先を拒否。Cloudflare は RS256 build で `firewall.jwks.allowed_hosts` を必須化 | — |
 | JWKS ホストから内部エンドポイントへの攻撃者制御リダイレクト | 3xx レスポンスを拒否（Workers: `redirect: 'error'`、Lambda@Edge: 明示的な 3xx 拒否） | — |
-| ポリシーに明示的な allowlist がある場合、範囲外の IdP ホスト | ビルド時に `firewall.jwks.allowed_hosts` で拒否 | — |
+| ポリシーに明示的な allowlist がある場合、範囲外の IdP ホスト | ビルド時に `firewall.jwks.allowed_hosts` で拒否。Cloudflare RS256 build では必須 | — |
+| 過大な JWKS document / 病的な key set | cache / parse 前に上限で拒否（body 256 KiB、100 keys） | — |
 
 **フレームワーク**:
-- ビルド時バリデータ（`validateJwksUrl`）が `https://` 必須、userinfo / loopback / RFC1918 / リンクローカル / IPv4-mapped IPv6 を拒否し、任意で `firewall.jwks.allowed_hosts` メンバーシップを強制。
-- ランタイムの `fetchJwks` が URL を再チェックし、3xx レスポンスを拒否。
+- ビルド時バリデータ（`validateJwksUrl`）が `https://` 必須、userinfo / loopback / RFC1918 / リンクローカル / IPv4-mapped IPv6 を拒否し、設定時は `firewall.jwks.allowed_hosts` メンバーシップを強制。Cloudflare RS256 build では allowlist が必須。
+- ランタイムの `fetchJwks` が URL を再チェックし、3xx レスポンスを拒否し、JWKS body / key 件数に上限をかける。
+- Lambda@Edge の JWKS fetch は custom DNS lookup を使い、loopback / private / link-local の解決先を拒否。
 - 運用推奨: 本番環境では `firewall.jwks.allowed_hosts` を必ず設定し IdP ホスト名を固定する。
 
 ---

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -99,12 +99,15 @@ This document organizes threats that this Edge Security Framework is designed to
 | Threat | Edge responsibility | WAF / Origin |
 |--------|---------------------|---------------|
 | Malicious or accidental `jwks_url` pointing at cloud metadata (`169.254.169.254`), loopback, RFC1918, or link-local ranges | Reject at build time and re-validate at runtime | — |
+| JWKS hostname resolves to cloud metadata, loopback, RFC1918, or link-local IPs | Lambda@Edge rejects the DNS result via a custom lookup; Cloudflare requires `firewall.jwks.allowed_hosts` for RS256 builds | — |
 | Attacker-controlled redirect from JWKS host to internal endpoint | Refuse 3xx responses (`redirect: 'error'` in Workers / explicit 3xx rejection in Lambda@Edge) | — |
-| Out-of-scope IdP host when policy has an explicit allowlist | Reject at build time via `firewall.jwks.allowed_hosts` | — |
+| Out-of-scope IdP host when policy has an explicit allowlist | Reject at build time via `firewall.jwks.allowed_hosts`; required for Cloudflare RS256 builds | — |
+| Oversized JWKS document or pathological key set | Reject before caching/parsing beyond bounded limits (256 KiB body, 100 keys) | — |
 
 **Framework**:
-- Build-time validator (`validateJwksUrl`) enforces `https://`, rejects userinfo, loopback, RFC1918, link-local, IPv4-mapped IPv6, and optional `firewall.jwks.allowed_hosts` membership.
-- Runtime `fetchJwks` re-checks the URL and refuses any 3xx response.
+- Build-time validator (`validateJwksUrl`) enforces `https://`, rejects userinfo, loopback, RFC1918, link-local, IPv4-mapped IPv6, and `firewall.jwks.allowed_hosts` membership when configured. Cloudflare RS256 builds require the allowlist.
+- Runtime `fetchJwks` re-checks the URL, refuses any 3xx response, and caps JWKS body and key count.
+- Lambda@Edge JWKS fetches use a custom DNS lookup and reject loopback, private, and link-local resolution targets.
 - Recommended operator practice: always set `firewall.jwks.allowed_hosts` in production to pin the exact IdP hostname(s).
 
 ---

--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -51,6 +51,17 @@ function compileAws(policyContent) {
     fs.rmSync(tempDir, { recursive: true, force: true });
     return { status: result.status, stderr: result.stderr || '' };
 }
+function base64UrlJson(value) {
+    return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+function createUnsignedRs256Jwt(kid = 'test-key') {
+    const nowSec = Math.floor(Date.now() / 1000);
+    return [
+        base64UrlJson({ alg: 'RS256', typ: 'JWT', kid }),
+        base64UrlJson({ sub: 'user1', iss: 'test', aud: 'test', exp: nowSec + 3600 }),
+        'signature',
+    ].join('.');
+}
 async function runGeneratedWorker(generated, query, options = {}) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-'));
     const modPath = path.join(tempDir, 'worker.cjs');
@@ -242,6 +253,9 @@ request:
   trust_forwarded_for: false
 response_headers:
   hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
 routes:
   - name: api-jwt
     match:
@@ -259,6 +273,85 @@ routes:
     assert.ok(/trustForwardedFor:\s*false/.test(generated));
     assert.ok(generated.includes('"allowed_algorithms":["RS256"]'), 'allowed_algorithms emitted without "none" or cross-alg entries');
     assert.ok(generated.includes('"clock_skew_sec":60'));
+});
+test('cloudflare RS256 JWT rejects oversized JWKS responses before origin fetch', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-jwks-cap-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+    const req = new Request('https://edge.example.com/api/data', {
+        method: 'GET',
+        headers: {
+            'user-agent': 'runtime-test',
+            authorization: 'Bearer ' + createUnsignedRs256Jwt(),
+        },
+    });
+    const oversizedJwks = JSON.stringify({ keys: [], padding: 'a'.repeat((256 * 1024) + 1) });
+    const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, req, {
+        originBody: oversizedJwks,
+        originHeaders: { 'content-type': 'application/json' },
+    });
+    assert.strictEqual(res.status, 401);
+    assert.strictEqual(fetchCalls.length, 1, 'oversized JWKS should fail before origin fetch');
+});
+test('cloudflare RS256 JWT rejects JWKS documents with too many keys', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-jwks-key-cap-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+    const req = new Request('https://edge.example.com/api/data', {
+        method: 'GET',
+        headers: {
+            'user-agent': 'runtime-test',
+            authorization: 'Bearer ' + createUnsignedRs256Jwt(),
+        },
+    });
+    const keys = Array.from({ length: 101 }, (_value, i) => ({
+        kid: 'key-' + i,
+        kty: 'RSA',
+        n: 'sXch7EoJ89XcP_Gyo-t6fA',
+        e: 'AQAB',
+    }));
+    const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, req, {
+        originBody: JSON.stringify({ keys }),
+        originHeaders: { 'content-type': 'application/json' },
+    });
+    assert.strictEqual(res.status, 401);
+    assert.strictEqual(fetchCalls.length, 1, 'too-large JWKS key set should fail before origin fetch');
 });
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {
     const generated = compileCloudflare(`
@@ -362,6 +455,9 @@ request:
   allow_methods: ["GET"]
 response_headers:
   hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
 routes:
   - name: api-jwt
     match:

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -59,7 +59,7 @@ warnSignedUrlReplay(policy);
 // Cloudflare Workers reads env at runtime for static_token/basic_auth, so build
 // does not require the actual token value. Only structural gate fields matter.
 // We still validate jwt/signed_url required fields via the shared helper.
-validateAuthGates(policy, { allowPlaceholderToken: true });
+validateAuthGates(policy, { allowPlaceholderToken: true, requireJwksAllowedHosts: true });
 const defaults = policy.defaults || {};
 const request = policy.request || {};
 const limits = request.limits || {};

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -717,6 +717,38 @@ test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', (
     };
     validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
 });
+test('validateAuthGates requires jwks allowed_hosts when target cannot inspect DNS', () => {
+    const policy = {
+        routes: [
+            {
+                name: 'cloudflare-rs256',
+                auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+            },
+        ],
+    };
+    assert.throws(() => validateAuthGates(policy, {
+        exitOnError: false,
+        allowPlaceholderToken: true,
+        requireJwksAllowedHosts: true,
+    }), (err) => Array.isArray(err.validationErrors)
+        && err.validationErrors.some((e) => /cloudflare-rs256/.test(e) && /allowed_hosts/.test(e)));
+});
+test('validateAuthGates accepts required jwks allowed_hosts for matching RS256 host', () => {
+    const policy = {
+        firewall: { jwks: { allowed_hosts: ['idp.example.com'] } },
+        routes: [
+            {
+                name: 'cloudflare-rs256',
+                auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+            },
+        ],
+    };
+    validateAuthGates(policy, {
+        exitOnError: false,
+        allowPlaceholderToken: true,
+        requireJwksAllowedHosts: true,
+    });
+});
 test('warnSignedUrlReplay flags write-like signed_url gates missing nonce_param', () => {
     const captured = [];
     const logger = { error: (m) => captured.push(m) };

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -268,6 +268,12 @@ function validateAuthGates(policy, options = {}) {
     const routes = policy.routes || [];
     const errors = [];
     const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
+    const normalizedJwksAllowedHosts = Array.isArray(jwksAllowedHosts)
+        ? jwksAllowedHosts
+            .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
+            .filter(Boolean)
+        : [];
+    const requireJwksAllowedHosts = options.requireJwksAllowedHosts === true;
     for (const route of routes) {
         const gate = route.auth_gate;
         if (!gate)
@@ -278,6 +284,9 @@ function validateAuthGates(policy, options = {}) {
             const alg = gate.algorithm || 'RS256';
             if (alg === 'RS256' && !gate.jwks_url) {
                 errors.push(`Route "${name}": JWT+RS256 requires "jwks_url"`);
+            }
+            if (alg === 'RS256' && requireJwksAllowedHosts && normalizedJwksAllowedHosts.length === 0) {
+                errors.push(`Route "${name}": JWT+RS256 requires firewall.jwks.allowed_hosts for this target`);
             }
             if (gate.jwks_url) {
                 const v = validateJwksUrl(gate.jwks_url, jwksAllowedHosts);

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -11,6 +11,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { EventEmitter } = require('events');
 // =========================================================================
 // Section 1: viewer-request.js tests (CloudFront Functions)
 // =========================================================================
@@ -364,6 +365,11 @@ function createHS256Jwt(payload, secret) {
         .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
     return headerB64 + '.' + payloadB64 + '.' + sig;
 }
+function createRS256Jwt(payload, kid = 'test-key') {
+    const header = { alg: 'RS256', typ: 'JWT', kid };
+    const enc = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    return enc(header) + '.' + enc(payload) + '.signature';
+}
 // Build Lambda@Edge event format
 function buildLambdaEdgeEvent(uri, headers = {}, querystring = '', method = 'GET') {
     const h = headers || {};
@@ -400,7 +406,7 @@ async function runAsyncCase(name, event, expected) {
     return true;
 }
 // Helper: compile origin-request template with inline config
-function compileOriginTemplate(cfgCode) {
+function compileOriginTemplate(cfgCode, deps = {}) {
     const templatePath = path.join(__dirname, '..', 'templates', 'aws', 'origin-request.js');
     let originCode;
     try {
@@ -411,16 +417,18 @@ function compileOriginTemplate(cfgCode) {
         return null;
     }
     originCode = originCode.replace('// {{INJECT_CONFIG}}', cfgCode);
-    const wrappedCode = '(function() {\n' +
-        'const crypto = require("crypto");\n' +
-        'const https = require("https");\n' +
+    const wrappedCode = '(function(deps) {\n' +
+        'const crypto = deps.crypto || require("crypto");\n' +
+        'const dns = deps.dns || require("dns");\n' +
+        'const https = deps.https || require("https");\n' +
         originCode
             .replace("const crypto = require('crypto');", '')
+            .replace("const dns = require('dns');", '')
             .replace("const https = require('https');", '') +
         '\nreturn exports.handler;\n' +
-        '})()';
+        '})';
     try {
-        return eval(wrappedCode);
+        return eval(wrappedCode)(deps);
     }
     catch (e) {
         console.error('Failed to eval origin-request template:', e.message);
@@ -775,6 +783,128 @@ async function runOriginJwtSecretFailClosedTests() {
     console.log('--- origin-request jwt secret fail-closed: ' + (ok ? 1 : 0) + '/1 passed ---');
     return { failed: ok ? 0 : 1, total: 1 };
 }
+function makeDnsLookup(address) {
+    return {
+        lookup: (_hostname, _options, callback) => {
+            process.nextTick(() => callback(null, address, address.includes(':') ? 6 : 4));
+        },
+    };
+}
+function makeJwksHttps(body, calls) {
+    return {
+        get: (rawUrl, options, callback) => {
+            calls.push({ rawUrl });
+            const req = new EventEmitter();
+            req.setTimeout = () => req;
+            req.destroy = () => req;
+            process.nextTick(() => {
+                const lookup = options && options.lookup;
+                const host = new URL(rawUrl).hostname;
+                const sendResponse = () => {
+                    const res = new EventEmitter();
+                    res.statusCode = 200;
+                    res.resume = () => undefined;
+                    callback(res);
+                    process.nextTick(() => {
+                        res.emit('data', Buffer.from(body));
+                        res.emit('end');
+                    });
+                };
+                if (typeof lookup === 'function') {
+                    lookup(host, {}, (err) => {
+                        if (err) {
+                            req.emit('error', err);
+                            return;
+                        }
+                        sendResponse();
+                    });
+                    return;
+                }
+                sendResponse();
+            });
+            return req;
+        },
+    };
+}
+async function runOriginJwksHardeningTests() {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const token = createRS256Jwt({
+        sub: 'user1',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: nowSec + 3600,
+    });
+    const cfgCode = [
+        'const CFG = {',
+        '  project: "test",',
+        '  mode: "enforce",',
+        '  maxHeaderSize: 0,',
+        '  jwtGates: [{',
+        '    name: "api",',
+        '    protectedPrefixes: ["/api"],',
+        '    type: "jwt",',
+        '    algorithm: "RS256",',
+        '    jwks_url: "https://idp.example.com/jwks.json",',
+        '    issuer: "test-issuer",',
+        '    audience: "test-audience",',
+        '    secret_env: ""',
+        '  }],',
+        '  signedUrlGates: [],',
+        '  originAuth: null,',
+        '  trustForwardedFor: false,',
+        '  obs: { logFormat: "json", correlationHeader: "" }',
+        '};',
+    ].join('\n');
+    const cases = [
+        {
+            name: 'origin: RS256 JWKS DNS resolving to metadata IP is rejected',
+            dns: makeDnsLookup('169.254.169.254'),
+            body: JSON.stringify({ keys: [] }),
+        },
+        {
+            name: 'origin: RS256 JWKS oversized response is rejected',
+            dns: makeDnsLookup('93.184.216.34'),
+            body: JSON.stringify({ keys: [], padding: 'a'.repeat((256 * 1024) + 1) }),
+        },
+        {
+            name: 'origin: RS256 JWKS with too many keys is rejected',
+            dns: makeDnsLookup('93.184.216.34'),
+            body: JSON.stringify({
+                keys: Array.from({ length: 101 }, (_value, i) => ({
+                    kid: 'key-' + i,
+                    kty: 'RSA',
+                    alg: 'RS256',
+                    n: 'sXch7EoJ89XcP_Gyo-t6fA',
+                    e: 'AQAB',
+                })),
+            }),
+        },
+    ];
+    let failed = 0;
+    const previous = originHandler;
+    for (const c of cases) {
+        const calls = [];
+        const handlerForCase = compileOriginTemplate(cfgCode, {
+            dns: c.dns,
+            https: makeJwksHttps(c.body, calls),
+        });
+        if (!handlerForCase) {
+            console.error('FAIL:', c.name, '| failed to compile origin template');
+            failed++;
+            continue;
+        }
+        originHandler = handlerForCase;
+        const ok = await runAsyncCase(c.name, buildLambdaEdgeEvent('/api/data', { Authorization: 'Bearer ' + token }), '401');
+        if (!ok || calls.length !== 1) {
+            if (ok)
+                console.error('FAIL:', c.name, '| expected exactly one JWKS fetch, got', calls.length);
+            failed++;
+        }
+    }
+    originHandler = previous;
+    console.log('--- origin-request jwks hardening: ' + (cases.length - failed) + '/' + cases.length + ' passed ---');
+    return { failed, total: cases.length };
+}
 async function runOriginAuthFailClosedTests() {
     const cfgCode = [
         'const CFG = {',
@@ -936,6 +1066,9 @@ async function main() {
     const jwtSecretResult = await runOriginJwtSecretFailClosedTests();
     totalFailed += jwtSecretResult.failed;
     totalTests += jwtSecretResult.total;
+    const jwksHardeningResult = await runOriginJwksHardeningTests();
+    totalFailed += jwksHardeningResult.failed;
+    totalTests += jwksHardeningResult.total;
     const originAuthResult = await runOriginAuthFailClosedTests();
     totalFailed += originAuthResult.failed;
     totalTests += originAuthResult.total;

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -61,6 +61,19 @@ function compileAws(policyContent: string): { status: number | null; stderr: str
   return { status: result.status, stderr: result.stderr || '' };
 }
 
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createUnsignedRs256Jwt(kid = 'test-key'): string {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return [
+    base64UrlJson({ alg: 'RS256', typ: 'JWT', kid }),
+    base64UrlJson({ sub: 'user1', iss: 'test', aud: 'test', exp: nowSec + 3600 }),
+    'signature',
+  ].join('.');
+}
+
 async function runGeneratedWorker(generated: string, query: string, options: any = {}) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-'));
   const modPath = path.join(tempDir, 'worker.cjs');
@@ -267,6 +280,9 @@ request:
   trust_forwarded_for: false
 response_headers:
   hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
 routes:
   - name: api-jwt
     match:
@@ -287,6 +303,91 @@ routes:
   assert.ok(generated.includes('"allowed_algorithms":["RS256"]'),
     'allowed_algorithms emitted without "none" or cross-alg entries');
   assert.ok(generated.includes('"clock_skew_sec":60'));
+});
+
+test('cloudflare RS256 JWT rejects oversized JWKS responses before origin fetch', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-jwks-cap-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+
+  const req = new Request('https://edge.example.com/api/data', {
+    method: 'GET',
+    headers: {
+      'user-agent': 'runtime-test',
+      authorization: 'Bearer ' + createUnsignedRs256Jwt(),
+    },
+  });
+  const oversizedJwks = JSON.stringify({ keys: [], padding: 'a'.repeat((256 * 1024) + 1) });
+  const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, req, {
+    originBody: oversizedJwks,
+    originHeaders: { 'content-type': 'application/json' },
+  });
+
+  assert.strictEqual(res.status, 401);
+  assert.strictEqual(fetchCalls.length, 1, 'oversized JWKS should fail before origin fetch');
+});
+
+test('cloudflare RS256 JWT rejects JWKS documents with too many keys', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-jwks-key-cap-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+
+  const req = new Request('https://edge.example.com/api/data', {
+    method: 'GET',
+    headers: {
+      'user-agent': 'runtime-test',
+      authorization: 'Bearer ' + createUnsignedRs256Jwt(),
+    },
+  });
+  const keys = Array.from({ length: 101 }, (_value, i) => ({
+    kid: 'key-' + i,
+    kty: 'RSA',
+    n: 'sXch7EoJ89XcP_Gyo-t6fA',
+    e: 'AQAB',
+  }));
+  const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, req, {
+    originBody: JSON.stringify({ keys }),
+    originHeaders: { 'content-type': 'application/json' },
+  });
+
+  assert.strictEqual(res.status, 401);
+  assert.strictEqual(fetchCalls.length, 1, 'too-large JWKS key set should fail before origin fetch');
 });
 
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {
@@ -402,6 +503,9 @@ request:
   allow_methods: ["GET"]
 response_headers:
   hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
 routes:
   - name: api-jwt
     match:

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -68,7 +68,7 @@ warnSignedUrlReplay(policy);
 // Cloudflare Workers reads env at runtime for static_token/basic_auth, so build
 // does not require the actual token value. Only structural gate fields matter.
 // We still validate jwt/signed_url required fields via the shared helper.
-validateAuthGates(policy, { allowPlaceholderToken: true });
+validateAuthGates(policy, { allowPlaceholderToken: true, requireJwksAllowedHosts: true });
 
 const defaults = policy.defaults || {};
 const request = policy.request || {};

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -887,6 +887,43 @@ test('validateAuthGates accepts jwks_url on allowed_hosts (case-insensitive)', (
   validateAuthGates(policy, { exitOnError: false, allowPlaceholderToken: true });
 });
 
+test('validateAuthGates requires jwks allowed_hosts when target cannot inspect DNS', () => {
+  const policy = {
+    routes: [
+      {
+        name: 'cloudflare-rs256',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+      },
+    ],
+  };
+  assert.throws(
+    () => validateAuthGates(policy, {
+      exitOnError: false,
+      allowPlaceholderToken: true,
+      requireJwksAllowedHosts: true,
+    }),
+    (err: any) => Array.isArray(err.validationErrors)
+      && err.validationErrors.some((e: string) => /cloudflare-rs256/.test(e) && /allowed_hosts/.test(e)),
+  );
+});
+
+test('validateAuthGates accepts required jwks allowed_hosts for matching RS256 host', () => {
+  const policy = {
+    firewall: { jwks: { allowed_hosts: ['idp.example.com'] } },
+    routes: [
+      {
+        name: 'cloudflare-rs256',
+        auth_gate: { type: 'jwt', algorithm: 'RS256', jwks_url: 'https://idp.example.com/jwks.json' },
+      },
+    ],
+  };
+  validateAuthGates(policy, {
+    exitOnError: false,
+    allowPlaceholderToken: true,
+    requireJwksAllowedHosts: true,
+  });
+});
+
 test('warnSignedUrlReplay flags write-like signed_url gates missing nonce_param', () => {
   const captured: string[] = [];
   const logger = { error: (m: string) => captured.push(m) };

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -274,6 +274,12 @@ function validateAuthGates(policy: any, options: any = {}) {
   const routes = policy.routes || [];
   const errors: string[] = [];
   const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
+  const normalizedJwksAllowedHosts = Array.isArray(jwksAllowedHosts)
+    ? jwksAllowedHosts
+      .map((h: any) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
+      .filter(Boolean)
+    : [];
+  const requireJwksAllowedHosts = options.requireJwksAllowedHosts === true;
 
   for (const route of routes) {
     const gate = route.auth_gate;
@@ -285,6 +291,9 @@ function validateAuthGates(policy: any, options: any = {}) {
       const alg = gate.algorithm || 'RS256';
       if (alg === 'RS256' && !gate.jwks_url) {
         errors.push(`Route "${name}": JWT+RS256 requires "jwks_url"`);
+      }
+      if (alg === 'RS256' && requireJwksAllowedHosts && normalizedJwksAllowedHosts.length === 0) {
+        errors.push(`Route "${name}": JWT+RS256 requires firewall.jwks.allowed_hosts for this target`);
       }
       if (gate.jwks_url) {
         const v = validateJwksUrl(gate.jwks_url, jwksAllowedHosts);

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -10,6 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { EventEmitter } = require('events');
 
 type HeaderMap = Record<string, string>;
 type CloudFrontHeaderMap = Record<string, { value: string }>;
@@ -396,6 +397,12 @@ function createHS256Jwt(payload: unknown, secret: string) {
   return headerB64 + '.' + payloadB64 + '.' + sig;
 }
 
+function createRS256Jwt(payload: unknown, kid = 'test-key') {
+  const header = { alg: 'RS256', typ: 'JWT', kid };
+  const enc = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return enc(header) + '.' + enc(payload) + '.signature';
+}
+
 // Build Lambda@Edge event format
 function buildLambdaEdgeEvent(uri: string, headers: HeaderMap = {}, querystring = '', method = 'GET') {
   const h = headers || {};
@@ -434,7 +441,7 @@ async function runAsyncCase(name: string, event: any, expected: ExpectedStatus) 
 }
 
 // Helper: compile origin-request template with inline config
-function compileOriginTemplate(cfgCode: string): any {
+function compileOriginTemplate(cfgCode: string, deps: any = {}): any {
   const templatePath = path.join(__dirname, '..', 'templates', 'aws', 'origin-request.js');
   let originCode;
   try {
@@ -446,17 +453,19 @@ function compileOriginTemplate(cfgCode: string): any {
 
   originCode = originCode.replace('// {{INJECT_CONFIG}}', cfgCode);
 
-  const wrappedCode = '(function() {\n' +
-    'const crypto = require("crypto");\n' +
-    'const https = require("https");\n' +
+  const wrappedCode = '(function(deps) {\n' +
+    'const crypto = deps.crypto || require("crypto");\n' +
+    'const dns = deps.dns || require("dns");\n' +
+    'const https = deps.https || require("https");\n' +
     originCode
       .replace("const crypto = require('crypto');", '')
+      .replace("const dns = require('dns');", '')
       .replace("const https = require('https');", '') +
     '\nreturn exports.handler;\n' +
-    '})()';
+    '})';
 
   try {
-    return eval(wrappedCode);
+    return eval(wrappedCode)(deps);
   } catch (e: any) {
     console.error('Failed to eval origin-request template:', e.message);
     return null;
@@ -866,6 +875,139 @@ async function runOriginJwtSecretFailClosedTests() {
   return { failed: ok ? 0 : 1, total: 1 };
 }
 
+function makeDnsLookup(address: string) {
+  return {
+    lookup: (_hostname: string, _options: any, callback: any) => {
+      process.nextTick(() => callback(null, address, address.includes(':') ? 6 : 4));
+    },
+  };
+}
+
+function makeJwksHttps(body: string, calls: any[]) {
+  return {
+    get: (rawUrl: string, options: any, callback: any) => {
+      calls.push({ rawUrl });
+      const req = new EventEmitter();
+      req.setTimeout = () => req;
+      req.destroy = () => req;
+
+      process.nextTick(() => {
+        const lookup = options && options.lookup;
+        const host = new URL(rawUrl).hostname;
+        const sendResponse = () => {
+          const res = new EventEmitter();
+          res.statusCode = 200;
+          res.resume = () => undefined;
+          callback(res);
+          process.nextTick(() => {
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        };
+        if (typeof lookup === 'function') {
+          lookup(host, {}, (err: Error | null) => {
+            if (err) {
+              req.emit('error', err);
+              return;
+            }
+            sendResponse();
+          });
+          return;
+        }
+        sendResponse();
+      });
+
+      return req;
+    },
+  };
+}
+
+async function runOriginJwksHardeningTests() {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const token = createRS256Jwt({
+    sub: 'user1',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: nowSec + 3600,
+  });
+  const cfgCode = [
+    'const CFG = {',
+    '  project: "test",',
+    '  mode: "enforce",',
+    '  maxHeaderSize: 0,',
+    '  jwtGates: [{',
+    '    name: "api",',
+    '    protectedPrefixes: ["/api"],',
+    '    type: "jwt",',
+    '    algorithm: "RS256",',
+    '    jwks_url: "https://idp.example.com/jwks.json",',
+    '    issuer: "test-issuer",',
+    '    audience: "test-audience",',
+    '    secret_env: ""',
+    '  }],',
+    '  signedUrlGates: [],',
+    '  originAuth: null,',
+    '  trustForwardedFor: false,',
+    '  obs: { logFormat: "json", correlationHeader: "" }',
+    '};',
+  ].join('\n');
+
+  const cases = [
+    {
+      name: 'origin: RS256 JWKS DNS resolving to metadata IP is rejected',
+      dns: makeDnsLookup('169.254.169.254'),
+      body: JSON.stringify({ keys: [] }),
+    },
+    {
+      name: 'origin: RS256 JWKS oversized response is rejected',
+      dns: makeDnsLookup('93.184.216.34'),
+      body: JSON.stringify({ keys: [], padding: 'a'.repeat((256 * 1024) + 1) }),
+    },
+    {
+      name: 'origin: RS256 JWKS with too many keys is rejected',
+      dns: makeDnsLookup('93.184.216.34'),
+      body: JSON.stringify({
+        keys: Array.from({ length: 101 }, (_value, i) => ({
+          kid: 'key-' + i,
+          kty: 'RSA',
+          alg: 'RS256',
+          n: 'sXch7EoJ89XcP_Gyo-t6fA',
+          e: 'AQAB',
+        })),
+      }),
+    },
+  ];
+
+  let failed = 0;
+  const previous = originHandler;
+  for (const c of cases) {
+    const calls: any[] = [];
+    const handlerForCase = compileOriginTemplate(cfgCode, {
+      dns: c.dns,
+      https: makeJwksHttps(c.body, calls),
+    });
+    if (!handlerForCase) {
+      console.error('FAIL:', c.name, '| failed to compile origin template');
+      failed++;
+      continue;
+    }
+    originHandler = handlerForCase;
+    const ok = await runAsyncCase(
+      c.name,
+      buildLambdaEdgeEvent('/api/data', { Authorization: 'Bearer ' + token }),
+      '401',
+    );
+    if (!ok || calls.length !== 1) {
+      if (ok) console.error('FAIL:', c.name, '| expected exactly one JWKS fetch, got', calls.length);
+      failed++;
+    }
+  }
+  originHandler = previous;
+
+  console.log('--- origin-request jwks hardening: ' + (cases.length - failed) + '/' + cases.length + ' passed ---');
+  return { failed, total: cases.length };
+}
+
 async function runOriginAuthFailClosedTests() {
   const cfgCode = [
     'const CFG = {',
@@ -1047,6 +1189,10 @@ async function main() {
   const jwtSecretResult = await runOriginJwtSecretFailClosedTests();
   totalFailed += jwtSecretResult.failed;
   totalTests += jwtSecretResult.total;
+
+  const jwksHardeningResult = await runOriginJwksHardeningTests();
+  totalFailed += jwksHardeningResult.failed;
+  totalTests += jwksHardeningResult.total;
 
   const originAuthResult = await runOriginAuthFailClosedTests();
   totalFailed += originAuthResult.failed;

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 // {{INJECT_CONFIG}}
@@ -25,6 +26,8 @@ const https = require('https');
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -76,47 +79,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -20,6 +20,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -409,6 +411,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -444,8 +488,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -515,32 +559,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/archetypes/admin-panel/edge/origin-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/archetypes/microservice-origin/edge/origin-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/archetypes/rest-api/edge/origin-request.js
+++ b/tests/golden/archetypes/rest-api/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/archetypes/spa-static-site/edge/origin-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -67,6 +67,8 @@ const jwksCache = new Map<string, JwksCacheEntry>();
 
 type JwksNegativeEntry = { failedAt: number; reason: string };
 const jwksNegativeCache = new Map<string, JwksNegativeEntry>();
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 
 function deny(code: number, msg: string) {
   return new Response(msg, { status: code, headers: { 'cache-control': 'no-store' } });
@@ -456,6 +458,48 @@ function isUnsafeJwksUrl(rawUrl: string): string | null {
   return null;
 }
 
+async function readLimitedResponseText(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) {
+    const text = await res.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error('JWKS response too large');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch (_e) { /* ignore */ }
+      throw new Error('JWKS response too large');
+    }
+    chunks.push(chunk.value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function validateJwksKeys(body: any): Array<Record<string, any>> {
+  const keys = Array.isArray(body?.keys) ? body.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
+}
+
 async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<string, any>>> {
   const unsafe = isUnsafeJwksUrl(jwksUrl);
   if (unsafe) {
@@ -491,8 +535,8 @@ async function fetchJwks(jwksUrl: string, ttlSec: number): Promise<Array<Record<
     // cloud-metadata endpoint or a different tenant's IdP.
     const res = await fetch(jwksUrl, { method: 'GET', redirect: 'error' });
     if (!res.ok) throw new Error('Failed to fetch JWKS: ' + res.status);
-    const body = await res.json();
-    const keys = Array.isArray((body as any)?.keys) ? (body as any).keys : [];
+    const bodyText = await readLimitedResponseText(res, JWKS_MAX_BODY_BYTES);
+    const keys = validateJwksKeys(JSON.parse(bodyText));
     jwksCache.set(jwksUrl, { fetchedAt: now, keys });
     jwksNegativeCache.delete(jwksUrl);
     return keys;
@@ -562,32 +606,36 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
 
   if (gate.algorithm === 'RS256') {
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
-    let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-    let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    // Key rotation: if `kid` is not in our cache, invalidate and refetch once
-    // — the IdP may have rotated keys since our last fetch. This prevents a
-    // "stuck isolate" 401 storm after rotation.
-    if (!jwk) {
-      jwksCache.delete(gate.jwks_url);
-      keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
-    }
-    if (!jwk) return { valid: false, error: 'JWK key not found' };
+    try {
+      let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      // Key rotation: if `kid` is not in our cache, invalidate and refetch once
+      // — the IdP may have rotated keys since our last fetch. This prevents a
+      // "stuck isolate" 401 storm after rotation.
+      if (!jwk) {
+        jwksCache.delete(gate.jwks_url);
+        keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
+        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      }
+      if (!jwk) return { valid: false, error: 'JWK key not found' };
 
-    const verifyKey = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-    const ok = await crypto.subtle.verify(
-      'RSASSA-PKCS1-v1_5',
-      verifyKey,
-      base64UrlToBytes(signatureB64),
-      new TextEncoder().encode(signData),
-    );
-    return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+      const verifyKey = await crypto.subtle.importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      const ok = await crypto.subtle.verify(
+        'RSASSA-PKCS1-v1_5',
+        verifyKey,
+        base64UrlToBytes(signatureB64),
+        new TextEncoder().encode(signData),
+      );
+      return ok ? { valid: true, payload } : { valid: false, error: 'Invalid signature' };
+    } catch (err: any) {
+      return { valid: false, error: err?.message || 'JWKS verification failed' };
+    }
   }
 
   return { valid: false, error: 'Unsupported JWT algorithm' };

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -14,6 +14,7 @@
  */
 
 const crypto = require('crypto');
+const dns = require('dns');
 const https = require('https');
 
 const CFG = {
@@ -36,6 +37,8 @@ const CFG = {
 let jwksCache = {};
 let jwksNegativeCache = {};
 const JWKS_CACHE_TTL = 600000; // 10 min fresh window (issue #41 default)
+const JWKS_MAX_BODY_BYTES = 256 * 1024;
+const JWKS_MAX_KEYS = 100;
 function jwksStaleIfErrorMs() {
   return (CFG && typeof CFG.jwksStaleIfErrorSec === 'number' ? CFG.jwksStaleIfErrorSec : 3600) * 1000;
 }
@@ -87,47 +90,98 @@ function isUnsafeJwksUrl(rawUrl) {
   if (u.username || u.password) return 'userinfo present';
   const host = (u.hostname || '').toLowerCase();
   if (!host || host === 'localhost') return 'loopback hostname';
-  if (/^127\./.test(host) || host === '::1' || host === '[::1]') return 'loopback literal';
-  if (/^10\./.test(host)) return 'rfc1918 10/8';
-  if (/^192\.168\./.test(host)) return 'rfc1918 192.168/16';
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return 'rfc1918 172.16/12';
-  if (/^169\.254\./.test(host)) return 'link-local / metadata';
-  if (/^0\./.test(host)) return 'reserved 0/8';
+  if (isUnsafeJwksAddress(host)) return 'private/loopback/link-local literal';
   return null;
+}
+
+function isUnsafeJwksAddress(address) {
+  const host = String(address || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^0\./.test(host)) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^fe8|^fe9|^fea|^feb/.test(host)) return true;
+  if (/^fc|^fd/.test(host)) return true;
+  if (host.startsWith('::ffff:')) return true;
+  return false;
+}
+
+function jwksLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err);
+    const addresses = Array.isArray(address) ? address.map((entry) => entry && entry.address) : [address];
+    if (addresses.some((entry) => isUnsafeJwksAddress(entry))) {
+      return callback(new Error('JWKS hostname resolved to private/loopback/link-local range'));
+    }
+    return callback(null, address, family);
+  });
+}
+
+function validateJwksKeys(jwks) {
+  const keys = jwks && Array.isArray(jwks.keys) ? jwks.keys : [];
+  if (keys.length > JWKS_MAX_KEYS) {
+    throw new Error('JWKS key count exceeds limit');
+  }
+  return keys;
 }
 
 // Raw network fetch (no cache). Caller handles caching policy.
 function fetchJwksNetwork(url) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, (res) => {
+    let settled = false;
+    function rejectOnce(err) {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    const req = https.get(url, { lookup: jwksLookup }, (res) => {
       // Refuse to follow cross-origin redirects (302 to 169.254.169.254,
       // to http://, etc.). Node's https.get does not follow redirects by
       // default, but be explicit in case that ever changes.
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         res.resume();
-        reject(new Error('JWKS fetch refused redirect: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch refused redirect: ' + res.statusCode));
         return;
       }
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error('JWKS fetch failed: ' + res.statusCode));
+        rejectOnce(new Error('JWKS fetch failed: ' + res.statusCode));
         return;
       }
       let data = '';
-      res.on('data', (chunk) => { data += chunk; });
+      let bytes = 0;
+      res.on('data', (chunk) => {
+        if (settled) return;
+        bytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (bytes > JWKS_MAX_BODY_BYTES) {
+          res.resume();
+          rejectOnce(new Error('JWKS response too large'));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
       res.on('end', () => {
+        if (settled) return;
         try {
           const jwks = JSON.parse(data);
-          resolve(jwks.keys);
+          const keys = validateJwksKeys(jwks);
+          settled = true;
+          resolve(keys);
         } catch (e) {
-          reject(e);
+          rejectOnce(e);
         }
       });
     });
-    req.on('error', reject);
+    req.on('error', rejectOnce);
     req.setTimeout(5000, () => {
+      rejectOnce(new Error('JWKS fetch timeout'));
       req.destroy();
-      reject(new Error('JWKS fetch timeout'));
     });
   });
 }


### PR DESCRIPTION
## Description

Hardens RS256 JWKS fetching for both edge runtimes:

- AWS Lambda@Edge now uses a custom DNS lookup for JWKS fetches and rejects resolved loopback, private, link-local, and metadata IP ranges before connecting.
- AWS and Cloudflare runtimes cap JWKS responses at 256 KiB and cap JWKS documents at 100 keys before caching.
- Cloudflare RS256 builds now require `firewall.jwks.allowed_hosts` because Workers cannot inspect DNS resolution targets before `fetch`.
- Cloudflare RS256 verification now fails closed on JWKS fetch/parse errors instead of surfacing a Worker exception.
- Docs and golden fixtures were updated to reflect the generated runtime changes.

## Type of change

- [x] Bug fix
- [ ] New feature or enhancement
- [ ] Documentation only
- [ ] Other (please describe)

## Checklist

- [x] Code and comments use **English only** in non–`.ja` files; Japanese only in `.ja` files.
- [x] Changes align with the framework’s design (Edge as front line, policy-driven where possible, no overlap with WAF).
- [x] Documentation (README or docs) updated if behavior or setup changed.
- [x] Manually tested the affected runtime(s) where applicable.

## Validation

- `npm run build:ts`
- `node scripts/compile-unit-tests.js`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; node scripts/compile.js --policy policy/base.yml --out-dir dist && npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret; npm run test:drift`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret; npm run test:unit`
- `npm run typecheck:scripts-lib-strict`
- `npm run typecheck:compiler-strict`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; npm run lint:policy` (passes with existing weak WAF baseline warning)

## Related issues

Fixes #142