### PR TITLE
fix(edge): append Vary for dynamic CORS origins

### DIFF
--- a/docs/response-headers.ja.md
+++ b/docs/response-headers.ja.md
@@ -7,6 +7,7 @@
 | キー | 型 | 既定値 | 備考 |
 |---|---|---|---|
 | `force_vary_auth` | boolean | `true` | `true` のとき、いずれかの `auth_gate.match.path_prefixes` にヒットするパスへ `Cache-Control: no-store, no-cache, must-revalidate, private` と `Vary: Authorization, Cookie` を強制付与する。異なる利用者間での共有キャッシュ汚染を防ぐ。ダウンストリームがユーザー単位でキーを切っていることが明らかな場合のみ無効化する。 |
+| `cors` | object | 未設定 | allowlist ベースの CORS ヘッダーを発行する。runtime がリクエストの `Origin` を `Access-Control-Allow-Origin` に echo する場合、preflight を含め `Vary` に `Origin` もマージし、キャッシュの誤再利用を防ぐ。 |
 | `csp_public` / `csp_admin` | string | 安全な既定値 | 非 admin / admin パスに発行する CSP 文字列。`csp_nonce` 有効時、文字列中の `'nonce-PLACEHOLDER'` はレスポンス生成時に per-response nonce へ置換される。 |
 | `csp_nonce` | boolean | `false` | `true` のとき、per-response nonce を `csp_public`/`csp_admin`/`csp_report_only` の `'nonce-PLACEHOLDER'` に注入し、`X-CSP-Nonce` ヘッダーでオリジンへ共有する。AWS は `Math.random`（暗号学的 PRNG ではない。「制限」節参照）、Cloudflare は `crypto.getRandomValues` を使う。 |
 | `csp_report_only` | string | `""` | 設定すると、通常の CSP と並行して `Content-Security-Policy-Report-Only` を返す。新しい CSP を破綻なく試すのに使う。 |
@@ -31,6 +32,10 @@
    - `Cache-Control: no-store, no-cache, must-revalidate, private`
    - `Pragma: no-cache`
    - `Vary: Authorization, Cookie`（既存の `Vary` とマージ）
+
+### CORS のキャッシュ安全性
+
+`response_headers.cors.allow_origins` を設定し、受信した `Origin` が許可されている場合、AWS と Cloudflare はその値を `Access-Control-Allow-Origin` に echo する。同時に `Vary` へ `Origin` を重複なく追加するため、共有キャッシュが別の許可 Origin 向けレスポンスを誤って再利用しにくくなる。この挙動は CORS preflight レスポンスにも適用される。
 
 ### CSP nonce の導入
 
@@ -103,3 +108,4 @@ response_headers:
 - Issue #11 — per-response CSP nonce により `'unsafe-inline'` を不要にする。
 - Issue #13 — Cloudflare ターゲットが複数 `Set-Cookie` を壊さずに属性を書き換える。AWS ターゲットは単一 Cookie 前提を明示する。
 - Issue #19 — `csp_report_only` を強制 CSP と並行で返し、安全に反復できる。
+- Issue #144 — 動的 CORS Origin echo 時に `Vary: Origin` を加え、許可 Origin ごとのキャッシュキーを正しく分ける。

--- a/docs/response-headers.md
+++ b/docs/response-headers.md
@@ -7,6 +7,7 @@ The `response_headers` section of `policy/security.yml` drives what the viewer-r
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `force_vary_auth` | boolean | `true` | When `true`, any path matched by any `auth_gate.match.path_prefixes` receives `Cache-Control: no-store, no-cache, must-revalidate, private` and `Vary: Authorization, Cookie`. Prevents shared-cache mix-ups between identities. Disable only if you know the downstream caches do not key by user. |
+| `cors` | object | unset | Emits allowlisted CORS headers. When the runtime echoes a request `Origin` into `Access-Control-Allow-Origin`, it also merges `Origin` into `Vary` for cache correctness, including preflight responses. |
 | `csp_public` / `csp_admin` | string | safe defaults | CSP strings emitted for non-admin vs. admin paths. `'nonce-PLACEHOLDER'` is substituted at response time when `csp_nonce` is enabled. |
 | `csp_nonce` | boolean | `false` | When `true`, the framework injects a per-response nonce into any `'nonce-PLACEHOLDER'` token in `csp_public` / `csp_admin` / `csp_report_only`, and exposes it to the origin via `X-CSP-Nonce`. AWS target uses `Math.random` (non-CS-PRNG — see limits); Cloudflare target uses `crypto.getRandomValues`. |
 | `csp_report_only` | string | `""` | If set, emitted as `Content-Security-Policy-Report-Only` alongside the enforced CSP. Use this to A/B a new policy without breaking traffic. |
@@ -31,6 +32,10 @@ With `force_vary_auth: true` (default):
    - `Cache-Control: no-store, no-cache, must-revalidate, private`
    - `Pragma: no-cache`
    - `Vary: Authorization, Cookie` (merged into any existing `Vary`)
+
+### CORS cache safety
+
+When `response_headers.cors.allow_origins` is configured and the incoming `Origin` is allowed, AWS and Cloudflare echo that value in `Access-Control-Allow-Origin`. The framework also appends `Origin` to `Vary` without duplicating existing tokens, so shared caches do not reuse a response generated for a different allowed origin. The same rule applies to CORS preflight responses.
 
 ### CSP nonce rollout
 
@@ -103,3 +108,4 @@ The edge emits `Clear-Site-Data` only when the origin response is 2xx or 3xx so 
 - Issue #11 — per-response CSP nonces remove the need for `'unsafe-inline'`.
 - Issue #13 — Cloudflare target rewrites Set-Cookie attributes without corrupting multi-cookie responses; AWS target documents the single-cookie limit.
 - Issue #19 — `csp_report_only` ships alongside the enforced CSP for safe iterations.
+- Issue #144 — dynamic CORS origin echo adds `Vary: Origin` so caches key allowed origins correctly.

--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -416,6 +416,56 @@ routes:
     assert.strictEqual(conflicting.res.status, 401);
     assert.strictEqual(conflicting.fetchCalls.length, 2, 'conflicting JWK alg should refetch once and not reach origin');
 });
+test('cloudflare CORS appends Vary Origin for preflight and origin responses', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-cors-vary-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+  cors:
+    allow_origins:
+      - https://app.example.com
+      - https://admin.example.com
+    allow_methods: ["GET"]
+    allow_headers: ["Authorization", "X-Api-Token"]
+    allow_credentials: true
+    expose_headers: ["X-Request-Id"]
+routes:
+  - name: api
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: static_token
+      header: X-Api-Token
+      token_env: API_TOKEN
+`);
+    const preflight = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/api/data', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://app.example.com' },
+    }), { env: { API_TOKEN: 'test-token' } });
+    assert.strictEqual(preflight.res.status, 204);
+    assert.strictEqual(preflight.res.headers.get('access-control-allow-origin'), 'https://app.example.com');
+    assert.strictEqual(preflight.res.headers.get('vary'), 'Origin');
+    assert.strictEqual(preflight.fetchCalls.length, 0, 'CORS preflight should not reach origin');
+    const forwarded = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/api/data', {
+        method: 'GET',
+        headers: {
+            origin: 'https://admin.example.com',
+            'user-agent': 'runtime-test',
+            'x-api-token': 'test-token',
+        },
+    }), {
+        env: { API_TOKEN: 'test-token' },
+        originHeaders: { vary: 'Accept-Language' },
+    });
+    assert.strictEqual(forwarded.res.status, 200);
+    assert.strictEqual(forwarded.res.headers.get('access-control-allow-origin'), 'https://admin.example.com');
+    assert.strictEqual(forwarded.res.headers.get('access-control-allow-credentials'), 'true');
+    assert.strictEqual(forwarded.res.headers.get('vary'), 'Accept-Language, Authorization, Cookie, Origin');
+    assert.strictEqual(forwarded.fetchCalls.length, 1, 'authorized CORS request should reach origin once');
+});
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {
     const generated = compileCloudflare(`
 version: 1

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -1067,6 +1067,58 @@ test('response_headers: force_vary_auth=false disables Vary/no-store override', 
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
 });
+test('viewer-response CORS appends Vary Origin and preserves auth Vary tokens', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-cors-vary-response-'));
+    try {
+        process.env.ADMIN_TOKEN = 'test-token';
+        build({
+            version: 1,
+            request: { allow_methods: ['GET'] },
+            response_headers: {
+                cors: {
+                    allow_origins: ['https://app.example.com', 'https://admin.example.com'],
+                    allow_credentials: true,
+                    expose_headers: ['X-Request-Id'],
+                },
+            },
+            routes: [{
+                    name: 'api',
+                    match: { path_prefixes: ['/api'] },
+                    auth_gate: { type: 'static_token', header: 'x-admin-token', token_env: 'ADMIN_TOKEN' },
+                }],
+        }, { outDir: tmpDir });
+        const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
+        const handler = new Function(code + '\nreturn handler;')();
+        const merged = handler({
+            request: {
+                uri: '/api/data',
+                headers: { origin: { value: 'https://app.example.com' } },
+            },
+            response: {
+                statusCode: '200',
+                headers: { vary: { value: 'Accept-Language' } },
+            },
+        });
+        assert.strictEqual(merged.headers['access-control-allow-origin'].value, 'https://app.example.com');
+        assert.strictEqual(merged.headers['access-control-allow-credentials'].value, 'true');
+        assert.strictEqual(merged.headers.vary.value, 'Accept-Language, Authorization, Cookie, Origin');
+        const duplicate = handler({
+            request: {
+                uri: '/',
+                headers: { origin: { value: 'https://admin.example.com' } },
+            },
+            response: {
+                statusCode: '200',
+                headers: { vary: { value: 'Origin' } },
+            },
+        });
+        assert.strictEqual(duplicate.headers.vary.value, 'Origin');
+    }
+    finally {
+        delete process.env.ADMIN_TOKEN;
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
 test('response_headers: emits COOP/COEP/CORP/Reporting-Endpoints when configured', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-resp-iso-'));
     try {
@@ -1112,6 +1164,40 @@ test('response_headers: csp_nonce=true emits substitution hook and Report-Only c
         // Template must have nonce substitution hook + Report-Only emission path
         assert.match(resp, /'nonce-PLACEHOLDER'/);
         assert.match(resp, /Content-Security-Policy-Report-Only/);
+    }
+    finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+test('viewer-request CORS preflight includes Vary Origin', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-cors-vary-preflight-'));
+    try {
+        build({
+            version: 1,
+            request: { allow_methods: ['GET'] },
+            response_headers: {
+                cors: {
+                    allow_origins: ['https://app.example.com', 'https://admin.example.com'],
+                    allow_methods: ['GET', 'POST'],
+                    allow_headers: ['Authorization'],
+                    max_age: 600,
+                },
+            },
+            routes: [],
+        }, { outDir: tmpDir, allowPlaceholderToken: true });
+        const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-request.js'), 'utf8');
+        const handler = new Function(code + '\nreturn handler;')();
+        const result = handler({
+            request: {
+                method: 'OPTIONS',
+                uri: '/api/data',
+                querystring: '',
+                headers: { origin: { value: 'https://app.example.com' } },
+            },
+        });
+        assert.strictEqual(result.statusCode, 204);
+        assert.strictEqual(result.headers['access-control-allow-origin'].value, 'https://app.example.com');
+        assert.strictEqual(result.headers.vary.value, 'Origin');
     }
     finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -459,6 +459,67 @@ routes:
   assert.strictEqual(conflicting.fetchCalls.length, 2, 'conflicting JWK alg should refetch once and not reach origin');
 });
 
+test('cloudflare CORS appends Vary Origin for preflight and origin responses', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-cors-vary-test
+request:
+  allow_methods: ["GET"]
+response_headers:
+  hsts: "max-age=31536000"
+  cors:
+    allow_origins:
+      - https://app.example.com
+      - https://admin.example.com
+    allow_methods: ["GET"]
+    allow_headers: ["Authorization", "X-Api-Token"]
+    allow_credentials: true
+    expose_headers: ["X-Request-Id"]
+routes:
+  - name: api
+    match:
+      path_prefixes: ["/api"]
+    auth_gate:
+      type: static_token
+      header: X-Api-Token
+      token_env: API_TOKEN
+`);
+
+  const preflight = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/api/data', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://app.example.com' },
+    }),
+    { env: { API_TOKEN: 'test-token' } },
+  );
+  assert.strictEqual(preflight.res.status, 204);
+  assert.strictEqual(preflight.res.headers.get('access-control-allow-origin'), 'https://app.example.com');
+  assert.strictEqual(preflight.res.headers.get('vary'), 'Origin');
+  assert.strictEqual(preflight.fetchCalls.length, 0, 'CORS preflight should not reach origin');
+
+  const forwarded = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/api/data', {
+      method: 'GET',
+      headers: {
+        origin: 'https://admin.example.com',
+        'user-agent': 'runtime-test',
+        'x-api-token': 'test-token',
+      },
+    }),
+    {
+      env: { API_TOKEN: 'test-token' },
+      originHeaders: { vary: 'Accept-Language' },
+    },
+  );
+  assert.strictEqual(forwarded.res.status, 200);
+  assert.strictEqual(forwarded.res.headers.get('access-control-allow-origin'), 'https://admin.example.com');
+  assert.strictEqual(forwarded.res.headers.get('access-control-allow-credentials'), 'true');
+  assert.strictEqual(forwarded.res.headers.get('vary'), 'Accept-Language, Authorization, Cookie, Origin');
+  assert.strictEqual(forwarded.fetchCalls.length, 1, 'authorized CORS request should reach origin once');
+});
+
 test('cloudflare graphql guard allows normal GraphQL POST', async () => {
   const generated = compileCloudflare(`
 version: 1

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -1248,6 +1248,60 @@ test('response_headers: force_vary_auth=false disables Vary/no-store override', 
   }
 });
 
+test('viewer-response CORS appends Vary Origin and preserves auth Vary tokens', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-cors-vary-response-'));
+  try {
+    process.env.ADMIN_TOKEN = 'test-token';
+    build({
+      version: 1,
+      request: { allow_methods: ['GET'] },
+      response_headers: {
+        cors: {
+          allow_origins: ['https://app.example.com', 'https://admin.example.com'],
+          allow_credentials: true,
+          expose_headers: ['X-Request-Id'],
+        },
+      },
+      routes: [{
+        name: 'api',
+        match: { path_prefixes: ['/api'] },
+        auth_gate: { type: 'static_token', header: 'x-admin-token', token_env: 'ADMIN_TOKEN' },
+      }],
+    }, { outDir: tmpDir });
+    const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
+    const handler = new Function(code + '\nreturn handler;')();
+
+    const merged = handler({
+      request: {
+        uri: '/api/data',
+        headers: { origin: { value: 'https://app.example.com' } },
+      },
+      response: {
+        statusCode: '200',
+        headers: { vary: { value: 'Accept-Language' } },
+      },
+    });
+    assert.strictEqual(merged.headers['access-control-allow-origin'].value, 'https://app.example.com');
+    assert.strictEqual(merged.headers['access-control-allow-credentials'].value, 'true');
+    assert.strictEqual(merged.headers.vary.value, 'Accept-Language, Authorization, Cookie, Origin');
+
+    const duplicate = handler({
+      request: {
+        uri: '/',
+        headers: { origin: { value: 'https://admin.example.com' } },
+      },
+      response: {
+        statusCode: '200',
+        headers: { vary: { value: 'Origin' } },
+      },
+    });
+    assert.strictEqual(duplicate.headers.vary.value, 'Origin');
+  } finally {
+    delete process.env.ADMIN_TOKEN;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('response_headers: emits COOP/COEP/CORP/Reporting-Endpoints when configured', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-resp-iso-'));
   try {
@@ -1293,6 +1347,41 @@ test('response_headers: csp_nonce=true emits substitution hook and Report-Only c
     // Template must have nonce substitution hook + Report-Only emission path
     assert.match(resp, /'nonce-PLACEHOLDER'/);
     assert.match(resp, /Content-Security-Policy-Report-Only/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('viewer-request CORS preflight includes Vary Origin', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compile-unit-cors-vary-preflight-'));
+  try {
+    build({
+      version: 1,
+      request: { allow_methods: ['GET'] },
+      response_headers: {
+        cors: {
+          allow_origins: ['https://app.example.com', 'https://admin.example.com'],
+          allow_methods: ['GET', 'POST'],
+          allow_headers: ['Authorization'],
+          max_age: 600,
+        },
+      },
+      routes: [] as any[],
+    }, { outDir: tmpDir, allowPlaceholderToken: true });
+    const code = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-request.js'), 'utf8');
+    const handler = new Function(code + '\nreturn handler;')();
+
+    const result = handler({
+      request: {
+        method: 'OPTIONS',
+        uri: '/api/data',
+        querystring: '',
+        headers: { origin: { value: 'https://app.example.com' } },
+      },
+    });
+    assert.strictEqual(result.statusCode, 204);
+    assert.strictEqual(result.headers['access-control-allow-origin'].value, 'https://app.example.com');
+    assert.strictEqual(result.headers.vary.value, 'Origin');
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/templates/aws/viewer-request.js
+++ b/templates/aws/viewer-request.js
@@ -32,6 +32,14 @@
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -124,6 +132,7 @@
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/templates/aws/viewer-response.js
+++ b/templates/aws/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 // {{INJECT_RESPONSE_CONFIG}}
 
 // Non-cryptographic CSP nonce. CloudFront Functions do not expose crypto.
@@ -92,12 +100,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -145,6 +149,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -704,6 +704,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -714,15 +722,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1413,12 +1422,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1479,6 +1484,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/archetypes/admin-panel/edge/viewer-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/archetypes/admin-panel/edge/viewer-response.js
+++ b/tests/golden/archetypes/admin-panel/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"no-referrer","permissions-policy":"camera=(), microphone=(), geolocation=(), payment=()"},
   csp_public: "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/archetypes/microservice-origin/edge/viewer-response.js
+++ b/tests/golden/archetypes/microservice-origin/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"no-referrer","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'none'; frame-ancestors 'none';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/archetypes/rest-api/edge/viewer-request.js
+++ b/tests/golden/archetypes/rest-api/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/archetypes/rest-api/edge/viewer-response.js
+++ b/tests/golden/archetypes/rest-api/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"no-referrer","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'none'; frame-ancestors 'none';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/archetypes/spa-static-site/edge/viewer-response.js
+++ b/tests/golden/archetypes/spa-static-site/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"strict-origin-when-cross-origin","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'self'; script-src 'self' 'nonce-{{nonce}}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/base/edge/viewer-request.js
+++ b/tests/golden/base/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/base/edge/viewer-response.js
+++ b/tests/golden/base/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"strict-origin-when-cross-origin","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/profiles/balanced/edge/viewer-request.js
+++ b/tests/golden/profiles/balanced/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/profiles/balanced/edge/viewer-response.js
+++ b/tests/golden/profiles/balanced/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"strict-origin-when-cross-origin","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/profiles/permissive/edge/viewer-request.js
+++ b/tests/golden/profiles/permissive/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/profiles/permissive/edge/viewer-response.js
+++ b/tests/golden/profiles/permissive/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"strict-origin-when-cross-origin","permissions-policy":"camera=(), microphone=(), geolocation=()"},
   csp_public: "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -751,6 +751,14 @@ function isHostAllowed(hostHeader: string): boolean {
   return false;
 }
 
+function appendVary(headers: Headers, token: string): void {
+  const existing = headers.get('vary') || '';
+  const tokens = existing.split(',').map((s: string) => s.trim()).filter(Boolean);
+  const lower = tokens.map((s: string) => s.toLowerCase());
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  headers.set('Vary', tokens.join(', '));
+}
+
 function handleCorsPreflight(request: Request): Response | null {
   if (request.method !== 'OPTIONS' || !CFG.cors) return null;
 
@@ -761,15 +769,16 @@ function handleCorsPreflight(request: Request): Response | null {
   const isAllowed = allowedOrigins.includes('*') || allowedOrigins.includes(origin);
   if (!isAllowed) return null;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Access-Control-Allow-Origin': origin,
     'Cache-Control': 'no-store',
-  };
+  });
+  appendVary(headers, 'Origin');
 
-  if (CFG.cors.allow_methods) headers['Access-Control-Allow-Methods'] = CFG.cors.allow_methods.join(', ');
-  if (CFG.cors.allow_headers) headers['Access-Control-Allow-Headers'] = CFG.cors.allow_headers.join(', ');
-  if (CFG.cors.allow_credentials) headers['Access-Control-Allow-Credentials'] = 'true';
-  if (CFG.cors.max_age) headers['Access-Control-Max-Age'] = String(CFG.cors.max_age);
+  if (CFG.cors.allow_methods) headers.set('Access-Control-Allow-Methods', CFG.cors.allow_methods.join(', '));
+  if (CFG.cors.allow_headers) headers.set('Access-Control-Allow-Headers', CFG.cors.allow_headers.join(', '));
+  if (CFG.cors.allow_credentials) headers.set('Access-Control-Allow-Credentials', 'true');
+  if (CFG.cors.max_age) headers.set('Access-Control-Max-Age', String(CFG.cors.max_age));
 
   return new Response(null, { status: 204, headers });
 }
@@ -1460,12 +1469,8 @@ export default {
     if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
       out.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
       out.headers.set('Pragma', 'no-cache');
-      const existingVary = out.headers.get('vary') || '';
-      const tokens = existingVary.split(',').map((s: string) => s.trim()).filter(Boolean);
-      const lower = tokens.map((t: string) => t.toLowerCase());
-      if (lower.indexOf('authorization') === -1) tokens.push('Authorization');
-      if (lower.indexOf('cookie') === -1) tokens.push('Cookie');
-      out.headers.set('Vary', tokens.join(', '));
+      appendVary(out.headers, 'Authorization');
+      appendVary(out.headers, 'Cookie');
     }
 
     // Clear-Site-Data on configured logout paths (issue #20). Only on 2xx/3xx.
@@ -1526,6 +1531,7 @@ export default {
 
       if (origin && isAllowed) {
         out.headers.set('Access-Control-Allow-Origin', origin);
+        appendVary(out.headers, 'Origin');
         if (RESPONSE_CFG.cors.allow_credentials) out.headers.set('Access-Control-Allow-Credentials', 'true');
         if (RESPONSE_CFG.cors.expose_headers?.length > 0) out.headers.set('Access-Control-Expose-Headers', RESPONSE_CFG.cors.expose_headers.join(', '));
       }

--- a/tests/golden/profiles/strict/edge/viewer-request.js
+++ b/tests/golden/profiles/strict/edge/viewer-request.js
@@ -50,6 +50,14 @@ const CFG = {
     };
   }
 
+  function appendVary(headers, token) {
+    var existing = (headers["vary"] && headers["vary"].value) || '';
+    var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var lower = tokens.map(function (s) { return s.toLowerCase(); });
+    if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+    headers["vary"] = { value: tokens.join(', ') };
+  }
+
   // Structured log emitter. CloudFront Functions supports console.log + JSON.stringify
   // on flat primitives (our records only contain those). `event` distinguishes
   // block / monitor / audit records for downstream Logs Insights queries.
@@ -142,6 +150,7 @@ const CFG = {
       'access-control-allow-origin': { value: origin },
       'cache-control': { value: 'no-store' },
     };
+    appendVary(headers, 'Origin');
 
     if (CFG.cors.allow_methods) {
       headers['access-control-allow-methods'] = { value: CFG.cors.allow_methods.join(', ') };

--- a/tests/golden/profiles/strict/edge/viewer-response.js
+++ b/tests/golden/profiles/strict/edge/viewer-response.js
@@ -21,6 +21,14 @@
 
 function set(headers, k, v) { headers[k.toLowerCase()] = { value: v }; }
 
+function appendVary(headers, token) {
+  var existing = (headers["vary"] && headers["vary"].value) || '';
+  var tokens = existing.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  var lower = tokens.map(function (s) { return s.toLowerCase(); });
+  if (lower.indexOf(token.toLowerCase()) === -1) tokens.push(token);
+  set(headers, "Vary", tokens.join(', '));
+}
+
 const RESPONSE_CFG = {
   headers: {"strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-content-type-options":"nosniff","referrer-policy":"no-referrer","permissions-policy":"camera=(), microphone=(), geolocation=(), payment=()"},
   csp_public: "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self';",
@@ -111,12 +119,8 @@ function handler(event) {
   if (RESPONSE_CFG.forceVaryAuth && isAuthPath) {
     set(h, "Cache-Control", "no-store, no-cache, must-revalidate, private");
     set(h, "Pragma", "no-cache");
-    // Append Authorization+Cookie to Vary without clobbering existing Vary.
-    var existingVary = (h["vary"] && h["vary"].value) || '';
-    var tokens = existingVary.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-    if (tokens.indexOf('authorization') === -1) tokens.push('Authorization');
-    if (tokens.indexOf('cookie') === -1) tokens.push('Cookie');
-    set(h, "Vary", tokens.join(', '));
+    appendVary(h, "Authorization");
+    appendVary(h, "Cookie");
   }
 
   // Clear-Site-Data on configured logout paths (issue #20). Only applied on
@@ -164,6 +168,7 @@ function handler(event) {
 
     if (origin && isAllowed) {
       set(h, 'Access-Control-Allow-Origin', origin);
+      appendVary(h, 'Origin');
       if (RESPONSE_CFG.cors.allow_credentials) {
         set(h, 'Access-Control-Allow-Credentials', 'true');
       }


### PR DESCRIPTION
## Summary
- add non-clobbering `Vary` append helpers for AWS viewer-request/viewer-response and Cloudflare Workers
- append `Vary: Origin` whenever CORS echoes an allowed request Origin, including preflight responses
- keep auth-path `Vary: Authorization, Cookie` behavior intact while merging with CORS `Origin`

## Tests
- `node scripts/compile-unit-tests.js`
- `node scripts/cloudflare-runtime-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret npm run test:unit`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret npm run test:drift`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret; node scripts/compile.js --policy policy/base.yml --out-dir dist; npm run test:runtime`
- `git diff --check`
- `npm run lint:policy -- policy/base.yml`

Fixes #144
