### PR TITLE
docs(policy): add deployment recipes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,7 @@ Terraform / CloudFormation / CDK / WAF の利用例は [IaC 連携](docs/iac.ja.
 - [プログラマティック API](docs/programmatic-api.ja.md) — `require('cdn-security-framework')` で CI / IaC から直接呼び出し
 - [Compiler strictness](docs/compiler-strictness.ja.md) — phase contract、strict check、残る dynamic area
 - [アーキタイプ](docs/archetypes.ja.md) — アプリ形状別プリセット（SPA / REST API / 管理画面 / マイクロサービス）
+- [ポリシーレシピ](docs/recipes.ja.md) — Cognito API、SPA、管理画面、署名付き download、Cloudflare GraphQL の copyable snippet
 - [レスポンス DLP](docs/response-dlp.ja.md) — Cloudflare Workers で高信頼の漏えい値を mask/block する設定
 - [シークレットローテーション runbook](docs/runbooks/secret-rotation.ja.md) — JWT / JWKS / 署名付き URL / 管理トークン / origin シークレット
 - [スキーママイグレーション](docs/schema-migration.ja.md) — `policy/schema.json` のバージョン契約と `migrate` CLI

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See [IaC integration](docs/iac.md) for Terraform / CloudFormation / CDK / WAF us
 - [Programmatic API](docs/programmatic-api.md) — `require('cdn-security-framework')` for CI / IaC integration
 - [Compiler strictness](docs/compiler-strictness.md) — phase contracts, strict checks, and remaining dynamic areas
 - [Archetypes](docs/archetypes.md) — app-shaped policy presets (SPA, REST API, admin, microservice)
+- [Policy recipes](docs/recipes.md) — copyable snippets for Cognito APIs, SPAs, admin panels, signed downloads, and Cloudflare GraphQL
 - [Response DLP](docs/response-dlp.md) — Cloudflare Workers response masking/blocking for high-confidence data leaks
 - [Secret rotation runbook](docs/runbooks/secret-rotation.md) — JWT / JWKS / signed URL / admin token / origin secret
 - [Schema migration](docs/schema-migration.md) — how `policy/schema.json` evolves and the `migrate` CLI

--- a/docs/quickstart.ja.md
+++ b/docs/quickstart.ja.md
@@ -16,6 +16,9 @@ npx cdn-security init
 非対話: `npx cdn-security init --platform aws --profile balanced --force`
 最初の推奨ルート: `npx cdn-security init --platform aws --archetype spa-static-site --force`
 
+Cognito JWT API、署名付き download、Cloudflare GraphQL など用途別の
+copyable snippet が必要な場合は [ポリシーレシピ](./recipes.ja.md) を参照してください。
+
 ## 2. ポリシー編集とビルド
 
 `policy/security.yml` を必要に応じて編集し（allow_methods、block ルール、routes など）、次を実行します。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,6 +16,9 @@ Choose platform (AWS CloudFront / Cloudflare Workers) and either a profile (Stri
 Non-interactive: `npx cdn-security init --platform aws --profile balanced --force`
 Recommended first path: `npx cdn-security init --platform aws --archetype spa-static-site --force`
 
+For copyable end-to-end snippets such as Cognito JWT APIs, signed downloads, or
+Cloudflare GraphQL, see [Policy recipes](./recipes.md).
+
 ## 2. Edit policy and build
 
 Edit `policy/security.yml` as needed (allow_methods, block rules, routes, etc.), then:

--- a/docs/recipes.ja.md
+++ b/docs/recipes.ja.md
@@ -1,0 +1,422 @@
+# ポリシーレシピ
+
+> **言語:** [English](./recipes.md) - 日本語
+
+レシピは、よくあるデプロイ形態向けにそのまま貼り付けられる出発点です。
+`policy/security.yml` に貼り付け、ドメイン名と環境変数名を置き換えてから、
+snippet 下のコマンドを実行してください。
+
+[アーキタイプ](./archetypes.ja.md) がアプリ形状を表すのに対し、レシピは
+target 前提、認証方式、必要な環境変数、検証コマンドまで含む具体例です。
+
+---
+
+## Cognito JWT API
+
+**用途:** AWS Cognito の RS256 access token で JSON API を保護する。
+**主 target:** AWS CloudFront + Lambda@Edge origin-request、または Cloudflare Workers。
+**必要 env:** `origin.auth` も有効化する場合のみ `ORIGIN_SECRET`。
+
+```yaml
+version: 1
+project: cognito-api
+metadata:
+  risk_level: strict
+  description: Cognito-protected JSON API.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 2048
+    max_query_params: 64
+    max_header_count: 80
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+    drop_query_keys: ["utm_*", gclid, fbclid]
+routes:
+  - name: api
+    match:
+      path_prefixes: ["/api/"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      allowed_algorithms: [RS256]
+      jwks_url: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_example/.well-known/jwks.json"
+      issuer: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_example"
+      audience: "example-client-id"
+      cache_ttl_sec: 3600
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  cors:
+    allow_origins: ["https://app.example.com"]
+    allow_methods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
+    allow_headers: [Authorization, Content-Type]
+    allow_credentials: true
+    max_age: 600
+firewall:
+  jwks:
+    allowed_hosts:
+      - "cognito-idp.us-east-1.amazonaws.com"
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+      - AWSManagedRulesIPReputationList
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie]
+```
+
+コマンド:
+
+```bash
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target aws
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+```
+
+Cognito の region、user pool ID、client ID、`firewall.jwks.allowed_hosts`
+を必ず揃えて置き換えてください。Cloudflare Workers でも同じレシピを
+`--target cloudflare` で使えます。Workers は JWKS fetch 前の低レベル DNS
+検査ができないため、`allowed_hosts` は維持してください。
+
+---
+
+## Next.js or SPA Static Site
+
+**用途:** Next.js static export、React/Vue/Svelte SPA、静的マーケティングサイトを
+CloudFront または Cloudflare で配信する。
+**主 target:** AWS CloudFront Functions または Cloudflare Workers。
+**必要 env:** なし。
+
+```yaml
+version: 1
+project: spa-static-site
+metadata:
+  risk_level: balanced
+  description: Static frontend with browser security headers.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 40
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+    drop_query_keys: ["utm_*", gclid, fbclid]
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "strict-origin-when-cross-origin"
+  permissions_policy: "camera=(), microphone=(), geolocation=()"
+  csp_public: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.example.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self';"
+  cors:
+    allow_origins: ["https://www.example.com"]
+    allow_methods: [GET, HEAD, OPTIONS]
+    allow_headers: [Content-Type]
+    max_age: 86400
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 2000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+```
+
+コマンド:
+
+```bash
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target aws
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+npm run test:runtime
+```
+
+Next.js が static export ではなく SSR の場合は、origin 側の cache-control と
+認証付き route の cache 境界を `response_headers.force_vary_auth` と合わせて確認してください。
+
+---
+
+## Internal Admin Panel
+
+**用途:** VPN、IP allowlist、identity-aware proxy と併用しつつ、社内向け管理画面を
+簡易 edge gate で保護する。
+**主 target:** AWS CloudFront Functions または Cloudflare Workers。
+**必要 env:** `EDGE_ADMIN_TOKEN`。
+
+```yaml
+version: 1
+project: internal-admin
+metadata:
+  risk_level: strict
+  description: Internal admin panel protected by static edge token and WAF allowlist.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, POST]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 40
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix, curl, wget, python-requests]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+routes:
+  - name: admin
+    match:
+      path_prefixes: ["/"]
+    auth_gate:
+      type: static_token
+      header: x-edge-admin-token
+      token_env: EDGE_ADMIN_TOKEN
+    response:
+      cache_control: "no-store, no-cache, must-revalidate"
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  permissions_policy: "camera=(), microphone=(), geolocation=(), payment=()"
+  csp_admin: "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';"
+  force_vary_auth: true
+firewall:
+  ip:
+    allowlist:
+      - "203.0.113.0/24"
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 500
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+      - AWSManagedRulesIPReputationList
+      - AWSManagedRulesAnonymousIpList
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie, x-api-key]
+```
+
+コマンド:
+
+```bash
+export EDGE_ADMIN_TOKEN=replace-with-a-strong-random-token
+npm run lint:policy -- policy/security.yml
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+```
+
+static token は短期的な edge guard として扱い、唯一の管理者認証にしないでください。
+CDN/IaC の secret flow で rotate し、SSO と併用してください。
+
+---
+
+## Signed Download URLs
+
+**用途:** private file を origin path から配信し、長期 bearer token ではなく期限付きリンクで保護する。
+**主 target:** AWS Lambda@Edge origin-request または Cloudflare Workers。
+**必要 env:** `URL_SIGNING_SECRET`。origin auth を有効化する場合は `ORIGIN_SECRET`。
+
+```yaml
+version: 1
+project: signed-downloads
+metadata:
+  risk_level: strict
+  description: Expiring signed URLs for private downloads.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 16
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+routes:
+  - name: private-downloads
+    match:
+      path_prefixes: ["/downloads/"]
+    auth_gate:
+      type: signed_url
+      algorithm: HMAC-SHA256
+      secret_env: URL_SIGNING_SECRET
+      expires_param: exp
+      signature_param: sig
+      exact_path: true
+      nonce_param: nonce
+    response:
+      cache_control: "private, no-store"
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  force_vary_auth: true
+origin:
+  auth:
+    type: hmac_signature
+    secret_env: ORIGIN_SECRET
+    header_prefix: X-Edge-Origin
+    signed_components: [method, path, query, timestamp, nonce]
+    timestamp_tolerance_seconds: 300
+    include_body_hash: false
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+```
+
+コマンド:
+
+```bash
+export URL_SIGNING_SECRET=replace-with-url-signing-secret
+export ORIGIN_SECRET=replace-with-origin-hmac-secret
+npm run lint:policy -- policy/security.yml
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+npm run test:runtime
+```
+
+`nonce_param` は `X-Signed-URL-Nonce` を origin に転送します。単回利用の保証は
+origin 側で Redis `SET NX` などを使って実装してください。
+
+---
+
+## Cloudflare GraphQL API
+
+**用途:** GraphQL API に Worker layer の body guard と任意の response DLP を適用する。
+**主 target:** Cloudflare Workers。
+**必要 env:** HMAC origin auth を有効化する場合は `ORIGIN_SECRET`。
+
+```yaml
+version: 1
+project: cloudflare-graphql-api
+metadata:
+  risk_level: strict
+  description: Cloudflare GraphQL API with body guard and response DLP report-only rollout.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS, POST]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 2048
+    max_query_params: 64
+    max_header_count: 80
+  graphql_guard:
+    endpoint_paths: ["/graphql"]
+    max_depth: 8
+    max_aliases: 20
+    max_fields: 200
+    max_body_bytes: 65536
+    mode: block
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  cors:
+    allow_origins: ["https://app.example.com"]
+    allow_methods: [GET, POST, OPTIONS]
+    allow_headers: [Authorization, Content-Type]
+    allow_credentials: true
+    max_age: 600
+response_dlp:
+  enabled: true
+  action: report_only
+  body:
+    enabled: true
+    max_bytes: 32768
+    content_types: ["application/json", "text/"]
+  headers:
+    enabled: true
+    names: [set-cookie, authorization, x-api-key]
+  detectors:
+    built_in: [api_key, credit_card]
+origin:
+  auth:
+    type: hmac_signature
+    secret_env: ORIGIN_SECRET
+    header_prefix: X-Edge-Origin
+    signed_components: [method, path, query, timestamp, nonce]
+    timestamp_tolerance_seconds: 300
+    include_body_hash: false
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+```
+
+コマンド:
+
+```bash
+export ORIGIN_SECRET=replace-with-origin-hmac-secret
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target cloudflare
+npx cdn-security readiness --policy policy/security.yml --target cloudflare --strict
+npx cdn-security build --policy policy/security.yml --target cloudflare --out-dir dist
+npm run test:runtime
+```
+
+`response_dlp.action` は `report_only` から始め、Worker log の
+`response_dlp_report_only` を確認してから `mask` または `block` へ上げてください。
+
+---
+
+## レシピのメンテナンス
+
+レシピを編集したら次を実行してください。
+
+```bash
+npm run lint:policy -- policy/base.yml
+npm run test:security-baseline
+git diff --check
+```
+
+`test:security-baseline` には、英日レシピ docs が存在し、5 つの主要 recipe heading
+を維持しているかを確認する軽量 freshness check が含まれます。

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,426 @@
+# Policy Recipes
+
+> **Languages:** English - [日本語](./recipes.ja.md)
+
+Recipes are copyable starting points for common deployments. Paste one into
+`policy/security.yml`, replace placeholder domains and environment variable
+names, then run the commands below the snippet.
+
+These recipes are more specific than [archetypes](./archetypes.md): an archetype
+describes an app shape, while a recipe includes target assumptions, auth mode,
+required environment variables, and verification commands.
+
+---
+
+## Cognito JWT API
+
+**Use when:** A JSON API is protected by AWS Cognito RS256 access tokens.
+**Primary target:** AWS CloudFront + Lambda@Edge origin-request, or Cloudflare Workers.
+**Required env:** `ORIGIN_SECRET` only if you also enable `origin.auth`.
+
+```yaml
+version: 1
+project: cognito-api
+metadata:
+  risk_level: strict
+  description: Cognito-protected JSON API.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 2048
+    max_query_params: 64
+    max_header_count: 80
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+    drop_query_keys: ["utm_*", gclid, fbclid]
+routes:
+  - name: api
+    match:
+      path_prefixes: ["/api/"]
+    auth_gate:
+      type: jwt
+      algorithm: RS256
+      allowed_algorithms: [RS256]
+      jwks_url: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_example/.well-known/jwks.json"
+      issuer: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_example"
+      audience: "example-client-id"
+      cache_ttl_sec: 3600
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  cors:
+    allow_origins: ["https://app.example.com"]
+    allow_methods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
+    allow_headers: [Authorization, Content-Type]
+    allow_credentials: true
+    max_age: 600
+firewall:
+  jwks:
+    allowed_hosts:
+      - "cognito-idp.us-east-1.amazonaws.com"
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+      - AWSManagedRulesIPReputationList
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie]
+```
+
+Commands:
+
+```bash
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target aws
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+```
+
+Replace the Cognito region, user pool ID, client ID, and `firewall.jwks.allowed_hosts`
+entry together. For Cloudflare Workers, run the same recipe with
+`--target cloudflare`; keep `allowed_hosts` because Workers cannot perform
+low-level DNS safety checks before fetching JWKS.
+
+---
+
+## Next.js or SPA Static Site
+
+**Use when:** CloudFront or Cloudflare serves a built Next.js static export,
+React/Vue/Svelte SPA, or static marketing site.
+**Primary target:** AWS CloudFront Functions or Cloudflare Workers.
+**Required env:** none.
+
+```yaml
+version: 1
+project: spa-static-site
+metadata:
+  risk_level: balanced
+  description: Static frontend with browser security headers.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 40
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+    drop_query_keys: ["utm_*", gclid, fbclid]
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "strict-origin-when-cross-origin"
+  permissions_policy: "camera=(), microphone=(), geolocation=()"
+  csp_public: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.example.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self';"
+  cors:
+    allow_origins: ["https://www.example.com"]
+    allow_methods: [GET, HEAD, OPTIONS]
+    allow_headers: [Content-Type]
+    max_age: 86400
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 2000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+```
+
+Commands:
+
+```bash
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target aws
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+npm run test:runtime
+```
+
+If your Next.js deployment is SSR rather than static export, add origin-side
+cache controls and review authenticated route caching with
+`response_headers.force_vary_auth`.
+
+---
+
+## Internal Admin Panel
+
+**Use when:** A private admin UI sits behind the CDN and needs a simple edge gate
+in addition to VPN, IP allowlists, or identity-aware proxy controls.
+**Primary target:** AWS CloudFront Functions or Cloudflare Workers.
+**Required env:** `EDGE_ADMIN_TOKEN`.
+
+```yaml
+version: 1
+project: internal-admin
+metadata:
+  risk_level: strict
+  description: Internal admin panel protected by static edge token and WAF allowlist.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, POST]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 40
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix, curl, wget, python-requests]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+routes:
+  - name: admin
+    match:
+      path_prefixes: ["/"]
+    auth_gate:
+      type: static_token
+      header: x-edge-admin-token
+      token_env: EDGE_ADMIN_TOKEN
+    response:
+      cache_control: "no-store, no-cache, must-revalidate"
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  permissions_policy: "camera=(), microphone=(), geolocation=(), payment=()"
+  csp_admin: "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';"
+  force_vary_auth: true
+firewall:
+  ip:
+    allowlist:
+      - "203.0.113.0/24"
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 500
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+      - AWSManagedRulesIPReputationList
+      - AWSManagedRulesAnonymousIpList
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie, x-api-key]
+```
+
+Commands:
+
+```bash
+export EDGE_ADMIN_TOKEN=replace-with-a-strong-random-token
+npm run lint:policy -- policy/security.yml
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+```
+
+Treat the static token as a short-term edge guard, not the only admin identity
+control. Rotate it through your CDN/IaC secret flow and pair it with SSO.
+
+---
+
+## Signed Download URLs
+
+**Use when:** Private files are served from an origin path and links should expire
+without exposing a long-lived bearer token.
+**Primary target:** AWS Lambda@Edge origin-request or Cloudflare Workers.
+**Required env:** `URL_SIGNING_SECRET`; `ORIGIN_SECRET` if origin auth is enabled.
+
+```yaml
+version: 1
+project: signed-downloads
+metadata:
+  risk_level: strict
+  description: Expiring signed URLs for private downloads.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 1024
+    max_query_params: 16
+    max_header_count: 64
+  block:
+    header_missing: [user-agent]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+routes:
+  - name: private-downloads
+    match:
+      path_prefixes: ["/downloads/"]
+    auth_gate:
+      type: signed_url
+      algorithm: HMAC-SHA256
+      secret_env: URL_SIGNING_SECRET
+      expires_param: exp
+      signature_param: sig
+      exact_path: true
+      nonce_param: nonce
+    response:
+      cache_control: "private, no-store"
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  force_vary_auth: true
+origin:
+  auth:
+    type: hmac_signature
+    secret_env: ORIGIN_SECRET
+    header_prefix: X-Edge-Origin
+    signed_components: [method, path, query, timestamp, nonce]
+    timestamp_tolerance_seconds: 300
+    include_body_hash: false
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesKnownBadInputsRuleSet
+```
+
+Commands:
+
+```bash
+export URL_SIGNING_SECRET=replace-with-url-signing-secret
+export ORIGIN_SECRET=replace-with-origin-hmac-secret
+npm run lint:policy -- policy/security.yml
+npx cdn-security readiness --policy policy/security.yml --target aws --strict
+npx cdn-security build --policy policy/security.yml --target aws --out-dir dist
+npm run test:runtime
+```
+
+`nonce_param` forwards `X-Signed-URL-Nonce` to the origin. The origin must enforce
+single use, for example with a Redis `SET NX` or equivalent write.
+
+---
+
+## Cloudflare GraphQL API
+
+**Use when:** A GraphQL API needs bounded body inspection and optional response
+DLP at the Worker layer.
+**Primary target:** Cloudflare Workers.
+**Required env:** `ORIGIN_SECRET` if HMAC origin auth is enabled.
+
+```yaml
+version: 1
+project: cloudflare-graphql-api
+metadata:
+  risk_level: strict
+  description: Cloudflare GraphQL API with body guard and response DLP report-only rollout.
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, HEAD, OPTIONS, POST]
+  limits:
+    max_uri_length: 2048
+    max_query_length: 2048
+    max_query_params: 64
+    max_header_count: 80
+  graphql_guard:
+    endpoint_paths: ["/graphql"]
+    max_depth: 8
+    max_aliases: 20
+    max_fields: 200
+    max_body_bytes: 65536
+    mode: block
+  block:
+    header_missing: [user-agent]
+    ua_contains: [sqlmap, nikto, acunetix]
+  normalize:
+    path:
+      collapse_slashes: true
+      remove_dot_segments: true
+response_headers:
+  hsts: "max-age=31536000; includeSubDomains; preload"
+  x_content_type_options: "nosniff"
+  referrer_policy: "no-referrer"
+  csp_public: "default-src 'none'; frame-ancestors 'none';"
+  cors:
+    allow_origins: ["https://app.example.com"]
+    allow_methods: [GET, POST, OPTIONS]
+    allow_headers: [Authorization, Content-Type]
+    allow_credentials: true
+    max_age: 600
+response_dlp:
+  enabled: true
+  action: report_only
+  body:
+    enabled: true
+    max_bytes: 32768
+    content_types: ["application/json", "text/"]
+  headers:
+    enabled: true
+    names: [set-cookie, authorization, x-api-key]
+  detectors:
+    built_in: [api_key, credit_card]
+origin:
+  auth:
+    type: hmac_signature
+    secret_env: ORIGIN_SECRET
+    header_prefix: X-Edge-Origin
+    signed_components: [method, path, query, timestamp, nonce]
+    timestamp_tolerance_seconds: 300
+    include_body_hash: false
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+```
+
+Commands:
+
+```bash
+export ORIGIN_SECRET=replace-with-origin-hmac-secret
+npm run lint:policy -- policy/security.yml
+npx cdn-security capabilities --policy policy/security.yml --target cloudflare
+npx cdn-security readiness --policy policy/security.yml --target cloudflare --strict
+npx cdn-security build --policy policy/security.yml --target cloudflare --out-dir dist
+npm run test:runtime
+```
+
+Start `response_dlp.action` at `report_only`, review Worker logs for
+`response_dlp_report_only`, then promote to `mask` or `block` after tuning.
+
+---
+
+## Recipe Maintenance
+
+Run these checks after editing recipes:
+
+```bash
+npm run lint:policy -- policy/base.yml
+npm run test:security-baseline
+git diff --check
+```
+
+`test:security-baseline` includes a lightweight freshness check that both
+English and Japanese recipe docs exist and retain the five core recipe headings.

--- a/scripts/security-baseline-check.js
+++ b/scripts/security-baseline-check.js
@@ -48,6 +48,28 @@ function main() {
         ensureIncludes(p.file, p.heading, 'parity doc heading');
         ensureIncludes(p.file, '--fail-on-waf-approximation', 'reference to the CI gate flag');
     }
+    // Copyable deployment recipes are a documented adoption surface. Keep both
+    // language variants present and ensure the core recipe set does not regress.
+    const recipeFiles = [
+        { file: 'docs/recipes.md', heading: '# Policy Recipes' },
+        { file: 'docs/recipes.ja.md', heading: '# ポリシーレシピ' },
+    ];
+    const recipeHeadings = [
+        '## Cognito JWT API',
+        '## Next.js or SPA Static Site',
+        '## Internal Admin Panel',
+        '## Signed Download URLs',
+        '## Cloudflare GraphQL API',
+    ];
+    for (const p of recipeFiles) {
+        if (!fs.existsSync(path.join(repoRoot, p.file))) {
+            fail(`${p.file} is missing — policy recipes (issue #132) require EN + JA docs`);
+        }
+        ensureIncludes(p.file, p.heading, 'recipe doc heading');
+        for (const heading of recipeHeadings) {
+            ensureIncludes(p.file, heading, 'core policy recipe heading');
+        }
+    }
     console.log('Security baseline check passed.');
 }
 main();

--- a/src/scripts/security-baseline-check.ts
+++ b/src/scripts/security-baseline-check.ts
@@ -56,6 +56,29 @@ function main() {
     ensureIncludes(p.file, '--fail-on-waf-approximation', 'reference to the CI gate flag');
   }
 
+  // Copyable deployment recipes are a documented adoption surface. Keep both
+  // language variants present and ensure the core recipe set does not regress.
+  const recipeFiles = [
+    { file: 'docs/recipes.md', heading: '# Policy Recipes' },
+    { file: 'docs/recipes.ja.md', heading: '# ポリシーレシピ' },
+  ];
+  const recipeHeadings = [
+    '## Cognito JWT API',
+    '## Next.js or SPA Static Site',
+    '## Internal Admin Panel',
+    '## Signed Download URLs',
+    '## Cloudflare GraphQL API',
+  ];
+  for (const p of recipeFiles) {
+    if (!fs.existsSync(path.join(repoRoot, p.file))) {
+      fail(`${p.file} is missing — policy recipes (issue #132) require EN + JA docs`);
+    }
+    ensureIncludes(p.file, p.heading, 'recipe doc heading');
+    for (const heading of recipeHeadings) {
+      ensureIncludes(p.file, heading, 'core policy recipe heading');
+    }
+  }
+
   console.log('Security baseline check passed.');
 }
 


### PR DESCRIPTION
## Summary
- add English/Japanese policy recipe docs for Cognito JWT APIs, Next.js/SPA, internal admin panels, signed download URLs, and Cloudflare GraphQL APIs
- link recipes from README and quickstart
- add a lightweight security-baseline freshness check for the core recipe headings

## Tests
- `npm run test:security-baseline`
- `git diff --check`
- recipe YAML snippet lint: extracted 10 `yaml` blocks from `docs/recipes*.md` and ran `node scripts/policy-lint.js` against each

Fixes #132