### PR TITLE
chore: sync v1.4.0 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-07
+
+### Security
+
+- Added HMAC origin authentication support for origin-bound request signing.
+- Added edge security primitives for JavaScript challenges, GraphQL depth/complexity guarding, and response DLP guard coverage.
+- Hardened JWT/JWKS behavior, including fail-closed HS256 secret handling, RS256 JWK `alg` handling, and JWKS resilience.
+- Added raw request anomaly checks for encoded traversal, CRLF indicators, header multi-values, query object values, and CloudFront cookie maps before normalization hides the original input shape.
+- Tightened CORS response behavior with `Vary: Origin` handling.
+
+### Added
+
+- Added guided `init` wizard support, deployment workflow templates, and production readiness reporting.
+- Added target capability reporting and policy recipe documentation for common deployment archetypes.
+- Added local CI/test helper coverage, CODEOWNERS wiring, and security baseline release checks.
+
+### Changed
+
+- Updated npm dependencies and documented local build/test secret prerequisites.
+- Clarified the source/generated artifact boundary for OSS consumers.
+
+### Fixed
+
+- Addressed post-merge review findings around body-hash handling and CloudFront request-anomaly event shapes.
+
 ## [1.3.0] - 2026-05-01
 
 ### Added
@@ -109,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/albert-einshutoin/cdn-security-framework/compare/v1.0.0...v1.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdn-security-framework",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdn-security-framework",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdn-security-framework",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Policy-driven CDN edge security. Init YAML with npx cdn-security init, then npx cdn-security build to generate runtime code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

- Sync the v1.4.0 release metadata back into develop after the main release merge.
- Keeps package.json, package-lock.json, and CHANGELOG.md aligned across main and develop.

## Verification

- v1.4.0 tag release workflow passed.
- npm latest is cdn-security-framework@1.4.0.
- GitHub Release v1.4.0 has been created.
