### PR TITLE
test(ci): add local CI quality gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,17 +31,21 @@ Thank you for your interest in contributing. This document explains how to propo
 
 ## CI quality gate
 
-Before opening a PR, ensure these checks pass locally:
+Before opening a PR, export the CI fixture secrets and run the local CI gate:
 
-1. `npm run lint:policy -- policy/base.yml`
-2. `npm run build`
-3. `node scripts/compile-cloudflare.js`
-4. `npm run test:runtime`
-5. `npm run test:unit`
-6. `npm run test:drift`
-7. `npm run test:security-baseline`
+```bash
+export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
+export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
+npm run test:ci
+```
 
-GitHub Actions runs the same gate on push/PR to `develop`.
+`test:ci` mirrors the single-Node GitHub Actions quality gate: audit, policy
+lint, AWS/Cloudflare builds, dist existence checks, runtime/unit/fuzz/integration
+tests, drift, security-baseline, coverage, and package smoke. The GitHub Actions
+Node-version matrix is still CI-only; local `test:ci` runs package smoke on your
+current Node version. When a local `policy/security.yml` exists, the script
+lints and builds it first, then regenerates `policy/base.yml` fixtures for the
+runtime and coverage suites.
 
 Release is automated by tag:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -172,13 +172,25 @@ production ではない fixture build だけなら
 export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
 export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
 
+npm run test:ci
+```
+
+単一 Node 版の CI 品質ゲートを実行します。audit、policy lint、build、runtime、
+unit、fuzz、integration、drift、security-baseline、coverage、package smoke を含みます。
+GitHub Actions の Node バージョン matrix は再現しません。CI 側では引き続き
+Node 20.17.0 / 22 / 24 で package smoke を走らせます。
+ローカルに `policy/security.yml` がある場合、`test:ci` はまずそれを lint/build し、
+runtime / coverage テスト用には `policy/base.yml` fixture を再生成します。
+
+局所確認には以下を使えます。
+
+```bash
 npm run test:runtime
 npm run test:unit
 npm run test:drift
 npm run test:security-baseline
 ```
 
-CI と同じ runtime / unit / drift / security-baseline チェックを実行します。
 `EDGE_ADMIN_TOKEN` は組み込み admin `static_token` gate を含む生成 artifact に必要です。
 `ORIGIN_SECRET` は origin-auth fixture policy を含む drift / release 系チェックで必要です。
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,25 @@ that contain the placeholder token.
 export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy
 export ORIGIN_SECRET=ci-origin-secret-not-for-deploy
 
+npm run test:ci
+```
+
+Runs the single-Node CI quality gate, including audit, policy lint, build,
+runtime, unit, fuzz, integration, drift, security-baseline, coverage, and
+package smoke checks. It intentionally does not reproduce the GitHub Actions
+Node-version matrix; CI still runs package smoke on Node 20.17.0, 22, and 24.
+If you have a local `policy/security.yml`, `test:ci` lints and builds it first,
+then regenerates `policy/base.yml` fixtures for runtime and coverage tests.
+
+For focused local checks:
+
+```bash
 npm run test:runtime
 npm run test:unit
 npm run test:drift
 npm run test:security-baseline
 ```
 
-Runs runtime, unit, drift, and security-baseline checks used by CI.
 `EDGE_ADMIN_TOKEN` is required by generated artifacts that include the built-in
 admin `static_token` gate. `ORIGIN_SECRET` is required by origin-auth fixture
 policies used by the broader drift/release checks.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "typecheck:cli-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/bin/cli.ts",
     "typecheck:compiler-strict": "tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution Node --moduleDetection force --ignoreDeprecations 6.0 --esModuleInterop --resolveJsonModule --types node --strict true --noImplicitAny true --strictNullChecks true --useUnknownInCatchVariables true src/parser/*.ts src/validator/*.ts src/emitter/*.ts src/scripts/compile.ts src/scripts/compile-cloudflare.ts src/scripts/compile-infra.ts src/scripts/compile-cloudflare-waf.ts src/scripts/policy-lint.ts",
     "build": "npm run build:ts && node scripts/compile.js",
+    "build:test-fixtures": "npm run build:ts && node scripts/compile.js --policy policy/base.yml --out-dir dist",
     "lint:policy": "npm run build:ts && node scripts/policy-lint.js",
+    "lint:policy:ci": "if [ -f policy/security.yml ]; then npm run lint:policy -- policy/security.yml; else npm run lint:policy -- policy/base.yml; fi && npm run lint:policy -- policy/profiles/balanced.yml && npm run lint:policy -- policy/profiles/strict.yml && npm run lint:policy -- policy/profiles/permissive.yml && npm run lint:policy -- policy/archetypes/spa-static-site.yml && npm run lint:policy -- policy/archetypes/rest-api.yml && npm run lint:policy -- policy/archetypes/admin-panel.yml && npm run lint:policy -- policy/archetypes/microservice-origin.yml",
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
     "test:vitest": "npm run build:ts && node scripts/ensure-report-dir.js && vitest run",
     "test:runtime": "npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
@@ -53,8 +55,10 @@
     "test:cloudflare-integration": "npm run build:ts && node scripts/cloudflare-integration-tests.js",
     "test:edge-container": "npm run build:ts && node scripts/edge-container-attack-tests.js",
     "test:package": "npm run build:ts && node scripts/package-smoke-tests.js",
+    "test:dist-exists": "node -e \"const fs=require('fs'); for (const f of ['dist/edge/viewer-request.js','dist/edge/viewer-response.js','dist/edge/origin-request.js','dist/edge/cloudflare/index.ts']) fs.accessSync(f);\"",
     "test:coverage": "c8 --reporter=text --reporter=lcov --include='scripts/**/*.js' --include='lib/**/*.js' --include='parser/**/*.js' --include='validator/**/*.js' --include='emitter/**/*.js' --exclude='scripts/**/*-tests.js' --lines 80 --functions 75 --branches 70 npm run test:all",
-    "test:all": "npm run build && npm run test:types && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run typecheck:compiler-strict && npm run typecheck:unit-tests-strict && npm run typecheck:cli-strict && npm run test:api-contract && npm run test:vitest && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
+    "test:ci": "npm audit --audit-level=high && npm run lint:policy:ci && npm run build && node scripts/compile-cloudflare.js && node scripts/compile-cloudflare-waf.js --policy policy/base.yml --out-dir dist --fail-on-waf-approximation && npm run test:dist-exists && npm run build:test-fixtures && npm run test:runtime && npm run test:unit && node bin/cli.js doctor --no-report && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container && npm run test:drift && npm run test:security-baseline && npm run test:coverage && npm run test:package",
+    "test:all": "npm run build:test-fixtures && npm run test:types && npm run typecheck:lib-strict && npm run typecheck:scripts-lib-strict && npm run typecheck:compiler-strict && npm run typecheck:unit-tests-strict && npm run typecheck:cli-strict && npm run test:api-contract && npm run test:vitest && npm run test:unit && npm run test:runtime && npm run test:fuzz && npm run test:cloudflare-integration && npm run test:edge-container",
     "fingerprints:candidates": "npm run build:ts && node scripts/fingerprint-candidates.js"
   },
   "keywords": [

--- a/scripts/README.ja.md
+++ b/scripts/README.ja.md
@@ -43,6 +43,9 @@ node scripts/policy-lint.js policy/profiles/balanced.yml
 ### テスト
 
 ```bash
+npm run test:ci
+
+# 局所確認
 npm run test:runtime
 npm run test:unit
 npm run test:drift
@@ -68,6 +71,11 @@ GitHub Actions の `.github/workflows/policy-lint.yml` では、`main` への pu
 5. unit テスト（`npm run test:unit`）
 6. drift チェック（`npm run test:drift`）
 7. security baseline チェック（`npm run test:security-baseline`）
+8. coverage（`npm run test:coverage`）
+9. package smoke（`npm run test:package`）
+
+ローカルで単一 Node 版の同等ゲートを走らせる場合は `npm run test:ci` を使います。
+GitHub workflow では追加で Node バージョン matrix の package smoke も実行します。
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,6 +43,9 @@ node scripts/policy-lint.js policy/profiles/balanced.yml
 ### Tests
 
 ```bash
+npm run test:ci
+
+# Focused checks
 npm run test:runtime
 npm run test:unit
 npm run test:drift
@@ -68,6 +71,11 @@ GitHub Actions workflow `.github/workflows/policy-lint.yml` runs the default qua
 5. unit tests (`npm run test:unit`)
 6. drift check (`npm run test:drift`)
 7. security baseline check (`npm run test:security-baseline`)
+8. coverage (`npm run test:coverage`)
+9. package smoke (`npm run test:package`)
+
+Use `npm run test:ci` for the local single-Node equivalent. The GitHub workflow
+also runs package smoke on the Node-version matrix.
 
 ---
 

--- a/scripts/edge-container-attack-tests.js
+++ b/scripts/edge-container-attack-tests.js
@@ -39,7 +39,7 @@ let awsArtifactsCompiled = false;
 function ensureAwsArtifactsCompiled() {
     if (awsArtifactsCompiled)
         return;
-    runNode('scripts/compile.js', []);
+    runNode('scripts/compile.js', ['--policy', 'policy/base.yml', '--out-dir', 'dist']);
     awsArtifactsCompiled = true;
 }
 function loadAwsViewerHandler() {

--- a/src/scripts/edge-container-attack-tests.ts
+++ b/src/scripts/edge-container-attack-tests.ts
@@ -46,7 +46,7 @@ function runNode(script: string, args: string[], env: Record<string, string> = {
 let awsArtifactsCompiled = false;
 function ensureAwsArtifactsCompiled() {
   if (awsArtifactsCompiled) return;
-  runNode('scripts/compile.js', []);
+  runNode('scripts/compile.js', ['--policy', 'policy/base.yml', '--out-dir', 'dist']);
   awsArtifactsCompiled = true;
 }
 


### PR DESCRIPTION
## Summary
- add `npm run test:ci` as a local single-Node equivalent of the CI quality gate
- add helper scripts for CI policy lint, fixture builds, and dist existence checks
- make edge-container AWS fixtures compile from `policy/base.yml` so local ignored `policy/security.yml` cannot break fixture tests
- document `test:ci` in README, CONTRIBUTING, and scripts README

## Tests
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret-not-for-deploy; npm run test:edge-container`
- `export EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy; export ORIGIN_SECRET=ci-origin-secret-not-for-deploy; npm run test:ci`
- `git diff --check`

Fixes #146
