### PR TITLE
fix(ci): correct security baseline CODEOWNERS path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /scripts/compile-cloudflare.js  @albert-einshutoin
 /scripts/compile-infra.js       @albert-einshutoin
 /scripts/policy-lint.js         @albert-einshutoin
-/scripts/security-baseline.js   @albert-einshutoin
+/scripts/security-baseline-check.js @albert-einshutoin
 /templates/                     @albert-einshutoin
 
 # Supply-chain / release


### PR DESCRIPTION
## Summary
- update `.github/CODEOWNERS` to point at `scripts/security-baseline-check.js`
- remove the stale `scripts/security-baseline.js` security-critical path entry

## Tests
- `test -f scripts/security-baseline-check.js && ! test -f scripts/security-baseline.js`
- `npm run test:security-baseline`
- `git diff --check`

Fixes #145
