### PR TITLE
feat(edge): add request anomaly guards

### DIFF
--- a/docs/SECURITY-FEATURE-MATRIX.ja.md
+++ b/docs/SECURITY-FEATURE-MATRIX.ja.md
@@ -58,6 +58,7 @@
 | **クエリパラム数制限** | ✅ 対応 | `request.limits.max_query_params` → 超過時 400。 |
 | **ヘッダーサイズ制限** | ✅ 対応 | `request.limits.max_header_size` → 超過時 431。Lambda@Edge / Cloudflare 限定。 |
 | **ヘッダー数制限** | ✅ 対応 | `request.limits.max_header_count`（既定 64、1..500 にクランプ）→ 超過時 431。CFF viewer-request と Cloudflare Worker の入口で適用。 |
+| **Request anomaly guards** | ✅ 対応 | `request.anomaly_guards` は CRLF indicator、不正な Cookie header、bounded な double-encoded traversal signal を CFF viewer-request / Cloudflare Workers でブロック。 |
 | **パス正規化** | ✅ 対応 | `request.normalize.path.collapse_slashes`, `remove_dot_segments` で URI をクリーンアップ。 |
 | **クエリ正規化** | ✅ 対応 | `request.normalize.drop_query_keys` でトラッキングパラメータ（utm_*、gclid 等）を除去。 |
 | **GraphQL depth/complexity guard** | Cloudflare Workers のみ | `request.graphql_guard` で POST GraphQL body を検査し、depth、alias 数、field 数、malformed document を検出。AWS target は CloudFront edge output が request body を読めないため未対応警告のみ。 |
@@ -93,7 +94,7 @@
 | **Transport** | HSTS, TLS 版, HTTP 版 | — | — |
 | **Firewall / Access** | レート制限（グローバル＋URI 単位）, Geo, IP, WAF マネージド, カスタムブロックレスポンス, ロギング, JA3/JA4 指紋ルール | Edge JS challenge（Cloudflare Workers のみ） | — |
 | **Authentication** | トークン, Basic, JWT, 署名付き URL | — | — |
-| **Request Hygiene** | メソッド, URI/クエリ/ヘッダー制限, 正規化, UA ブロック, 必須ヘッダー, 指紋（JA3/JA4） | — | — |
+| **Request Hygiene** | メソッド, URI/クエリ/ヘッダー制限, Request anomaly guards, 正規化, UA ブロック, 必須ヘッダー, 指紋（JA3/JA4） | — | — |
 | **Response Security** | セキュリティヘッダー, CORS, Cookie 属性 | — | — |
 | **Origin Security** | オリジン認証, タイムアウト | — | — |
 
@@ -105,6 +106,7 @@
 |------|---------------------|-------------|-------------------|-----------|
 | URI/クエリ制限 | ✓ | — | ✓ | — |
 | パス正規化 | ✓ | — | ✓ | — |
+| Request anomaly guards | ✓ | — | ✓ | — |
 | 必須ヘッダー | ✓ | — | ✓ | — |
 | ヘッダーサイズ | — | ✓ | ✓ | — |
 | Edge JS challenge / PoW | — | — | ✓ | — |
@@ -141,6 +143,14 @@ built-in detector は API key prefix（`sk-live-`、`sk_test_`、`ghp_`）と、
 body inspection は設定されたテキスト系 `Content-Type` と `body.max_bytes`（既定 32768、最大 131072）に限定します。上限超過または非テキストレスポンスは変更せず通します。CloudFront Functions はレスポンス body を検査できないため、`response_dlp.enabled: true` の AWS compile では unsupported warning を出します。
 
 policy shape、rollout guidance、target support、performance constraints は [レスポンス DLP](./response-dlp.ja.md) を参照してください。
+
+### Request Anomaly Guards
+
+`request.anomaly_guards` は optional で、CloudFront Functions viewer-request と
+Cloudflare Workers が enforcement 対応です。CRLF indicator、不正な Cookie header、
+double-encoded traversal signal を bounded な文字列 check で検出します。policy shape
+と rollout guidance は [Request Anomaly Guards](./request-anomaly-guards.ja.md)
+を参照してください。
 
 ---
 

--- a/docs/SECURITY-FEATURE-MATRIX.md
+++ b/docs/SECURITY-FEATURE-MATRIX.md
@@ -56,6 +56,7 @@ This document maps **which security-related YAML settings are supported** by cat
 | **Query param count limit** | Supported | `request.limits.max_query_params` → 400 if exceeded. |
 | **Header size limit** | Supported | `request.limits.max_header_size` → 431 if exceeded. Lambda@Edge / Cloudflare only. |
 | **Header count limit** | Supported | `request.limits.max_header_count` (default 64, clamped 1..500) → 431 if exceeded. Enforced in CFF viewer-request and Cloudflare Worker entry. |
+| **Request anomaly guards** | Supported | `request.anomaly_guards` blocks CRLF indicators, malformed Cookie headers, and bounded double-encoded traversal signals in CFF viewer-request and Cloudflare Workers. |
 | **Path normalization** | Supported | `request.normalize.path.collapse_slashes`, `remove_dot_segments` clean up URIs. |
 | **Query normalization** | Supported | `request.normalize.drop_query_keys` strips tracking params (utm_*, gclid, etc.). |
 | **GraphQL depth/complexity guard** | Cloudflare Workers only | `request.graphql_guard` inspects POST GraphQL bodies for depth, aliases, fields, and malformed documents. AWS targets warn because CloudFront edge output cannot read request bodies. |
@@ -91,7 +92,7 @@ This document maps **which security-related YAML settings are supported** by cat
 | **Transport** | HSTS, TLS version, HTTP version | — | — |
 | **Firewall / Access** | Rate limit (global + per-URI), Geo, IP, WAF managed rules, custom block response, logging, JA3/JA4 fingerprint rules | Edge JS challenge (Cloudflare Workers only) | — |
 | **Authentication** | Token, Basic, JWT, Signed URL | — | — |
-| **Request Hygiene** | Method, URI/Query/Header limits, Normalization, UA block, Required headers, Fingerprint (JA3/JA4) | — | — |
+| **Request Hygiene** | Method, URI/Query/Header limits, Request anomaly guards, Normalization, UA block, Required headers, Fingerprint (JA3/JA4) | — | — |
 | **Response Security** | Security headers, CORS, Cookie attributes | — | — |
 | **Origin Security** | Origin auth, Timeout | — | — |
 
@@ -103,6 +104,7 @@ This document maps **which security-related YAML settings are supported** by cat
 |---------|---------------------|-------------|-------------------|-----------|
 | URI/Query limits | ✓ | — | ✓ | — |
 | Path normalization | ✓ | — | ✓ | — |
+| Request anomaly guards | ✓ | — | ✓ | — |
 | Required headers | ✓ | — | ✓ | — |
 | Header size limit | — | ✓ | ✓ | — |
 | Edge JS challenge / PoW | — | — | ✓ | — |
@@ -139,6 +141,14 @@ Built-in detectors cover API-key prefixes (`sk-live-`, `sk_test_`, `ghp_`) and c
 Body inspection is limited to configured text-like `Content-Type` values and `body.max_bytes` (default 32768, maximum 131072). Larger or non-text responses pass through unchanged. CloudFront Functions cannot inspect response bodies; the AWS compiler emits an unsupported warning when `response_dlp.enabled: true`.
 
 See [Response DLP](./response-dlp.md) for the policy shape, rollout guidance, target support, and performance constraints.
+
+### Request Anomaly Guards
+
+`request.anomaly_guards` is optional and enforced by CloudFront Functions
+viewer-request and Cloudflare Workers. It uses bounded string checks for CRLF
+indicators, malformed Cookie headers, and double-encoded traversal signals. See
+[Request Anomaly Guards](./request-anomaly-guards.md) for policy shape and
+rollout guidance.
 
 ---
 

--- a/docs/quickstart.ja.md
+++ b/docs/quickstart.ja.md
@@ -70,4 +70,4 @@ CI と同じ runtime / unit / drift / security-baseline チェックを実行し
 
 - `/admin` がトークン無しで 401
 - トークン付きで通る
-- Path traversal / 異常 UA / 過剰クエリが弾かれる
+- Path traversal / request anomaly indicator / 異常 UA / 過剰クエリが弾かれる

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,4 +71,4 @@ Use the generated files in **`dist/edge/`** with Terraform, CDK, or your CDN con
 
 - `/admin` returns 401 without a token
 - Request with valid token is allowed
-- Path traversal, anomalous User-Agent, and excessive query params are blocked
+- Path traversal, request anomaly indicators, anomalous User-Agent, and excessive query params are blocked

--- a/docs/request-anomaly-guards.ja.md
+++ b/docs/request-anomaly-guards.ja.md
@@ -1,0 +1,48 @@
+> **言語:** [English](./request-anomaly-guards.md) - 日本語
+
+# Request Anomaly Guards
+
+`request.anomaly_guards` は、origin へ転送する前に軽量な request hygiene
+check を行う opt-in 設定です。対象は意図的に狭く、CRLF injection indicator、
+不正な Cookie header、bounded な double-encoded traversal signal だけを見ます。
+広範な SQLi/XSS signature scan は WAF managed rules に任せます。
+
+```yaml
+request:
+  anomaly_guards:
+    enabled: true
+    # enabled 時の既定は true。
+    crlf: true
+    malformed_cookie: true
+    double_encoded_traversal: true
+    max_cookie_bytes: 4096
+    max_cookie_pairs: 80
+```
+
+## チェック内容
+
+- **CRLF indicator**: request URI、query string、request header value 内の
+  生の `\r` / `\n` と、encoded form の `%0d` / `%0a` を拒否します。
+- **不正な Cookie header**: control character、`a=1;;b=2` のような空 delimiter、
+  `name=value` delimiter のない pair、設定した Cookie size / pair count 超過を拒否します。
+- **Double-encoded traversal**: `%25` がある場合だけ最大 1 回の追加
+  `decodeURIComponent` を行い、その後に `%252e%252e`、`%252f`、`%255c`
+  由来の traversal indicator が見えたら拒否します。
+
+## Runtime 対応
+
+CloudFront Functions viewer-request と Cloudflare Workers が enforcement 対応です。
+Lambda@Edge origin-request は既存の `max_header_size` handling を維持し、
+viewer-request check を重複実装しません。
+
+## 性能制約
+
+この guard は URI/header count cap の後、path normalization や origin/auth forwarding
+の前に動きます。処理量は header 数と URI/query 長に対して bounded です。decode-based
+traversal 検出は `%25` がない限り skip し、decode attempt は 1 回だけです。
+
+## Rollout
+
+client を制御できる strict/admin surface では default checks のまま `enabled: true`
+を使えます。広い browser/API traffic では、legacy client が非標準 Cookie delimiter
+を送る可能性がある場合、まず `malformed_cookie: false` で始めてください。

--- a/docs/request-anomaly-guards.md
+++ b/docs/request-anomaly-guards.md
@@ -1,0 +1,50 @@
+> **Languages:** English - [日本語](./request-anomaly-guards.ja.md)
+
+# Request Anomaly Guards
+
+`request.anomaly_guards` enables lightweight request hygiene checks before the
+edge forwards traffic to origin. The guards are intentionally narrow: they look
+for CRLF injection indicators, malformed Cookie headers, and bounded
+double-encoded traversal signals without running broad signature scans.
+
+```yaml
+request:
+  anomaly_guards:
+    enabled: true
+    # Defaults to true when enabled.
+    crlf: true
+    malformed_cookie: true
+    double_encoded_traversal: true
+    max_cookie_bytes: 4096
+    max_cookie_pairs: 80
+```
+
+## Checks
+
+- **CRLF indicators**: rejects raw `\r` / `\n` and encoded `%0d` / `%0a`
+  indicators in the request URI, query string, or request header values.
+- **Malformed Cookie header**: rejects control characters, empty delimiter
+  segments such as `a=1;;b=2`, cookie pairs without a `name=value` delimiter,
+  and configured Cookie size/pair-count overages.
+- **Double-encoded traversal**: only when `%25` is present, performs at most one
+  extra `decodeURIComponent` pass and rejects traversal indicators such as
+  `%252e%252e`, `%252f`, and `%255c` after that pass.
+
+## Runtime Support
+
+CloudFront Functions viewer-request and Cloudflare Workers enforce these
+guards. Lambda@Edge origin-request keeps its existing `max_header_size` handling
+and does not duplicate the viewer-request checks.
+
+## Performance
+
+The guards run after URI/header count caps and before path normalization or
+origin/auth forwarding. Work is bounded by the number of headers plus the
+URI/query length. Decode-based traversal detection is skipped unless `%25` is
+present, and it performs one decode attempt only.
+
+## Rollout
+
+Use `enabled: true` with the default checks on strict/admin surfaces where you
+control clients. For broad browser/API traffic, start with `malformed_cookie:
+false` if legacy clients may send non-standard Cookie delimiters.

--- a/policy/README.ja.md
+++ b/policy/README.ja.md
@@ -63,6 +63,7 @@ node scripts/policy-lint.js policy/base.yml
 | `max_query_length` | 1024 | 512 | 2048 |
 | `max_query_params` | 30 | 20 | 50 |
 | `max_uri_length` | 2048 | 1024 | 4096 |
+| Request anomaly guards | CRLF + double-encoded traversal | CRLF + Cookie + double-encoded traversal | off |
 | UA ブロック | スキャナ系 | スキャナ＋curl, wget 等 | スキャナのみ |
 | User-Agent 欠落でブロック | する | する | しない |
 | 許可メソッド（デフォルト） | GET, HEAD, POST | GET, HEAD, POST | + PUT, PATCH, DELETE, OPTIONS |
@@ -81,6 +82,8 @@ node scripts/policy-lint.js policy/base.yml
 | `request.limits.max_query_params` | 1 | 1,024 | キー数 |
 | `request.limits.max_uri_length` | 1 | 8,192 | バイト |
 | `request.limits.max_header_size` | 1 | 65,536 | バイト |
+| `request.anomaly_guards.max_cookie_bytes` | 1 | 65,536 | バイト |
+| `request.anomaly_guards.max_cookie_pairs` | 1 | 1,000 | Cookie pair 数 |
 | `routes[].auth_gate.clock_skew_sec` | 0 | 600 | 秒 |
 | `routes[].auth_gate.cache_ttl_sec` | 0 | 86,400 | 秒（1 日） |
 | `request.graphql_guard.max_depth` | 1 | 64 | Cloudflare Workers のみ |
@@ -112,6 +115,7 @@ npx cdn-security build --fail-on-permissive
 
 * [プロファイル](../docs/profiles.ja.md) — プロファイル選択と本番 CI の permissive ゲート。
 * [Edge JS Challenge](../docs/edge-js-challenge.ja.md) — Cloudflare Workers の実験的 JS challenge / lightweight PoW primitive。
+* [Request Anomaly Guards](../docs/request-anomaly-guards.ja.md) — CRLF、不正 Cookie、double-encoded traversal のチェック。
 * [ポリシーとランタイムの同期](../docs/policy-runtime-sync.ja.md) — ポリシーとランタイムの同期方法。
 * [GraphQL Guard](../docs/graphql-guard.ja.md) — Cloudflare Workers の GraphQL depth/complexity request body guard。
 * [アーキテクチャ](../docs/architecture.ja.md) — ポリシー駆動の設計。

--- a/policy/README.md
+++ b/policy/README.md
@@ -63,6 +63,7 @@ node scripts/policy-lint.js policy/base.yml
 | `max_query_length` | 1024 | 512 | 2048 |
 | `max_query_params` | 30 | 20 | 50 |
 | `max_uri_length` | 2048 | 1024 | 4096 |
+| Request anomaly guards | CRLF + double-encoded traversal | CRLF + Cookie + double-encoded traversal | off |
 | UA block list | scanners | scanners + curl, wget, etc. | scanners only |
 | Block missing User-Agent | yes | yes | no |
 | Allowed methods (default) | GET, HEAD, POST | GET, HEAD, POST | + PUT, PATCH, DELETE, OPTIONS |
@@ -84,6 +85,8 @@ issue with the use case.
 | `request.limits.max_query_params` | 1 | 1,024 | Keys |
 | `request.limits.max_uri_length` | 1 | 8,192 | Bytes |
 | `request.limits.max_header_size` | 1 | 65,536 | Bytes |
+| `request.anomaly_guards.max_cookie_bytes` | 1 | 65,536 | Bytes |
+| `request.anomaly_guards.max_cookie_pairs` | 1 | 1,000 | Cookie pairs |
 | `routes[].auth_gate.clock_skew_sec` | 0 | 600 | Seconds |
 | `routes[].auth_gate.cache_ttl_sec` | 0 | 86,400 | Seconds (1 day) |
 | `request.graphql_guard.max_depth` | 1 | 64 | Cloudflare Workers only |
@@ -115,6 +118,7 @@ See [docs/profiles.md](../docs/profiles.md) for the full profile comparison and 
 
 * [Profiles](../docs/profiles.md) — how to choose a profile and gate permissive in production CI.
 * [Edge JS Challenge](../docs/edge-js-challenge.md) — experimental Cloudflare Workers JS challenge / lightweight PoW primitive.
+* [Request Anomaly Guards](../docs/request-anomaly-guards.md) — CRLF, malformed Cookie, and double-encoded traversal checks.
 * [Policy and runtime sync](../docs/policy-runtime-sync.md) — how to keep policy and runtimes in sync.
 * [GraphQL Guard](../docs/graphql-guard.md) — Cloudflare Workers request body guard for GraphQL depth/complexity.
 * [Architecture](../docs/architecture.md) — policy-driven design.

--- a/policy/archetypes/admin-panel.yml
+++ b/policy/archetypes/admin-panel.yml
@@ -23,6 +23,11 @@ request:
     max_query_params: 20
     max_uri_length: 1024
 
+  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 4096
+    max_cookie_pairs: 80
+
   block:
     path_patterns:
       contains:

--- a/policy/archetypes/microservice-origin.yml
+++ b/policy/archetypes/microservice-origin.yml
@@ -24,6 +24,10 @@ request:
     max_uri_length: 1024
     max_header_count: 40
 
+  anomaly_guards:
+    enabled: true
+    malformed_cookie: false
+
   block:
     path_patterns:
       contains:

--- a/policy/archetypes/rest-api.yml
+++ b/policy/archetypes/rest-api.yml
@@ -24,6 +24,10 @@ request:
     max_uri_length: 2048
     max_header_count: 48
 
+  anomaly_guards:
+    enabled: true
+    malformed_cookie: false
+
   block:
     path_patterns:
       contains:

--- a/policy/archetypes/spa-static-site.yml
+++ b/policy/archetypes/spa-static-site.yml
@@ -24,6 +24,10 @@ request:
     max_query_params: 20
     max_uri_length: 1024
 
+  anomaly_guards:
+    enabled: true
+    malformed_cookie: false
+
   block:
     path_patterns:
       contains:

--- a/policy/base.yml
+++ b/policy/base.yml
@@ -14,6 +14,10 @@ request:
     max_query_params: 30
     max_uri_length: 2048
 
+  anomaly_guards:
+    enabled: true
+    malformed_cookie: false
+
   block:
     path_patterns:
       - "(?i)\\.{2}/"       # ../

--- a/policy/profiles/balanced.yml
+++ b/policy/profiles/balanced.yml
@@ -21,6 +21,10 @@ request:
     max_query_params: 30
     max_uri_length: 2048
 
+  anomaly_guards:
+    enabled: true
+    malformed_cookie: false
+
   block:
     path_patterns:
       - "(?i)\\.{2}/"       # ../

--- a/policy/profiles/strict.yml
+++ b/policy/profiles/strict.yml
@@ -22,6 +22,11 @@ request:
     max_query_params: 20
     max_uri_length: 1024
 
+  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 4096
+    max_cookie_pairs: 80
+
   block:
     path_patterns:
       contains:

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -84,6 +84,41 @@
             }
           }
         },
+        "anomaly_guards": {
+          "description": "Optional lightweight request anomaly guards. When enabled, supported edge targets reject CRLF indicators in URI/query/header values, malformed Cookie headers, and bounded double-encoded traversal indicators before origin forwarding.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "description": "Enable request anomaly guards. Individual checks default to enabled unless explicitly set to false.",
+              "type": "boolean"
+            },
+            "crlf": {
+              "description": "Reject raw CR/LF characters and encoded %0d/%0a indicators in request URI, query, or header values.",
+              "type": "boolean"
+            },
+            "malformed_cookie": {
+              "description": "Reject Cookie headers with control characters, empty delimiter segments, missing name/value delimiters, or configured size/pair-count overages.",
+              "type": "boolean"
+            },
+            "double_encoded_traversal": {
+              "description": "Reject double-encoded traversal indicators such as %252e%252e, %252f, and %255c using at most one extra decode pass when %25 is present.",
+              "type": "boolean"
+            },
+            "max_cookie_bytes": {
+              "description": "Maximum Cookie header length accepted by the malformed-cookie guard. Default 4096.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65536
+            },
+            "max_cookie_pairs": {
+              "description": "Maximum number of semicolon-delimited Cookie pairs accepted by the malformed-cookie guard. Default 80.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            }
+          }
+        },
         "block": {
           "type": "object",
           "additionalProperties": false,

--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -186,6 +186,8 @@ test('cloudflare template contains auth enforcement logic', () => {
     assert.ok(template.includes('async function handleChallenge'), 'challenge handler missing');
     assert.ok(template.includes('verifyChallengeCookie'), 'challenge cookie verifier missing');
     assert.ok(template.includes('verifyChallengeSolution'), 'challenge proof verifier missing');
+    assert.ok(template.includes('function blockIfRequestAnomaly'), 'request anomaly guard missing');
+    assert.ok(template.includes('hasDoubleEncodedTraversalIndicator'), 'double-encoded traversal helper missing');
     // Auth/crypto hardening fixtures
     assert.ok(template.includes('isJwtAlgAllowed'), 'JWT alg whitelist helper missing');
     assert.ok(template.includes('isHostAllowed'), 'Host allowlist helper missing');
@@ -227,6 +229,68 @@ response_headers:
     const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, request);
     assert.strictEqual(res.status, 400);
     assert.strictEqual(fetchCalls.length, 0, 'raw traversal should block before origin fetch');
+});
+test('cloudflare request anomaly guards block CRLF, malformed cookies, and double-encoded traversal', async () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-anomaly-guard-test
+request:
+  allow_methods: ["GET"]
+  limits:
+    max_query_length: 1024
+    max_query_params: 30
+    max_uri_length: 2048
+  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 32
+    max_cookie_pairs: 2
+response_headers:
+  hsts: "max-age=31536000"
+`);
+    const encodedCrlf = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/?next=%0d%0aheader', {
+        method: 'GET',
+        headers: { 'user-agent': 'runtime-test' },
+    }));
+    assert.strictEqual(encodedCrlf.res.status, 400);
+    assert.strictEqual(encodedCrlf.fetchCalls.length, 0);
+    const rawHeaderRequest = {
+        url: 'https://edge.example.com/',
+        method: 'GET',
+        headers: {
+            get(name) {
+                if (name.toLowerCase() === 'user-agent')
+                    return 'runtime-test';
+                if (name.toLowerCase() === 'x-test')
+                    return 'ok\nbad';
+                return '';
+            },
+            forEach(fn) {
+                fn('runtime-test', 'user-agent');
+                fn('ok\nbad', 'x-test');
+            },
+        },
+    };
+    const rawHeader = await runGeneratedWorkerRequest(generated, rawHeaderRequest);
+    assert.strictEqual(rawHeader.res.status, 400);
+    assert.strictEqual(rawHeader.fetchCalls.length, 0);
+    const malformedCookie = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/', {
+        method: 'GET',
+        headers: { 'user-agent': 'runtime-test', cookie: 'a=1;;b=2' },
+    }));
+    assert.strictEqual(malformedCookie.res.status, 400);
+    assert.strictEqual(malformedCookie.fetchCalls.length, 0);
+    const doubleEncodedTraversal = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/%252e%252e%252fsecret', {
+        method: 'GET',
+        headers: { 'user-agent': 'runtime-test' },
+    }));
+    assert.strictEqual(doubleEncodedTraversal.res.status, 400);
+    assert.strictEqual(doubleEncodedTraversal.fetchCalls.length, 0);
+    const benign = await runGeneratedWorkerRequest(generated, new Request('https://edge.example.com/download/%2520report?name=hello%2520world', {
+        method: 'GET',
+        headers: { 'user-agent': 'runtime-test' },
+    }));
+    assert.strictEqual(benign.res.status, 200);
+    assert.strictEqual(benign.fetchCalls.length, 1);
 });
 test('cloudflare compile emits experimental challenge config', () => {
     const generated = compileCloudflare(`

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { parsePathPatterns, regexesLiteralCode, validateAuthGates, hasAllowPlaceholderFlag, hasFailOnPermissiveFlag, hasCatastrophicBacktrackShape, compileRegexOrThrow, warnIfPermissive, warnSignedUrlReplay, buildChallengeConfig, buildGraphqlGuardConfig, buildObsConfig, } = require('./lib/compile-core');
+const { parsePathPatterns, regexesLiteralCode, validateAuthGates, hasAllowPlaceholderFlag, hasFailOnPermissiveFlag, hasCatastrophicBacktrackShape, compileRegexOrThrow, warnIfPermissive, warnSignedUrlReplay, buildChallengeConfig, buildGraphqlGuardConfig, buildAnomalyGuardConfig, buildObsConfig, } = require('./lib/compile-core');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -244,6 +244,7 @@ const cfgCode = renderConstObject('CFG', {
     geoAllowCountries: runtimeCode(`new Set(${JSON.stringify(geoAllowCountries)})`),
     challenge: challengeConfig,
     graphqlGuard: buildGraphqlGuardConfig(policy),
+    anomalyGuards: buildAnomalyGuardConfig(policy),
     obs: buildObsConfig(policy),
 });
 let adminPathPrefixes = ['/admin', '/docs', '/swagger'];

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { DEFAULT_CONTAINS, parsePathPatterns, hasCatastrophicBacktrackShape, regexesLiteralCode, getAuthGates, validateAuthGates, validateJwksUrl, build, PLACEHOLDER_TOKEN, hasFailOnPermissiveFlag, warnIfPermissive, warnWeakAwsCspNonce, warnUnsupportedAwsResponseDlp, warnSignedUrlReplay, buildChallengeConfig, warnUnsupportedAwsChallenge, buildGraphqlGuardConfig, warnUnsupportedGraphqlGuard, validateOriginAuth, } = require('./lib/compile-core');
+const { DEFAULT_CONTAINS, parsePathPatterns, hasCatastrophicBacktrackShape, regexesLiteralCode, getAuthGates, validateAuthGates, validateJwksUrl, build, PLACEHOLDER_TOKEN, hasFailOnPermissiveFlag, warnIfPermissive, warnWeakAwsCspNonce, warnUnsupportedAwsResponseDlp, warnSignedUrlReplay, buildChallengeConfig, warnUnsupportedAwsChallenge, buildGraphqlGuardConfig, buildAnomalyGuardConfig, warnUnsupportedGraphqlGuard, validateOriginAuth, } = require('./lib/compile-core');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
 function test(name, fn) {
     try {
@@ -145,6 +145,34 @@ test('buildGraphqlGuardConfig normalizes configured limits and defaults endpoint
         maxFields: 50,
         maxBodyBytes: 65536,
         mode: 'report',
+    });
+});
+test('buildAnomalyGuardConfig defaults disabled and normalizes enabled limits', () => {
+    assert.deepStrictEqual(buildAnomalyGuardConfig({ request: {} }), {
+        enabled: false,
+        crlf: false,
+        malformedCookie: false,
+        doubleEncodedTraversal: false,
+        maxCookieBytes: 4096,
+        maxCookiePairs: 80,
+    });
+    const cfg = buildAnomalyGuardConfig({
+        request: {
+            anomaly_guards: {
+                enabled: true,
+                crlf: false,
+                max_cookie_bytes: 999999,
+                max_cookie_pairs: 0,
+            },
+        },
+    });
+    assert.deepStrictEqual(cfg, {
+        enabled: true,
+        crlf: false,
+        malformedCookie: true,
+        doubleEncodedTraversal: true,
+        maxCookieBytes: 65536,
+        maxCookiePairs: 1,
     });
 });
 test('warnUnsupportedGraphqlGuard warns for AWS body-unreadable target', () => {

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -598,6 +598,31 @@ function buildGraphqlGuardConfig(policy) {
         mode: guard.mode === 'report' ? 'report' : 'block',
     };
 }
+function buildAnomalyGuardConfig(policy) {
+    const raw = policy && policy.request && policy.request.anomaly_guards;
+    if (!raw || raw.enabled !== true) {
+        return {
+            enabled: false,
+            crlf: false,
+            malformedCookie: false,
+            doubleEncodedTraversal: false,
+            maxCookieBytes: 4096,
+            maxCookiePairs: 80,
+        };
+    }
+    return {
+        enabled: true,
+        crlf: raw.crlf !== false,
+        malformedCookie: raw.malformed_cookie !== false,
+        doubleEncodedTraversal: raw.double_encoded_traversal !== false,
+        maxCookieBytes: Number.isFinite(Number(raw.max_cookie_bytes))
+            ? Math.max(1, Math.min(65536, Number(raw.max_cookie_bytes)))
+            : 4096,
+        maxCookiePairs: Number.isFinite(Number(raw.max_cookie_pairs))
+            ? Math.max(1, Math.min(1000, Number(raw.max_cookie_pairs)))
+            : 80,
+    };
+}
 function warnUnsupportedGraphqlGuard(policy, target, options = {}) {
     const logger = options.logger || console;
     const guard = buildGraphqlGuardConfig(policy);
@@ -679,6 +704,7 @@ function build(policy, options = {}) {
         trustForwardedFor,
         cors: corsConfig,
         authGates,
+        anomalyGuards: buildAnomalyGuardConfig(policy),
         obs: obsCfg,
     });
     const templatePath = path.join(rootDir, 'templates', 'aws', 'viewer-request.js');
@@ -895,6 +921,7 @@ module.exports = {
     buildChallengeConfig,
     warnUnsupportedAwsChallenge,
     buildGraphqlGuardConfig,
+    buildAnomalyGuardConfig,
     warnUnsupportedGraphqlGuard,
     validateJwksUrl,
     build,

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -255,6 +255,58 @@ console.log('--- viewer-request: ' + (cases.length - viewerFailed) + '/' + cases
         }
     }
 })();
+// Lightweight request anomaly guards (#117): opt-in checks for CRLF,
+// malformed Cookie headers, and one-pass double-encoded traversal indicators.
+(function runRequestAnomalyGuardTests() {
+    const cfgCode = [
+        'const CFG = {',
+        '  mode: "enforce",',
+        '  allowMethods: ["GET"],',
+        '  maxQueryLength: 1024,',
+        '  maxQueryParams: 30,',
+        '  maxUriLength: 2048,',
+        '  maxHeaderCount: 64,',
+        '  dropQueryKeys: new Set([]),',
+        '  uaDenyContains: [],',
+        '  blockPathContains: [],',
+        '  blockPathRegexes: [],',
+        '  normalizePath: { collapseSlashes: false, removeDotSegments: false },',
+        '  requiredHeaders: [],',
+        '  allowedHosts: [],',
+        '  trustForwardedFor: false,',
+        '  cors: null,',
+        '  anomalyGuards: { enabled: true, crlf: true, malformedCookie: true, doubleEncodedTraversal: true, maxCookieBytes: 32, maxCookiePairs: 2 },',
+        '  authGates: [],',
+        '};',
+    ].join('\n');
+    const h = compileViewerTemplate(cfgCode);
+    if (!h) {
+        viewerFailed++;
+        return;
+    }
+    const cases = [
+        ['anomaly: raw CRLF in path rejected', buildEvent('GET', '/bad\r\npath', {}), 400],
+        ['anomaly: encoded CRLF in query rejected', buildEvent('GET', '/', {}, 'next=%0d%0aheader'), 400],
+        ['anomaly: CRLF in header value rejected', buildEvent('GET', '/', { 'x-test': 'ok\nbad' }), 400],
+        ['anomaly: malformed cookie delimiter rejected', buildEvent('GET', '/', { cookie: 'a=1;;b=2' }), 400],
+        ['anomaly: cookie pair count over limit rejected', buildEvent('GET', '/', { cookie: 'a=1; b=2; c=3' }), 400],
+        ['anomaly: double-encoded traversal rejected', buildEvent('GET', '/%252e%252e%252fsecret', {}), 400],
+        ['anomaly: benign double-encoded space allowed', buildEvent('GET', '/download/%2520report', {}, 'name=hello%2520world'), 'allow'],
+    ];
+    for (const [name, event, expected] of cases) {
+        const result = h(event);
+        const allowed = result && !result.statusCode && result.uri !== undefined;
+        const got = allowed ? 'allow' : (result && result.statusCode);
+        const ok = (expected === 'allow' && allowed) || (typeof expected === 'number' && got === expected);
+        if (!ok) {
+            console.error('FAIL:', name, '| expected', expected, 'got', got);
+            viewerFailed++;
+        }
+        else {
+            console.log('OK:', name);
+        }
+    }
+})();
 // =========================================================================
 // Section 1b: viewer-request.js monitor mode tests
 // =========================================================================

--- a/scripts/runtime-tests.js
+++ b/scripts/runtime-tests.js
@@ -287,10 +287,40 @@ console.log('--- viewer-request: ' + (cases.length - viewerFailed) + '/' + cases
     const cases = [
         ['anomaly: raw CRLF in path rejected', buildEvent('GET', '/bad\r\npath', {}), 400],
         ['anomaly: encoded CRLF in query rejected', buildEvent('GET', '/', {}, 'next=%0d%0aheader'), 400],
+        ['anomaly: encoded CRLF in CloudFront query object rejected',
+            buildEvent('GET', '/', {}, { next: { value: '%0d%0aheader' } }),
+            400],
         ['anomaly: CRLF in header value rejected', buildEvent('GET', '/', { 'x-test': 'ok\nbad' }), 400],
+        ['anomaly: CRLF in header multiValue rejected',
+            (() => {
+                const event = buildEvent('GET', '/', {});
+                event.request.headers['x-test'] = {
+                    value: 'ok',
+                    multiValue: [{ value: 'ok' }, { value: 'bad%0d%0aheader' }],
+                };
+                return event;
+            })(),
+            400],
         ['anomaly: malformed cookie delimiter rejected', buildEvent('GET', '/', { cookie: 'a=1;;b=2' }), 400],
+        ['anomaly: malformed CloudFront cookie map rejected',
+            (() => {
+                const event = buildEvent('GET', '/', {});
+                event.request.cookies = { session: { value: 'ok\nbad' } };
+                return event;
+            })(),
+            400],
         ['anomaly: cookie pair count over limit rejected', buildEvent('GET', '/', { cookie: 'a=1; b=2; c=3' }), 400],
+        ['anomaly: CloudFront cookie map pair count over limit rejected',
+            (() => {
+                const event = buildEvent('GET', '/', {});
+                event.request.cookies = { a: { value: '1' }, b: { value: '2' }, c: { value: '3' } };
+                return event;
+            })(),
+            400],
         ['anomaly: double-encoded traversal rejected', buildEvent('GET', '/%252e%252e%252fsecret', {}), 400],
+        ['anomaly: double-encoded traversal in CloudFront query object rejected',
+            buildEvent('GET', '/', {}, { next: { value: '%252e%252e%252fsecret' } }),
+            400],
         ['anomaly: benign double-encoded space allowed', buildEvent('GET', '/download/%2520report', {}, 'name=hello%2520world'), 'allow'],
     ];
     for (const [name, event, expected] of cases) {

--- a/scripts/schema-lint-tests.js
+++ b/scripts/schema-lint-tests.js
@@ -48,6 +48,7 @@ request:
     max_query_params: ${overrides.max_query_params ?? 30}
     max_uri_length: ${overrides.max_uri_length ?? 2048}
     max_header_size: ${overrides.max_header_size ?? 8192}
+${overrides.requestExtra || ''}
 response_headers:
   hsts: "max-age=31536000"
 ${overrides.extra || ''}
@@ -158,6 +159,44 @@ test('lint accepts firewall.challenge at configured bounds', () => {
     try {
         const result = runLint(file);
         assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+    }
+    finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+test('lint accepts request anomaly guards at configured bounds', () => {
+    const yaml = basePolicy({
+        requestExtra: `  anomaly_guards:
+    enabled: true
+    crlf: true
+    malformed_cookie: true
+    double_encoded_traversal: true
+    max_cookie_bytes: 65536
+    max_cookie_pairs: 1000
+`,
+    });
+    const { dir, file } = writeTempPolicy(yaml);
+    try {
+        const result = runLint(file);
+        assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+    }
+    finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+test('lint rejects request anomaly guard cookie bounds outside schema limits', () => {
+    const yaml = basePolicy({
+        requestExtra: `  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 70000
+    max_cookie_pairs: 1001
+`,
+    });
+    const { dir, file } = writeTempPolicy(yaml);
+    try {
+        const result = runLint(file);
+        assert.notStrictEqual(result.status, 0);
+        assert.match(result.stderr + result.stdout, /anomaly_guards|max_cookie_bytes|max_cookie_pairs|maximum/i);
     }
     finally {
         fs.rmSync(dir, { recursive: true, force: true });

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -206,6 +206,8 @@ test('cloudflare template contains auth enforcement logic', () => {
   assert.ok(template.includes('async function handleChallenge'), 'challenge handler missing');
   assert.ok(template.includes('verifyChallengeCookie'), 'challenge cookie verifier missing');
   assert.ok(template.includes('verifyChallengeSolution'), 'challenge proof verifier missing');
+  assert.ok(template.includes('function blockIfRequestAnomaly'), 'request anomaly guard missing');
+  assert.ok(template.includes('hasDoubleEncodedTraversalIndicator'), 'double-encoded traversal helper missing');
   // Auth/crypto hardening fixtures
   assert.ok(template.includes('isJwtAlgAllowed'), 'JWT alg whitelist helper missing');
   assert.ok(template.includes('isHostAllowed'), 'Host allowlist helper missing');
@@ -252,6 +254,84 @@ response_headers:
   const { res, fetchCalls } = await runGeneratedWorkerRequest(generated, request);
   assert.strictEqual(res.status, 400);
   assert.strictEqual(fetchCalls.length, 0, 'raw traversal should block before origin fetch');
+});
+
+test('cloudflare request anomaly guards block CRLF, malformed cookies, and double-encoded traversal', async () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-anomaly-guard-test
+request:
+  allow_methods: ["GET"]
+  limits:
+    max_query_length: 1024
+    max_query_params: 30
+    max_uri_length: 2048
+  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 32
+    max_cookie_pairs: 2
+response_headers:
+  hsts: "max-age=31536000"
+`);
+
+  const encodedCrlf = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/?next=%0d%0aheader', {
+      method: 'GET',
+      headers: { 'user-agent': 'runtime-test' },
+    }),
+  );
+  assert.strictEqual(encodedCrlf.res.status, 400);
+  assert.strictEqual(encodedCrlf.fetchCalls.length, 0);
+
+  const rawHeaderRequest: any = {
+    url: 'https://edge.example.com/',
+    method: 'GET',
+    headers: {
+      get(name: string) {
+        if (name.toLowerCase() === 'user-agent') return 'runtime-test';
+        if (name.toLowerCase() === 'x-test') return 'ok\nbad';
+        return '';
+      },
+      forEach(fn: (value: string, key: string) => void) {
+        fn('runtime-test', 'user-agent');
+        fn('ok\nbad', 'x-test');
+      },
+    },
+  };
+  const rawHeader = await runGeneratedWorkerRequest(generated, rawHeaderRequest);
+  assert.strictEqual(rawHeader.res.status, 400);
+  assert.strictEqual(rawHeader.fetchCalls.length, 0);
+
+  const malformedCookie = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/', {
+      method: 'GET',
+      headers: { 'user-agent': 'runtime-test', cookie: 'a=1;;b=2' },
+    }),
+  );
+  assert.strictEqual(malformedCookie.res.status, 400);
+  assert.strictEqual(malformedCookie.fetchCalls.length, 0);
+
+  const doubleEncodedTraversal = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/%252e%252e%252fsecret', {
+      method: 'GET',
+      headers: { 'user-agent': 'runtime-test' },
+    }),
+  );
+  assert.strictEqual(doubleEncodedTraversal.res.status, 400);
+  assert.strictEqual(doubleEncodedTraversal.fetchCalls.length, 0);
+
+  const benign = await runGeneratedWorkerRequest(
+    generated,
+    new Request('https://edge.example.com/download/%2520report?name=hello%2520world', {
+      method: 'GET',
+      headers: { 'user-agent': 'runtime-test' },
+    }),
+  );
+  assert.strictEqual(benign.res.status, 200);
+  assert.strictEqual(benign.fetchCalls.length, 1);
 });
 
 test('cloudflare compile emits experimental challenge config', () => {

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -19,6 +19,7 @@ const {
   warnSignedUrlReplay,
   buildChallengeConfig,
   buildGraphqlGuardConfig,
+  buildAnomalyGuardConfig,
   buildObsConfig,
 } = require('./lib/compile-core');
 const {
@@ -259,6 +260,7 @@ const cfgCode = renderConstObject('CFG', {
   geoAllowCountries: runtimeCode(`new Set(${JSON.stringify(geoAllowCountries)})`),
   challenge: challengeConfig,
   graphqlGuard: buildGraphqlGuardConfig(policy),
+  anomalyGuards: buildAnomalyGuardConfig(policy),
   obs: buildObsConfig(policy),
 });
 

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -22,6 +22,7 @@ const {
   buildChallengeConfig,
   warnUnsupportedAwsChallenge,
   buildGraphqlGuardConfig,
+  buildAnomalyGuardConfig,
   warnUnsupportedGraphqlGuard,
   validateOriginAuth,
 } = require('./lib/compile-core');
@@ -222,6 +223,37 @@ test('buildGraphqlGuardConfig normalizes configured limits and defaults endpoint
     maxFields: 50,
     maxBodyBytes: 65536,
     mode: 'report',
+  });
+});
+
+test('buildAnomalyGuardConfig defaults disabled and normalizes enabled limits', () => {
+  assert.deepStrictEqual(buildAnomalyGuardConfig({ request: {} }), {
+    enabled: false,
+    crlf: false,
+    malformedCookie: false,
+    doubleEncodedTraversal: false,
+    maxCookieBytes: 4096,
+    maxCookiePairs: 80,
+  });
+
+  const cfg = buildAnomalyGuardConfig({
+    request: {
+      anomaly_guards: {
+        enabled: true,
+        crlf: false,
+        max_cookie_bytes: 999999,
+        max_cookie_pairs: 0,
+      },
+    },
+  });
+
+  assert.deepStrictEqual(cfg, {
+    enabled: true,
+    crlf: false,
+    malformedCookie: true,
+    doubleEncodedTraversal: true,
+    maxCookieBytes: 65536,
+    maxCookiePairs: 1,
   });
 });
 

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -644,6 +644,33 @@ function buildGraphqlGuardConfig(policy: any) {
   };
 }
 
+function buildAnomalyGuardConfig(policy: any) {
+  const raw = policy && policy.request && policy.request.anomaly_guards;
+  if (!raw || raw.enabled !== true) {
+    return {
+      enabled: false,
+      crlf: false,
+      malformedCookie: false,
+      doubleEncodedTraversal: false,
+      maxCookieBytes: 4096,
+      maxCookiePairs: 80,
+    };
+  }
+
+  return {
+    enabled: true,
+    crlf: raw.crlf !== false,
+    malformedCookie: raw.malformed_cookie !== false,
+    doubleEncodedTraversal: raw.double_encoded_traversal !== false,
+    maxCookieBytes: Number.isFinite(Number(raw.max_cookie_bytes))
+      ? Math.max(1, Math.min(65536, Number(raw.max_cookie_bytes)))
+      : 4096,
+    maxCookiePairs: Number.isFinite(Number(raw.max_cookie_pairs))
+      ? Math.max(1, Math.min(1000, Number(raw.max_cookie_pairs)))
+      : 80,
+  };
+}
+
 function warnUnsupportedGraphqlGuard(policy: any, target: string, options: any = {}) {
   const logger = options.logger || console;
   const guard = buildGraphqlGuardConfig(policy);
@@ -731,6 +758,7 @@ function build(policy: any, options: any = {}) {
     trustForwardedFor,
     cors: corsConfig,
     authGates,
+    anomalyGuards: buildAnomalyGuardConfig(policy),
     obs: obsCfg,
   });
 
@@ -965,6 +993,7 @@ module.exports = {
   buildChallengeConfig,
   warnUnsupportedAwsChallenge,
   buildGraphqlGuardConfig,
+  buildAnomalyGuardConfig,
   warnUnsupportedGraphqlGuard,
   validateJwksUrl,
   build,

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -13,7 +13,7 @@ const crypto = require('crypto');
 const { EventEmitter } = require('events');
 
 type HeaderMap = Record<string, string>;
-type CloudFrontHeaderMap = Record<string, { value: string }>;
+type CloudFrontHeaderMap = Record<string, { value: string; multiValue?: Array<{ value: string }> }>;
 type LambdaHeaderMap = Record<string, Array<{ key: string; value: string }>>;
 type ExpectedStatus = 'allow' | number | string;
 type RuntimeCase = [string, any, ExpectedStatus];
@@ -40,7 +40,7 @@ let originHandler: any;
 const DEFAULT_TOKEN = process.env.EDGE_ADMIN_TOKEN
   || 'INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN';
 
-function buildEvent(method: string, uri: string, headers: HeaderMap = {}, querystring: any = '') {
+function buildEvent(method: string, uri: string, headers: HeaderMap = {}, querystring: any = ''): any {
   const h = headers || {};
   const cfHeaders: CloudFrontHeaderMap = {};
   for (const [k, v] of Object.entries(h)) {
@@ -304,10 +304,40 @@ console.log('--- viewer-request: ' + (cases.length - viewerFailed) + '/' + cases
   const cases: RuntimeCase[] = [
     ['anomaly: raw CRLF in path rejected', buildEvent('GET', '/bad\r\npath', {}), 400],
     ['anomaly: encoded CRLF in query rejected', buildEvent('GET', '/', {}, 'next=%0d%0aheader'), 400],
+    ['anomaly: encoded CRLF in CloudFront query object rejected',
+      buildEvent('GET', '/', {}, { next: { value: '%0d%0aheader' } }),
+      400],
     ['anomaly: CRLF in header value rejected', buildEvent('GET', '/', { 'x-test': 'ok\nbad' }), 400],
+    ['anomaly: CRLF in header multiValue rejected',
+      (() => {
+        const event = buildEvent('GET', '/', {});
+        event.request.headers['x-test'] = {
+          value: 'ok',
+          multiValue: [{ value: 'ok' }, { value: 'bad%0d%0aheader' }],
+        };
+        return event;
+      })(),
+      400],
     ['anomaly: malformed cookie delimiter rejected', buildEvent('GET', '/', { cookie: 'a=1;;b=2' }), 400],
+    ['anomaly: malformed CloudFront cookie map rejected',
+      (() => {
+        const event = buildEvent('GET', '/', {});
+        event.request.cookies = { session: { value: 'ok\nbad' } };
+        return event;
+      })(),
+      400],
     ['anomaly: cookie pair count over limit rejected', buildEvent('GET', '/', { cookie: 'a=1; b=2; c=3' }), 400],
+    ['anomaly: CloudFront cookie map pair count over limit rejected',
+      (() => {
+        const event = buildEvent('GET', '/', {});
+        event.request.cookies = { a: { value: '1' }, b: { value: '2' }, c: { value: '3' } };
+        return event;
+      })(),
+      400],
     ['anomaly: double-encoded traversal rejected', buildEvent('GET', '/%252e%252e%252fsecret', {}), 400],
+    ['anomaly: double-encoded traversal in CloudFront query object rejected',
+      buildEvent('GET', '/', {}, { next: { value: '%252e%252e%252fsecret' } }),
+      400],
     ['anomaly: benign double-encoded space allowed', buildEvent('GET', '/download/%2520report', {}, 'name=hello%2520world'), 'allow'],
   ];
 

--- a/src/scripts/runtime-tests.ts
+++ b/src/scripts/runtime-tests.ts
@@ -274,6 +274,57 @@ console.log('--- viewer-request: ' + (cases.length - viewerFailed) + '/' + cases
   }
 })();
 
+// Lightweight request anomaly guards (#117): opt-in checks for CRLF,
+// malformed Cookie headers, and one-pass double-encoded traversal indicators.
+(function runRequestAnomalyGuardTests() {
+  const cfgCode = [
+    'const CFG = {',
+    '  mode: "enforce",',
+    '  allowMethods: ["GET"],',
+    '  maxQueryLength: 1024,',
+    '  maxQueryParams: 30,',
+    '  maxUriLength: 2048,',
+    '  maxHeaderCount: 64,',
+    '  dropQueryKeys: new Set([]),',
+    '  uaDenyContains: [],',
+    '  blockPathContains: [],',
+    '  blockPathRegexes: [],',
+    '  normalizePath: { collapseSlashes: false, removeDotSegments: false },',
+    '  requiredHeaders: [],',
+    '  allowedHosts: [],',
+    '  trustForwardedFor: false,',
+    '  cors: null,',
+    '  anomalyGuards: { enabled: true, crlf: true, malformedCookie: true, doubleEncodedTraversal: true, maxCookieBytes: 32, maxCookiePairs: 2 },',
+    '  authGates: [],',
+    '};',
+  ].join('\n');
+  const h = compileViewerTemplate(cfgCode);
+  if (!h) { viewerFailed++; return; }
+
+  const cases: RuntimeCase[] = [
+    ['anomaly: raw CRLF in path rejected', buildEvent('GET', '/bad\r\npath', {}), 400],
+    ['anomaly: encoded CRLF in query rejected', buildEvent('GET', '/', {}, 'next=%0d%0aheader'), 400],
+    ['anomaly: CRLF in header value rejected', buildEvent('GET', '/', { 'x-test': 'ok\nbad' }), 400],
+    ['anomaly: malformed cookie delimiter rejected', buildEvent('GET', '/', { cookie: 'a=1;;b=2' }), 400],
+    ['anomaly: cookie pair count over limit rejected', buildEvent('GET', '/', { cookie: 'a=1; b=2; c=3' }), 400],
+    ['anomaly: double-encoded traversal rejected', buildEvent('GET', '/%252e%252e%252fsecret', {}), 400],
+    ['anomaly: benign double-encoded space allowed', buildEvent('GET', '/download/%2520report', {}, 'name=hello%2520world'), 'allow'],
+  ];
+
+  for (const [name, event, expected] of cases) {
+    const result: any = h(event);
+    const allowed = result && !result.statusCode && result.uri !== undefined;
+    const got = allowed ? 'allow' : (result && result.statusCode);
+    const ok = (expected === 'allow' && allowed) || (typeof expected === 'number' && got === expected);
+    if (!ok) {
+      console.error('FAIL:', name, '| expected', expected, 'got', got);
+      viewerFailed++;
+    } else {
+      console.log('OK:', name);
+    }
+  }
+})();
+
 // =========================================================================
 // Section 1b: viewer-request.js monitor mode tests
 // =========================================================================

--- a/src/scripts/schema-lint-tests.ts
+++ b/src/scripts/schema-lint-tests.ts
@@ -51,6 +51,7 @@ request:
     max_query_params: ${overrides.max_query_params ?? 30}
     max_uri_length: ${overrides.max_uri_length ?? 2048}
     max_header_size: ${overrides.max_header_size ?? 8192}
+${overrides.requestExtra || ''}
 response_headers:
   hsts: "max-age=31536000"
 ${overrides.extra || ''}
@@ -162,6 +163,44 @@ test('lint accepts firewall.challenge at configured bounds', () => {
   try {
     const result: any = runLint(file);
     assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lint accepts request anomaly guards at configured bounds', () => {
+  const yaml = basePolicy({
+    requestExtra: `  anomaly_guards:
+    enabled: true
+    crlf: true
+    malformed_cookie: true
+    double_encoded_traversal: true
+    max_cookie_bytes: 65536
+    max_cookie_pairs: 1000
+`,
+  });
+  const { dir, file } = writeTempPolicy(yaml);
+  try {
+    const result: any = runLint(file);
+    assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lint rejects request anomaly guard cookie bounds outside schema limits', () => {
+  const yaml = basePolicy({
+    requestExtra: `  anomaly_guards:
+    enabled: true
+    max_cookie_bytes: 70000
+    max_cookie_pairs: 1001
+`,
+  });
+  const { dir, file } = writeTempPolicy(yaml);
+  try {
+    const result: any = runLint(file);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr + result.stdout, /anomaly_guards|max_cookie_bytes|max_cookie_pairs|maximum/i);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/src/types/policy.d.ts
+++ b/src/types/policy.d.ts
@@ -60,6 +60,35 @@ export interface CDNSecurityFrameworkPolicy {
        */
       max_header_count?: number;
     };
+    /**
+     * Optional lightweight request anomaly guards. When enabled, supported edge targets reject CRLF indicators in URI/query/header values, malformed Cookie headers, and bounded double-encoded traversal indicators before origin forwarding.
+     */
+    anomaly_guards?: {
+      /**
+       * Enable request anomaly guards. Individual checks default to enabled unless explicitly set to false.
+       */
+      enabled?: boolean;
+      /**
+       * Reject raw CR/LF characters and encoded %0d/%0a indicators in request URI, query, or header values.
+       */
+      crlf?: boolean;
+      /**
+       * Reject Cookie headers with control characters, empty delimiter segments, missing name/value delimiters, or configured size/pair-count overages.
+       */
+      malformed_cookie?: boolean;
+      /**
+       * Reject double-encoded traversal indicators such as %252e%252e, %252f, and %255c using at most one extra decode pass when %25 is present.
+       */
+      double_encoded_traversal?: boolean;
+      /**
+       * Maximum Cookie header length accepted by the malformed-cookie guard. Default 4096.
+       */
+      max_cookie_bytes?: number;
+      /**
+       * Maximum number of semicolon-delimited Cookie pairs accepted by the malformed-cookie guard. Default 80.
+       */
+      max_cookie_pairs?: number;
+    };
     block?: {
       path_patterns?:
         | string[]

--- a/templates/aws/viewer-request.js
+++ b/templates/aws/viewer-request.js
@@ -202,6 +202,108 @@
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -253,6 +355,13 @@
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -260,6 +369,13 @@
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -404,33 +520,41 @@
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/templates/aws/viewer-request.js
+++ b/templates/aws/viewer-request.js
@@ -273,31 +273,98 @@
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/templates/cloudflare/index.ts
+++ b/templates/cloudflare/index.ts
@@ -160,6 +160,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
   return null;
 }
 
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
+  }
+  return null;
+}
+
 function isGraphqlPath(pathname: string): boolean {
   const guard = CFG.graphqlGuard;
   if (!guard || !Array.isArray(guard.endpointPaths) || guard.endpointPaths.length === 0) return false;
@@ -1134,6 +1230,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1146,17 +1267,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1175,17 +1285,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/admin-panel/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":true,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/archetypes/admin-panel/edge/viewer-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/archetypes/admin-panel/edge/viewer-request.js
+++ b/tests/golden/archetypes/admin-panel/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [{"name":"admin","protectedPrefixes":["/"],"type":"static_token","tokenHeaderName":"x-edge-token","tokenEnv":"EDGE_ADMIN_TOKEN","token":"ci-build-token-not-for-deploy","tokenIsPlaceholder":false}],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":true,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/microservice-origin/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
+++ b/tests/golden/archetypes/microservice-origin/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/rest-api/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/archetypes/rest-api/edge/viewer-request.js
+++ b/tests/golden/archetypes/rest-api/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/archetypes/rest-api/edge/viewer-request.js
+++ b/tests/golden/archetypes/rest-api/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: {"allow_origins":["https://app.example.com"],"allow_methods":["GET","POST","PUT","PATCH","DELETE","OPTIONS"],"allow_headers":["authorization","content-type","x-request-id"],"allow_credentials":true,"max_age":600},
   authGates: [{"name":"api","protectedPrefixes":["/api"],"type":"jwt"}],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
+++ b/tests/golden/archetypes/spa-static-site/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
+++ b/tests/golden/archetypes/spa-static-site/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/base/edge/cloudflare/index.ts
+++ b/tests/golden/base/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/base/edge/viewer-request.js
+++ b/tests/golden/base/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/base/edge/viewer-request.js
+++ b/tests/golden/base/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [{"name":"admin","protectedPrefixes":["/admin","/docs","/swagger"],"type":"static_token","tokenHeaderName":"x-edge-token","tokenEnv":"EDGE_ADMIN_TOKEN","token":"ci-build-token-not-for-deploy","tokenIsPlaceholder":false}],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/profiles/balanced/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/balanced/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/profiles/balanced/edge/viewer-request.js
+++ b/tests/golden/profiles/balanced/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/profiles/balanced/edge/viewer-request.js
+++ b/tests/golden/profiles/balanced/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [{"name":"admin","protectedPrefixes":["/admin","/docs","/swagger"],"type":"static_token","tokenHeaderName":"x-edge-token","tokenEnv":"EDGE_ADMIN_TOKEN","token":"ci-build-token-not-for-deploy","tokenIsPlaceholder":false}],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":false,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/profiles/permissive/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/permissive/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":false,"crlf":false,"malformedCookie":false,"doubleEncodedTraversal":false,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/profiles/permissive/edge/viewer-request.js
+++ b/tests/golden/profiles/permissive/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/profiles/permissive/edge/viewer-request.js
+++ b/tests/golden/profiles/permissive/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [{"name":"admin","protectedPrefixes":["/admin","/docs","/swagger"],"type":"static_token","tokenHeaderName":"x-edge-token","tokenEnv":"EDGE_ADMIN_TOKEN","token":"ci-build-token-not-for-deploy","tokenIsPlaceholder":false}],
+  anomalyGuards: {"enabled":false,"crlf":false,"malformedCookie":false,"doubleEncodedTraversal":false,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"","sampleRate":0,"auditLogAuth":false,"auditHashSub":false},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 

--- a/tests/golden/profiles/strict/edge/cloudflare/index.ts
+++ b/tests/golden/profiles/strict/edge/cloudflare/index.ts
@@ -30,6 +30,7 @@ const CFG = {
   geoAllowCountries: new Set([]),
   challenge: null,
   graphqlGuard: null,
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":true,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -203,6 +204,102 @@ function blockIfPathPattern(pathname: string, ctx: ReqCtx): Response | null {
       const r = shouldBlock(400, 'Bad Request', ctx);
       if (r) return r;
     }
+  }
+  return null;
+}
+
+function hasRawControlLineBreak(s: string): boolean {
+  return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+}
+
+function hasEncodedCrlfIndicator(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const lower = s.toLowerCase();
+  return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+}
+
+function hasCrlfIndicator(s: string): boolean {
+  return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+}
+
+function decodeOnceWhenPercent25Present(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  if (s.toLowerCase().indexOf('%25') === -1) return '';
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return '';
+  }
+}
+
+function hasDoubleEncodedTraversalIndicator(s: string): boolean {
+  const decoded = decodeOnceWhenPercent25Present(s);
+  if (!decoded) return false;
+  const lower = decoded.toLowerCase();
+  return lower.indexOf('%2e%2e') !== -1 ||
+    lower.indexOf('..%2f') !== -1 ||
+    lower.indexOf('..%5c') !== -1 ||
+    lower.indexOf('%2f..') !== -1 ||
+    lower.indexOf('%5c..') !== -1 ||
+    lower.indexOf('../') !== -1 ||
+    lower.indexOf('..\\') !== -1;
+}
+
+function hasCookieControlChar(cookie: string): boolean {
+  if (typeof cookie !== 'string') return false;
+  for (let i = 0; i < cookie.length; i++) {
+    const code = cookie.charCodeAt(i);
+    if (code < 32 || code === 127) return true;
+  }
+  return false;
+}
+
+function isMalformedCookie(cookie: string): boolean {
+  if (typeof cookie !== 'string' || cookie.length === 0) return false;
+  const guards = CFG.anomalyGuards || {};
+  if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+  if (hasCookieControlChar(cookie)) return true;
+
+  const parts = cookie.split(';');
+  let pairCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i].trim();
+    if (!part) {
+      if (i > 0 && i < parts.length - 1) return true;
+      continue;
+    }
+    const eq = part.indexOf('=');
+    if (eq <= 0) return true;
+    if (!part.slice(0, eq).trim()) return true;
+    pairCount++;
+    if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+  }
+  return false;
+}
+
+function blockIfRequestAnomaly(request: Request, rawPathname: string, query: string, ctx: ReqCtx): Response | null {
+  const guards = CFG.anomalyGuards || {};
+  if (guards.enabled !== true) return null;
+
+  if (guards.crlf !== false && (hasCrlfIndicator(rawPathname) || hasCrlfIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+  if (guards.doubleEncodedTraversal !== false &&
+    (hasDoubleEncodedTraversalIndicator(rawPathname) || hasDoubleEncodedTraversalIndicator(query))) {
+    return shouldBlock(400, 'Bad Request', ctx);
+  }
+
+  let headerBlock: Response | null = null;
+  request.headers.forEach((value) => {
+    if (!headerBlock && guards.crlf !== false && hasCrlfIndicator(value)) {
+      headerBlock = shouldBlock(400, 'Bad Request', ctx);
+    }
+  });
+  if (headerBlock) return headerBlock;
+
+  const cookie = request.headers.get('cookie') || '';
+  if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+    return shouldBlock(400, 'Malformed Cookie', ctx);
   }
   return null;
 }
@@ -1181,6 +1278,31 @@ export default {
       }
     }
 
+    if (CFG.maxHeaderSize > 0) {
+      let totalSize = 0;
+      request.headers.forEach((value, key) => {
+        totalSize += key.length + value.length;
+      });
+      if (totalSize > CFG.maxHeaderSize) {
+        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
+        if (r) return r;
+      }
+    }
+
+    const qs = url.search.slice(1);
+    if (qs.length > CFG.maxQueryLength) {
+      const r = shouldBlock(414, 'URI Too Long', ctx);
+      if (r) return r;
+    }
+    const parts = qs ? qs.split('&') : [];
+    if (parts.length > CFG.maxQueryParams) {
+      const r = shouldBlock(400, 'Too many query params', ctx);
+      if (r) return r;
+    }
+
+    const anomalyBlock = blockIfRequestAnomaly(request, rawPathname, qs, ctx);
+    if (anomalyBlock) return anomalyBlock;
+
     const rawPathBlock = blockIfPathPattern(rawPathname, ctx);
     if (rawPathBlock) return rawPathBlock;
 
@@ -1193,17 +1315,6 @@ export default {
       const val = request.headers.get(h);
       if (!val) {
         const r = shouldBlock(400, 'Missing ' + h, ctx);
-        if (r) return r;
-      }
-    }
-
-    if (CFG.maxHeaderSize > 0) {
-      let totalSize = 0;
-      request.headers.forEach((value, key) => {
-        totalSize += key.length + value.length;
-      });
-      if (totalSize > CFG.maxHeaderSize) {
-        const r = shouldBlock(431, 'Request Header Fields Too Large', ctx);
         if (r) return r;
       }
     }
@@ -1222,17 +1333,6 @@ export default {
         const r = shouldBlock(403, 'Forbidden', ctx);
         if (r) return r;
       }
-    }
-
-    const qs = url.search.slice(1);
-    if (qs.length > CFG.maxQueryLength) {
-      const r = shouldBlock(414, 'URI Too Long', ctx);
-      if (r) return r;
-    }
-    const parts = qs ? qs.split('&') : [];
-    if (parts.length > CFG.maxQueryParams) {
-      const r = shouldBlock(400, 'Too many query params', ctx);
-      if (r) return r;
     }
 
     for (const k of CFG.dropQueryKeys) url.searchParams.delete(k);

--- a/tests/golden/profiles/strict/edge/viewer-request.js
+++ b/tests/golden/profiles/strict/edge/viewer-request.js
@@ -292,31 +292,98 @@ const CFG = {
     return false;
   }
 
+  function querystringMatches(qs, predicate) {
+    if (!qs) return false;
+    if (typeof qs === 'string') return predicate(qs);
+    if (typeof qs !== 'object') return false;
+    for (const k in qs) {
+      if (!Object.prototype.hasOwnProperty.call(qs, k)) continue;
+      if (predicate(k)) return true;
+      const entry = qs[k];
+      if (!entry || typeof entry !== 'object') {
+        if (predicate(String(entry))) return true;
+        continue;
+      }
+      if (predicate(entry.value)) return true;
+      if (Array.isArray(entry.multiValue)) {
+        for (const mv of entry.multiValue) {
+          if (predicate(mv && mv.value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function headerEntryMatches(entry, predicate) {
+    if (!entry || typeof entry !== 'object') return false;
+    if (predicate(entry.value)) return true;
+    if (Array.isArray(entry.multiValue)) {
+      for (const mv of entry.multiValue) {
+        if (predicate(mv && mv.value)) return true;
+      }
+    }
+    return false;
+  }
+
+  function serializeCookieMap(cookies) {
+    if (!cookies || typeof cookies !== 'object') return '';
+    const parts = [];
+    for (const name in cookies) {
+      if (!Object.prototype.hasOwnProperty.call(cookies, name)) continue;
+      const entry = cookies[name];
+      if (!entry || typeof entry !== 'object') {
+        parts.push(name + '=' + String(entry));
+        continue;
+      }
+      if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+        for (const mv of entry.multiValue) {
+          parts.push(name + '=' + String((mv && mv.value) || ''));
+        }
+      } else {
+        parts.push(name + '=' + String(entry.value || ''));
+      }
+    }
+    return parts.join('; ');
+  }
+
+  function cookieStringFromRequest(req, headers) {
+    const cookieMap = serializeCookieMap(req.cookies);
+    if (cookieMap) return cookieMap;
+    const entry = headers['cookie'];
+    if (!entry || typeof entry !== 'object') return '';
+    if (Array.isArray(entry.multiValue) && entry.multiValue.length > 0) {
+      const parts = [];
+      for (const mv of entry.multiValue) {
+        parts.push((mv && mv.value) || '');
+      }
+      return parts.join('; ');
+    }
+    return entry.value || '';
+  }
+
   function blockIfRequestAnomaly(req) {
     const guards = CFG.anomalyGuards || {};
     if (guards.enabled !== true) return null;
 
     const uri = req.uri || '';
-    const qs = serializeQuerystring(req.querystring);
 
-    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || querystringMatches(req.querystring, hasCrlfIndicator))) {
       return resp(400, 'Bad Request');
     }
     if (guards.doubleEncodedTraversal !== false &&
-      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      (hasDoubleEncodedTraversalIndicator(uri) || querystringMatches(req.querystring, hasDoubleEncodedTraversalIndicator))) {
       return resp(400, 'Bad Request');
     }
 
     const headers = req.headers || {};
     for (const name in headers) {
       if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
-      const value = headers[name] && headers[name].value;
-      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+      if (guards.crlf !== false && headerEntryMatches(headers[name], hasCrlfIndicator)) {
         return resp(400, 'Bad Request');
       }
     }
 
-    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    const cookie = cookieStringFromRequest(req, headers);
     if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
       return resp(400, 'Malformed Cookie');
     }

--- a/tests/golden/profiles/strict/edge/viewer-request.js
+++ b/tests/golden/profiles/strict/edge/viewer-request.js
@@ -35,6 +35,7 @@ const CFG = {
   trustForwardedFor: false,
   cors: null,
   authGates: [{"name":"admin","protectedPrefixes":["/admin","/docs","/swagger","/api/admin","/internal"],"type":"static_token","tokenHeaderName":"x-edge-token","tokenEnv":"EDGE_ADMIN_TOKEN","token":"ci-build-token-not-for-deploy","tokenIsPlaceholder":false}],
+  anomalyGuards: {"enabled":true,"crlf":true,"malformedCookie":true,"doubleEncodedTraversal":true,"maxCookieBytes":4096,"maxCookiePairs":80},
   obs: {"logFormat":"json","correlationHeader":"traceparent","sampleRate":0,"auditLogAuth":true,"auditHashSub":true},
 };
 
@@ -220,6 +221,108 @@ const CFG = {
     return null;
   }
 
+  function hasRawControlLineBreak(s) {
+    return typeof s === 'string' && (s.indexOf('\r') !== -1 || s.indexOf('\n') !== -1);
+  }
+
+  function hasEncodedCrlfIndicator(s) {
+    if (typeof s !== 'string' || s.length === 0) return false;
+    var lower = s.toLowerCase();
+    return lower.indexOf('%0d') !== -1 || lower.indexOf('%0a') !== -1;
+  }
+
+  function hasCrlfIndicator(s) {
+    return hasRawControlLineBreak(s) || hasEncodedCrlfIndicator(s);
+  }
+
+  function decodeOnceWhenPercent25Present(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    if (s.toLowerCase().indexOf('%25') === -1) return '';
+    try {
+      return decodeURIComponent(s);
+    } catch (_e) {
+      return '';
+    }
+  }
+
+  function hasDoubleEncodedTraversalIndicator(s) {
+    const decoded = decodeOnceWhenPercent25Present(s);
+    if (!decoded) return false;
+    const lower = decoded.toLowerCase();
+    return lower.indexOf('%2e%2e') !== -1 ||
+      lower.indexOf('..%2f') !== -1 ||
+      lower.indexOf('..%5c') !== -1 ||
+      lower.indexOf('%2f..') !== -1 ||
+      lower.indexOf('%5c..') !== -1 ||
+      lower.indexOf('../') !== -1 ||
+      lower.indexOf('..\\') !== -1;
+  }
+
+  function hasCookieControlChar(cookie) {
+    if (typeof cookie !== 'string') return false;
+    for (var i = 0; i < cookie.length; i++) {
+      var code = cookie.charCodeAt(i);
+      if (code < 32 || code === 127) return true;
+    }
+    return false;
+  }
+
+  function isMalformedCookie(cookie) {
+    if (typeof cookie !== 'string' || cookie.length === 0) return false;
+    const guards = CFG.anomalyGuards || {};
+    if (guards.maxCookieBytes && cookie.length > guards.maxCookieBytes) return true;
+    if (hasCookieControlChar(cookie)) return true;
+
+    const parts = cookie.split(';');
+    let pairCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      // A leading/trailing semicolon is tolerated, but an empty middle segment
+      // (`a=1;;b=2`) is a clear delimiter anomaly.
+      if (!part) {
+        if (i > 0 && i < parts.length - 1) return true;
+        continue;
+      }
+      const eq = part.indexOf('=');
+      if (eq <= 0) return true;
+      if (!part.slice(0, eq).trim()) return true;
+      pairCount++;
+      if (guards.maxCookiePairs && pairCount > guards.maxCookiePairs) return true;
+    }
+    return false;
+  }
+
+  function blockIfRequestAnomaly(req) {
+    const guards = CFG.anomalyGuards || {};
+    if (guards.enabled !== true) return null;
+
+    const uri = req.uri || '';
+    const qs = serializeQuerystring(req.querystring);
+
+    if (guards.crlf !== false && (hasCrlfIndicator(uri) || hasCrlfIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+    if (guards.doubleEncodedTraversal !== false &&
+      (hasDoubleEncodedTraversalIndicator(uri) || hasDoubleEncodedTraversalIndicator(qs))) {
+      return resp(400, 'Bad Request');
+    }
+
+    const headers = req.headers || {};
+    for (const name in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, name)) continue;
+      const value = headers[name] && headers[name].value;
+      if (guards.crlf !== false && hasCrlfIndicator(value)) {
+        return resp(400, 'Bad Request');
+      }
+    }
+
+    const cookie = (headers['cookie'] && headers['cookie'].value) || '';
+    if (guards.malformedCookie !== false && isMalformedCookie(cookie)) {
+      return resp(400, 'Malformed Cookie');
+    }
+    return null;
+  }
+
   function normalizePath(req) {
     let p = req.uri || '/';
     if (CFG.normalizePath.collapseSlashes) {
@@ -271,6 +374,13 @@ const CFG = {
   }
 
   function guardAndNormalizeQuery(req) {
+    const limited = blockIfQueryLimits(req);
+    if (limited) return limited;
+    normalizeQuery(req);
+    return null;
+  }
+
+  function blockIfQueryLimits(req) {
     const originalQuerystring = req.querystring;
     const qs = serializeQuerystring(originalQuerystring);
 
@@ -278,6 +388,13 @@ const CFG = {
 
     const parts = qs ? qs.split("&") : [];
     if (parts.length > CFG.maxQueryParams) return resp(400, "Too many query params");
+    return null;
+  }
+
+  function normalizeQuery(req) {
+    const originalQuerystring = req.querystring;
+    const qs = serializeQuerystring(originalQuerystring);
+    const parts = qs ? qs.split("&") : [];
 
     const kept = [];
     for (const p of parts) {
@@ -422,33 +539,41 @@ const CFG = {
     const hc = shouldBlock(blockIfTooManyHeaders(req), req);
     if (hc) return hc;
 
-    // 3) Raw path traversal (coarse). Run before dot-segment normalization so
+    // 3) Query length / count caps before any query anomaly scan.
+    const qLimit = shouldBlock(blockIfQueryLimits(req), req);
+    if (qLimit) return qLimit;
+
+    // 4) Lightweight anomaly guards. Run after cheap caps, before path
+    // normalization and origin/auth forwarding.
+    const anomaly = shouldBlock(blockIfRequestAnomaly(req), req);
+    if (anomaly) return anomaly;
+
+    // 5) Raw path traversal (coarse). Run before dot-segment normalization so
     // suspicious input like /public/../private cannot be rewritten to /private
     // before the block patterns see it.
     const rawTraversal = shouldBlock(blockIfTraversal(req), req);
     if (rawTraversal) return rawTraversal;
 
-    // 4) Path normalization
+    // 6) Path normalization
     normalizePath(req);
 
-    // 4b) Path traversal after normalization. Preserves existing behavior for
+    // 6b) Path traversal after normalization. Preserves existing behavior for
     // block rules that intentionally match canonicalized paths.
     const t = shouldBlock(blockIfTraversal(req), req);
     if (t) return t;
 
-    // 5) Required headers check
+    // 7) Required headers check
     const hm = shouldBlock(blockIfHeaderMissing(req), req);
     if (hm) return hm;
 
-    // 6) UA sanity (deny list)
+    // 8) UA sanity (deny list)
     const u = shouldBlock(blockIfBadUA(req), req);
     if (u) return u;
 
-    // 7) Query guard + normalize
-    const q = shouldBlock(guardAndNormalizeQuery(req), req);
-    if (q) return q;
+    // 9) Query normalize after anomaly checks have seen the raw query.
+    normalizeQuery(req);
 
-    // 8) Auth gates (static token, basic auth)
+    // 10) Auth gates (static token, basic auth)
     const auth = shouldBlockAuth(checkAuthGates(req), req);
     if (auth) return auth;
 


### PR DESCRIPTION
## Summary
- Add `request.anomaly_guards` schema/compiler config for bounded CRLF, malformed Cookie, and double-encoded traversal checks.
- Enforce the guards in AWS viewer-request and Cloudflare Worker after cheap URI/query/header caps and before normalization/origin forwarding.
- Enable the guards in base/balanced/strict profiles and archetypes, update EN/JA docs, generated types, runtime tests, schema tests, and golden fixtures.

## Verification
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:ci`
- `git diff --check`

Fixes #117