### PR TITLE
fix(edge): accept RS256 JWKs without alg

### DIFF
--- a/docs/auth.ja.md
+++ b/docs/auth.ja.md
@@ -42,6 +42,10 @@ Lambda@Edge も allowlist がある場合は利用し、さらにランタイム
 ホストの DNS 解決先が loopback / private / link-local 範囲なら拒否する。
 
 JWKS レスポンスは parse / cache の前に 256 KiB、100 keys で上限をかける。
+RS256 では両 runtime とも `kid` 一致、`kty: RSA` 必須、かつ JWK の
+`alg` が省略または `RS256` の key を選択する。矛盾する `alg` を持つ
+JWK は無視する。受け入れる token algorithm の権威は JWT header の
+algorithm allowlist のまま。
 
 ### 挙動マトリクス
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -50,6 +50,10 @@ uses the allowlist when present and additionally rejects DNS-resolved JWKS IPs
 in loopback, private, or link-local ranges at runtime.
 
 JWKS responses are capped at 256 KiB and 100 keys before parsing/caching.
+For RS256, both runtimes select JWKs by matching `kid`, requiring
+`kty: RSA`, and accepting either an omitted `alg` field or `alg: RS256`.
+JWKs with a conflicting `alg` are ignored; the JWT header algorithm allowlist
+remains the authority for accepted token algorithms.
 
 ### Behaviour Matrix
 

--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const assert = require('assert');
 const fs = require('fs');
+const nodeCrypto = require('crypto');
 const os = require('os');
 const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
@@ -61,6 +62,14 @@ function createUnsignedRs256Jwt(kid = 'test-key') {
         base64UrlJson({ sub: 'user1', iss: 'test', aud: 'test', exp: nowSec + 3600 }),
         'signature',
     ].join('.');
+}
+function createSignedRs256Jwt(payload, privateKey, kid = 'test-key') {
+    const data = [
+        base64UrlJson({ alg: 'RS256', typ: 'JWT', kid }),
+        base64UrlJson(payload),
+    ].join('.');
+    const signature = nodeCrypto.sign('sha256', Buffer.from(data), privateKey).toString('base64url');
+    return data + '.' + signature;
 }
 async function runGeneratedWorker(generated, query, options = {}) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-'));
@@ -352,6 +361,60 @@ routes:
     });
     assert.strictEqual(res.status, 401);
     assert.strictEqual(fetchCalls.length, 1, 'too-large JWKS key set should fail before origin fetch');
+});
+test('cloudflare RS256 JWT accepts omitted/matching JWK alg and rejects conflicting alg', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-jwk-alg-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+    const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicJwk = publicKey.export({ format: 'jwk' });
+    const nowSec = Math.floor(Date.now() / 1000);
+    const token = createSignedRs256Jwt({
+        sub: 'user1',
+        iss: 'test',
+        aud: 'test',
+        exp: nowSec + 3600,
+    }, privateKey);
+    async function runCase(key) {
+        const req = new Request('https://edge.example.com/api/data', {
+            method: 'GET',
+            headers: {
+                'user-agent': 'runtime-test',
+                authorization: 'Bearer ' + token,
+            },
+        });
+        return runGeneratedWorkerRequest(generated, req, {
+            originBody: JSON.stringify({ keys: [key] }),
+            originHeaders: { 'content-type': 'application/json' },
+        });
+    }
+    const omitted = await runCase({ ...publicJwk, kid: 'test-key' });
+    assert.strictEqual(omitted.res.status, 200);
+    assert.strictEqual(omitted.fetchCalls.length, 2, 'omitted JWK alg should fetch JWKS then origin');
+    const matching = await runCase({ ...publicJwk, kid: 'test-key', alg: 'RS256' });
+    assert.strictEqual(matching.res.status, 200);
+    assert.strictEqual(matching.fetchCalls.length, 2, 'matching JWK alg should fetch JWKS then origin');
+    const conflicting = await runCase({ ...publicJwk, kid: 'test-key', alg: 'HS256' });
+    assert.strictEqual(conflicting.res.status, 401);
+    assert.strictEqual(conflicting.fetchCalls.length, 2, 'conflicting JWK alg should refetch once and not reach origin');
 });
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {
     const generated = compileCloudflare(`

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -370,6 +370,13 @@ function createRS256Jwt(payload, kid = 'test-key') {
     const enc = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
     return enc(header) + '.' + enc(payload) + '.signature';
 }
+function createSignedRS256Jwt(payload, privateKey, kid = 'test-key') {
+    const header = { alg: 'RS256', typ: 'JWT', kid };
+    const enc = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const data = enc(header) + '.' + enc(payload);
+    const signature = crypto.sign('sha256', Buffer.from(data), privateKey).toString('base64url');
+    return data + '.' + signature;
+}
 // Build Lambda@Edge event format
 function buildLambdaEdgeEvent(uri, headers = {}, querystring = '', method = 'GET') {
     const h = headers || {};
@@ -905,6 +912,82 @@ async function runOriginJwksHardeningTests() {
     console.log('--- origin-request jwks hardening: ' + (cases.length - failed) + '/' + cases.length + ' passed ---');
     return { failed, total: cases.length };
 }
+async function runOriginRs256JwkAlgSelectionTests() {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const nowSec = Math.floor(Date.now() / 1000);
+    const token = createSignedRS256Jwt({
+        sub: 'user1',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: nowSec + 3600,
+    }, privateKey);
+    const publicJwk = publicKey.export({ format: 'jwk' });
+    const cfgCode = [
+        'const CFG = {',
+        '  project: "test",',
+        '  mode: "enforce",',
+        '  maxHeaderSize: 0,',
+        '  jwtGates: [{',
+        '    name: "api",',
+        '    protectedPrefixes: ["/api"],',
+        '    type: "jwt",',
+        '    algorithm: "RS256",',
+        '    jwks_url: "https://idp.example.com/jwks.json",',
+        '    issuer: "test-issuer",',
+        '    audience: "test-audience",',
+        '    secret_env: ""',
+        '  }],',
+        '  signedUrlGates: [],',
+        '  originAuth: null,',
+        '  trustForwardedFor: false,',
+        '  obs: { logFormat: "json", correlationHeader: "" }',
+        '};',
+    ].join('\n');
+    const cases = [
+        {
+            name: 'origin: RS256 accepts matching RSA JWK with omitted alg',
+            key: { ...publicJwk, kid: 'test-key' },
+            expected: 'allow',
+            fetches: 1,
+        },
+        {
+            name: 'origin: RS256 accepts matching RSA JWK with alg=RS256',
+            key: { ...publicJwk, kid: 'test-key', alg: 'RS256' },
+            expected: 'allow',
+            fetches: 1,
+        },
+        {
+            name: 'origin: RS256 rejects matching kid with conflicting JWK alg',
+            key: { ...publicJwk, kid: 'test-key', alg: 'HS256' },
+            expected: '401',
+            fetches: 2,
+        },
+    ];
+    let failed = 0;
+    const previous = originHandler;
+    for (const c of cases) {
+        const calls = [];
+        const handlerForCase = compileOriginTemplate(cfgCode, {
+            dns: makeDnsLookup('93.184.216.34'),
+            https: makeJwksHttps(JSON.stringify({ keys: [c.key] }), calls),
+        });
+        if (!handlerForCase) {
+            console.error('FAIL:', c.name, '| failed to compile origin template');
+            failed++;
+            continue;
+        }
+        originHandler = handlerForCase;
+        const ok = await runAsyncCase(c.name, buildLambdaEdgeEvent('/api/data', { Authorization: 'Bearer ' + token }), c.expected);
+        if (!ok || calls.length !== c.fetches) {
+            if (ok)
+                console.error('FAIL:', c.name, '| expected', c.fetches, 'JWKS fetch(es), got', calls.length);
+            failed++;
+        }
+    }
+    originHandler = previous;
+    console.log('--- origin-request rs256 jwk alg selection: ' + (cases.length - failed) + '/' + cases.length + ' passed ---');
+    return { failed, total: cases.length };
+}
 async function runOriginAuthFailClosedTests() {
     const cfgCode = [
         'const CFG = {',
@@ -1069,6 +1152,9 @@ async function main() {
     const jwksHardeningResult = await runOriginJwksHardeningTests();
     totalFailed += jwksHardeningResult.failed;
     totalTests += jwksHardeningResult.total;
+    const rs256JwkAlgResult = await runOriginRs256JwkAlgSelectionTests();
+    totalFailed += rs256JwkAlgResult.failed;
+    totalTests += rs256JwkAlgResult.total;
     const originAuthResult = await runOriginAuthFailClosedTests();
     totalFailed += originAuthResult.failed;
     totalTests += originAuthResult.total;

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const nodeCrypto = require('crypto');
 const os = require('os');
 const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
@@ -72,6 +73,15 @@ function createUnsignedRs256Jwt(kid = 'test-key'): string {
     base64UrlJson({ sub: 'user1', iss: 'test', aud: 'test', exp: nowSec + 3600 }),
     'signature',
   ].join('.');
+}
+
+function createSignedRs256Jwt(payload: unknown, privateKey: any, kid = 'test-key'): string {
+  const data = [
+    base64UrlJson({ alg: 'RS256', typ: 'JWT', kid }),
+    base64UrlJson(payload),
+  ].join('.');
+  const signature = nodeCrypto.sign('sha256', Buffer.from(data), privateKey).toString('base64url');
+  return data + '.' + signature;
 }
 
 async function runGeneratedWorker(generated: string, query: string, options: any = {}) {
@@ -388,6 +398,65 @@ routes:
 
   assert.strictEqual(res.status, 401);
   assert.strictEqual(fetchCalls.length, 1, 'too-large JWKS key set should fail before origin fetch');
+});
+
+test('cloudflare RS256 JWT accepts omitted/matching JWK alg and rejects conflicting alg', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-jwk-alg-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+firewall:
+  jwks:
+    allowed_hosts: ["example.com"]
+routes:
+  - name: api-jwt
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      jwks_url: https://example.com/jwks.json
+      issuer: test
+      audience: test
+`);
+  const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  const nowSec = Math.floor(Date.now() / 1000);
+  const token = createSignedRs256Jwt({
+    sub: 'user1',
+    iss: 'test',
+    aud: 'test',
+    exp: nowSec + 3600,
+  }, privateKey);
+
+  async function runCase(key: any) {
+    const req = new Request('https://edge.example.com/api/data', {
+      method: 'GET',
+      headers: {
+        'user-agent': 'runtime-test',
+        authorization: 'Bearer ' + token,
+      },
+    });
+    return runGeneratedWorkerRequest(generated, req, {
+      originBody: JSON.stringify({ keys: [key] }),
+      originHeaders: { 'content-type': 'application/json' },
+    });
+  }
+
+  const omitted = await runCase({ ...publicJwk, kid: 'test-key' });
+  assert.strictEqual(omitted.res.status, 200);
+  assert.strictEqual(omitted.fetchCalls.length, 2, 'omitted JWK alg should fetch JWKS then origin');
+
+  const matching = await runCase({ ...publicJwk, kid: 'test-key', alg: 'RS256' });
+  assert.strictEqual(matching.res.status, 200);
+  assert.strictEqual(matching.fetchCalls.length, 2, 'matching JWK alg should fetch JWKS then origin');
+
+  const conflicting = await runCase({ ...publicJwk, kid: 'test-key', alg: 'HS256' });
+  assert.strictEqual(conflicting.res.status, 401);
+  assert.strictEqual(conflicting.fetchCalls.length, 2, 'conflicting JWK alg should refetch once and not reach origin');
 });
 
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -403,6 +403,14 @@ function createRS256Jwt(payload: unknown, kid = 'test-key') {
   return enc(header) + '.' + enc(payload) + '.signature';
 }
 
+function createSignedRS256Jwt(payload: unknown, privateKey: any, kid = 'test-key') {
+  const header = { alg: 'RS256', typ: 'JWT', kid };
+  const enc = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const data = enc(header) + '.' + enc(payload);
+  const signature = crypto.sign('sha256', Buffer.from(data), privateKey).toString('base64url');
+  return data + '.' + signature;
+}
+
 // Build Lambda@Edge event format
 function buildLambdaEdgeEvent(uri: string, headers: HeaderMap = {}, querystring = '', method = 'GET') {
   const h = headers || {};
@@ -1008,6 +1016,89 @@ async function runOriginJwksHardeningTests() {
   return { failed, total: cases.length };
 }
 
+async function runOriginRs256JwkAlgSelectionTests() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const nowSec = Math.floor(Date.now() / 1000);
+  const token = createSignedRS256Jwt({
+    sub: 'user1',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: nowSec + 3600,
+  }, privateKey);
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  const cfgCode = [
+    'const CFG = {',
+    '  project: "test",',
+    '  mode: "enforce",',
+    '  maxHeaderSize: 0,',
+    '  jwtGates: [{',
+    '    name: "api",',
+    '    protectedPrefixes: ["/api"],',
+    '    type: "jwt",',
+    '    algorithm: "RS256",',
+    '    jwks_url: "https://idp.example.com/jwks.json",',
+    '    issuer: "test-issuer",',
+    '    audience: "test-audience",',
+    '    secret_env: ""',
+    '  }],',
+    '  signedUrlGates: [],',
+    '  originAuth: null,',
+    '  trustForwardedFor: false,',
+    '  obs: { logFormat: "json", correlationHeader: "" }',
+    '};',
+  ].join('\n');
+
+  const cases = [
+    {
+      name: 'origin: RS256 accepts matching RSA JWK with omitted alg',
+      key: { ...publicJwk, kid: 'test-key' },
+      expected: 'allow',
+      fetches: 1,
+    },
+    {
+      name: 'origin: RS256 accepts matching RSA JWK with alg=RS256',
+      key: { ...publicJwk, kid: 'test-key', alg: 'RS256' },
+      expected: 'allow',
+      fetches: 1,
+    },
+    {
+      name: 'origin: RS256 rejects matching kid with conflicting JWK alg',
+      key: { ...publicJwk, kid: 'test-key', alg: 'HS256' },
+      expected: '401',
+      fetches: 2,
+    },
+  ];
+
+  let failed = 0;
+  const previous = originHandler;
+  for (const c of cases) {
+    const calls: any[] = [];
+    const handlerForCase = compileOriginTemplate(cfgCode, {
+      dns: makeDnsLookup('93.184.216.34'),
+      https: makeJwksHttps(JSON.stringify({ keys: [c.key] }), calls),
+    });
+    if (!handlerForCase) {
+      console.error('FAIL:', c.name, '| failed to compile origin template');
+      failed++;
+      continue;
+    }
+    originHandler = handlerForCase;
+    const ok = await runAsyncCase(
+      c.name,
+      buildLambdaEdgeEvent('/api/data', { Authorization: 'Bearer ' + token }),
+      c.expected,
+    );
+    if (!ok || calls.length !== c.fetches) {
+      if (ok) console.error('FAIL:', c.name, '| expected', c.fetches, 'JWKS fetch(es), got', calls.length);
+      failed++;
+    }
+  }
+  originHandler = previous;
+
+  console.log('--- origin-request rs256 jwk alg selection: ' + (cases.length - failed) + '/' + cases.length + ' passed ---');
+  return { failed, total: cases.length };
+}
+
 async function runOriginAuthFailClosedTests() {
   const cfgCode = [
     'const CFG = {',
@@ -1193,6 +1284,10 @@ async function main() {
   const jwksHardeningResult = await runOriginJwksHardeningTests();
   totalFailed += jwksHardeningResult.failed;
   totalTests += jwksHardeningResult.total;
+
+  const rs256JwkAlgResult = await runOriginRs256JwkAlgSelectionTests();
+  totalFailed += rs256JwkAlgResult.failed;
+  totalTests += rs256JwkAlgResult.total;
 
   const originAuthResult = await runOriginAuthFailClosedTests();
   totalFailed += originAuthResult.failed;

--- a/templates/aws/origin-request.js
+++ b/templates/aws/origin-request.js
@@ -246,6 +246,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -300,11 +305,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -514,6 +514,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -561,14 +568,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/archetypes/admin-panel/edge/origin-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/archetypes/microservice-origin/edge/origin-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/archetypes/rest-api/edge/origin-request.js
+++ b/tests/golden/archetypes/rest-api/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/archetypes/spa-static-site/edge/origin-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/base/edge/origin-request.js
+++ b/tests/golden/base/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/profiles/balanced/edge/origin-request.js
+++ b/tests/golden/profiles/balanced/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/profiles/permissive/edge/origin-request.js
+++ b/tests/golden/profiles/permissive/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -561,6 +561,13 @@ function isJwtAlgAllowed(headerAlg: unknown, gate: any, expected: string): boole
   return allowed.includes(headerAlg);
 }
 
+function isMatchingRs256Jwk(key: any, kid: unknown): boolean {
+  return typeof kid === 'string' && kid.length > 0
+    && key?.kid === kid
+    && key?.kty === 'RSA'
+    && (!key.alg || key.alg === 'RS256');
+}
+
 async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ valid: boolean; error?: string; payload?: any }> {
   const parts = token.split('.');
   if (parts.length !== 3) return { valid: false, error: 'Invalid token format' };
@@ -608,14 +615,14 @@ async function verifyJwt(gate: any, token: string, env: WorkerEnv): Promise<{ va
     if (!gate.jwks_url) return { valid: false, error: 'JWKS URL missing' };
     try {
       let keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-      let jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+      let jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       // Key rotation: if `kid` is not in our cache, invalidate and refetch once
       // — the IdP may have rotated keys since our last fetch. This prevents a
       // "stuck isolate" 401 storm after rotation.
       if (!jwk) {
         jwksCache.delete(gate.jwks_url);
         keys = await fetchJwks(gate.jwks_url, gate.cache_ttl_sec || 3600);
-        jwk = keys.find((k) => k.kid === header.kid && k.kty === 'RSA');
+        jwk = keys.find((k) => isMatchingRs256Jwk(k, header.kid));
       }
       if (!jwk) return { valid: false, error: 'JWK key not found' };
 

--- a/tests/golden/profiles/strict/edge/origin-request.js
+++ b/tests/golden/profiles/strict/edge/origin-request.js
@@ -257,6 +257,11 @@ function isAlgAllowed(headerAlg, gate, expected) {
   return allowed.indexOf(headerAlg) !== -1;
 }
 
+function isMatchingRs256Jwk(key, kid) {
+  if (!key || !kid || typeof kid !== 'string') return false;
+  return key.kid === kid && key.kty === 'RSA' && (!key.alg || key.alg === 'RS256');
+}
+
 // Verify JWT signature (RS256)
 async function verifyJwtRS256(token, gate) {
   const parts = token.split('.');
@@ -311,11 +316,11 @@ async function verifyJwtRS256(token, gate) {
 
     // Fetch JWKS and find matching key; retry once on kid miss (cache refresh)
     let keys = await fetchJwks(jwksUrl);
-    let key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+    let key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
     if (!key) {
       invalidateJwksCache(jwksUrl);
       keys = await fetchJwks(jwksUrl);
-      key = keys.find(k => k.kid === header.kid && k.alg === 'RS256');
+      key = keys.find(k => isMatchingRs256Jwk(k, header.kid));
       if (!key) {
         return { valid: false, error: 'Key not found' };
       }


### PR DESCRIPTION
## Description

Allows RS256 JWKs that omit the optional `alg` field while still rejecting keys with a conflicting `alg`.

- AWS Lambda@Edge now selects RS256 keys by `kid`, `kty: RSA`, and `alg` omitted or `RS256`.
- Cloudflare Worker selection is aligned to the same predicate, so conflicting JWK `alg` values are ignored on both targets.
- Runtime tests cover omitted, matching, and conflicting JWK `alg` cases with real RS256 signatures.
- Golden fixtures and auth docs are updated.

## Type of change

- [x] Bug fix
- [ ] New feature or enhancement
- [ ] Documentation only
- [ ] Other (please describe)

## Checklist

- [x] Code and comments use **English only** in non–`.ja` files; Japanese only in `.ja` files.
- [x] Changes align with the framework’s design (Edge as front line, policy-driven where possible, no overlap with WAF).
- [x] Documentation (README or docs) updated if behavior or setup changed.
- [x] Manually tested the affected runtime(s) where applicable.

## Validation

- `npm run build:ts`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; node scripts/compile.js --policy policy/base.yml --out-dir dist && npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret; npm run test:drift`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret; npm run test:unit`
- `git diff --check`

## Related issues

Fixes #143