### PR TITLE
feat(cli): add WAF rule recommendations

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -719,6 +719,188 @@ function printCapabilitiesReport(report) {
 function readinessFinding(severity, id, detail, recommendation) {
     return { severity, id, detail, recommendation };
 }
+const WAF_RECOMMENDATION_TEMPLATES = {
+    'spa-static-site': {
+        id: 'waf.recommendation.spa_static_site',
+        appShape: 'spa-static-site',
+        title: 'SPA/static site managed-rule baseline',
+        rules: [
+            'AWSManagedRulesCommonRuleSet',
+            'AWSManagedRulesKnownBadInputsRuleSet',
+            'AWSManagedRulesIPReputationList',
+        ],
+        settings: [
+            'Keep request.allow_methods to GET/HEAD for static assets.',
+            'Use a global WAF rate limit around 2000 requests per 5 minutes per IP, then tune from logs.',
+            'Enable WAF logging when scope=CLOUDFRONT before production release.',
+        ],
+        rationale: 'Static sites mostly need traversal, scanner, XSS/cache-poisoning, and known-bad source coverage without heavy auth-specific managed rules.',
+        cost: 'Standard AWS WAF request/WCU costs; no BotControl or ATP paid add-on in this baseline.',
+        falsePositiveRisk: 'Low to medium. KnownBadInputs/OWASP-style rules can catch unusual asset paths, so monitor before enforcing on legacy static content.',
+    },
+    'rest-api': {
+        id: 'waf.recommendation.rest_api',
+        appShape: 'rest-api',
+        title: 'REST API managed-rule baseline',
+        rules: [
+            'AWSManagedRulesCommonRuleSet',
+            'AWSManagedRulesKnownBadInputsRuleSet',
+            'AWSManagedRulesSQLiRuleSet',
+            'AWSManagedRulesIPReputationList',
+        ],
+        settings: [
+            'Add scoped rate_limit_rules for auth, write-heavy, or expensive API paths.',
+            'Keep CORS origins explicit; do not rely on WAF rules to compensate for wildcard credentials.',
+            'Enable WAF logging for CloudFront-scoped APIs before production release.',
+        ],
+        rationale: 'JSON APIs need injection and scanner coverage plus SQLi signatures and reputation filtering, especially on write/query endpoints.',
+        cost: 'Standard AWS WAF request/WCU costs; SQLi adds WCU pressure but avoids BotControl/ATP paid add-ons.',
+        falsePositiveRisk: 'Medium. SQLi signatures can flag unusual query DSLs or search syntax; start in count/monitor mode for affected routes.',
+    },
+    'admin-panel': {
+        id: 'waf.recommendation.admin_panel',
+        appShape: 'admin-panel',
+        title: 'Admin panel managed-rule baseline',
+        rules: [
+            'AWSManagedRulesCommonRuleSet',
+            'AWSManagedRulesKnownBadInputsRuleSet',
+            'AWSManagedRulesIPReputationList',
+            'AWSManagedRulesAnonymousIpList',
+            'AWSManagedRulesBotControlRuleSet',
+            'AWSManagedRulesATPRuleSet',
+        ],
+        settings: [
+            'Use a low global WAF rate limit and a stricter scoped login/admin rate_limit_rule.',
+            'Require WAF logging and redaction for authorization, cookie, and x-api-key fields.',
+            'Combine managed rules with route auth, IP allowlists, VPN, or SSO where possible.',
+        ],
+        rationale: 'Admin panels are high-value targets for credential stuffing, bot traffic, anonymizers, and exploit probes, so stronger managed signals are justified.',
+        cost: 'Higher. BotControl and ATP are paid AWS managed protections and add operational tuning cost.',
+        falsePositiveRisk: 'Medium to high. Bot and ATP controls can challenge or block automation; allowlist known internal tooling before enforce mode.',
+    },
+    'microservice-origin': {
+        id: 'waf.recommendation.microservice_origin',
+        appShape: 'microservice-origin',
+        title: 'Microservice origin managed-rule baseline',
+        rules: [
+            'AWSManagedRulesCommonRuleSet',
+            'AWSManagedRulesKnownBadInputsRuleSet',
+            'AWSManagedRulesIPReputationList',
+        ],
+        settings: [
+            'Prefer signed origin authentication or an IP allowlist so direct-origin bypasses fail closed.',
+            'Add scoped rate_limit_rules for expensive service endpoints instead of only a global limit.',
+            'Enable WAF logging for CloudFront-scoped origins and correlate logs with origin auth failures.',
+        ],
+        rationale: 'Service origins need exploit-probe and reputation coverage, but broad bot or ATP controls may interfere with legitimate service clients.',
+        cost: 'Standard AWS WAF request/WCU costs; avoids paid bot/account-takeover add-ons by default.',
+        falsePositiveRisk: 'Low to medium. Reputation lists can block shared egress ranges used by partners; validate known service clients before enforce mode.',
+    },
+};
+function includesAny(text, tokens) {
+    return tokens.some((token) => text.includes(token));
+}
+function inferWafAppShape(policy) {
+    const metadata = (policy && policy.metadata) || {};
+    const text = [
+        policy && policy.project,
+        metadata.description,
+        metadata.app_shape,
+        metadata.appShape,
+    ].filter(Boolean).join(' ').toLowerCase();
+    if (includesAny(text, ['spa-static-site', 'spa / static', 'static site', 'single-page', 'spa'])) {
+        return 'spa-static-site';
+    }
+    if (includesAny(text, ['rest-api', 'rest api', 'json api'])) {
+        return 'rest-api';
+    }
+    if (includesAny(text, ['admin-panel', 'admin panel', 'back-office', 'ops dashboard'])) {
+        return 'admin-panel';
+    }
+    if (includesAny(text, ['microservice-origin', 'microservice origin', 'service-to-service'])) {
+        return 'microservice-origin';
+    }
+    const routes = Array.isArray(policy && policy.routes) ? policy.routes : [];
+    const originAuth = policy && policy.origin && policy.origin.auth;
+    if (originAuth)
+        return 'microservice-origin';
+    if (routes.some((route) => route && route.auth_gate && route.auth_gate.type === 'jwt')) {
+        return 'rest-api';
+    }
+    if (routes.some((route) => {
+        const gateType = route && route.auth_gate && route.auth_gate.type;
+        const prefixes = route && route.match && Array.isArray(route.match.path_prefixes)
+            ? route.match.path_prefixes
+            : [];
+        return (gateType === 'static_token' || gateType === 'basic_auth') &&
+            prefixes.some((prefix) => typeof prefix === 'string' && (prefix === '/' || prefix.includes('admin')));
+    })) {
+        return 'admin-panel';
+    }
+    const methods = Array.isArray(policy && policy.request && policy.request.allow_methods)
+        ? policy.request.allow_methods.map((m) => String(m).toUpperCase()).sort()
+        : [];
+    if (methods.length > 0 && methods.every((method) => method === 'GET' || method === 'HEAD')) {
+        return 'spa-static-site';
+    }
+    if (methods.includes('OPTIONS') || (policy && policy.response_headers && policy.response_headers.cors)) {
+        return 'rest-api';
+    }
+    return 'unknown';
+}
+function cloudflareSupportForRules(rules) {
+    const { classifyManagedRule } = require(path.join(pkgRoot, 'scripts', 'lib', 'cloudflare-waf-parity.js'));
+    const notes = [];
+    let support = 'supported';
+    for (const rule of rules) {
+        const entry = classifyManagedRule(rule);
+        if (entry.status === 'unsupported') {
+            support = 'unsupported';
+        }
+        else if (entry.status === 'approximate' && support !== 'unsupported') {
+            support = 'partial';
+        }
+        if (entry.status !== 'equivalent') {
+            const target = entry.cloudflare && entry.cloudflare.rulesetName
+                ? entry.cloudflare.rulesetName
+                : 'no direct Cloudflare ruleset target';
+            notes.push(`${rule}: ${entry.status} on Cloudflare (${target}).`);
+        }
+    }
+    return { support, notes };
+}
+function buildWafRecommendation(template, policy) {
+    const managed = policy && policy.firewall && policy.firewall.waf && Array.isArray(policy.firewall.waf.managed_rules)
+        ? policy.firewall.waf.managed_rules
+        : [];
+    const configuredRules = template.rules.filter((rule) => managed.includes(rule));
+    const missingRules = template.rules.filter((rule) => !managed.includes(rule));
+    const cloudflare = cloudflareSupportForRules(template.rules);
+    return Object.assign({}, template, {
+        targetSupport: {
+            aws: 'supported',
+            cloudflare: cloudflare.support,
+        },
+        configuredRules,
+        missingRules,
+        alreadySatisfied: missingRules.length === 0,
+        notes: cloudflare.notes,
+    });
+}
+function buildWafRecommendations(policy, policyPath, target) {
+    const inferredAppShape = inferWafAppShape(policy);
+    const templates = inferredAppShape === 'unknown'
+        ? Object.values(WAF_RECOMMENDATION_TEMPLATES)
+        : [WAF_RECOMMENDATION_TEMPLATES[inferredAppShape]];
+    const recommendations = templates.map((template) => buildWafRecommendation(template, policy));
+    return {
+        policyPath,
+        target,
+        inferredAppShape,
+        readOnly: true,
+        recommendations,
+    };
+}
 function weakWafSeverity(options) {
     return options.failOnWeakWafBaseline ? 'fail' : 'warn';
 }
@@ -811,13 +993,31 @@ function printReadinessReport(report) {
     console.log(`Readiness: ${report.status.toUpperCase()} (target=${report.target}, policy=${report.policyPath})`);
     if (report.findings.length === 0) {
         console.log('[OK] No production readiness findings.');
-        return;
     }
-    for (const finding of report.findings) {
-        const marker = finding.severity === 'fail' ? 'FAIL' : 'WARN';
-        const stream = finding.severity === 'fail' ? console.error : console.warn;
-        stream(`[${marker}] ${finding.id}: ${finding.detail}`);
-        stream(`       ${finding.recommendation}`);
+    else {
+        for (const finding of report.findings) {
+            const marker = finding.severity === 'fail' ? 'FAIL' : 'WARN';
+            const stream = finding.severity === 'fail' ? console.error : console.warn;
+            stream(`[${marker}] ${finding.id}: ${finding.detail}`);
+            stream(`       ${finding.recommendation}`);
+        }
+    }
+    const waf = report.wafRecommendations;
+    if (waf && Array.isArray(waf.recommendations) && waf.recommendations.length > 0) {
+        console.log('');
+        console.log(`WAF recommendations: inferred_app_shape=${waf.inferredAppShape}, read_only=${waf.readOnly}`);
+        for (const rec of waf.recommendations) {
+            console.log(`- ${rec.id}: ${rec.title}`);
+            console.log(`  Target support: aws=${rec.targetSupport.aws}, cloudflare=${rec.targetSupport.cloudflare}`);
+            console.log(`  Recommended managed rules: ${rec.rules.join(', ')}`);
+            console.log(`  Missing managed rules: ${rec.missingRules.length > 0 ? rec.missingRules.join(', ') : 'none'}`);
+            console.log(`  Related settings: ${rec.settings.join('; ')}`);
+            console.log(`  Rationale: ${rec.rationale}`);
+            console.log(`  Cost: ${rec.cost}`);
+            console.log(`  False-positive risk: ${rec.falsePositiveRisk}`);
+            if (rec.notes.length > 0)
+                console.log(`  Target notes: ${rec.notes.join(' ')}`);
+        }
     }
 }
 function renderAwsDeploymentWorkflow() {
@@ -1395,6 +1595,7 @@ program
         }
     }
     let policy = null;
+    let wafRecommendations = null;
     const lint = lintPolicy({ policyPath, pkgRoot, env: process.env });
     lint.errors.forEach((error) => findings.push(readinessFinding('fail', 'policy.lint.error', error, 'Fix policy validation before production release.')));
     if (lint.policy && typeof lint.policy === 'object') {
@@ -1402,6 +1603,7 @@ program
         findings.push(...evaluateReadiness(policy, target, lint.warnings, {
             failOnWeakWafBaseline: Boolean(opts.failOnWeakWafBaseline),
         }));
+        wafRecommendations = buildWafRecommendations(policy, policyPath, target);
     }
     const failCount = findings.filter((f) => f.severity === 'fail').length;
     const warnCount = findings.filter((f) => f.severity === 'warn').length;
@@ -1419,6 +1621,7 @@ program
         exitCode,
         summary: { fail: failCount, warn: warnCount },
         findings,
+        wafRecommendations,
     };
     if (opts.report) {
         const reportPath = path.isAbsolute(opts.report) ? opts.report : path.join(cwd, opts.report);

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -127,6 +127,8 @@ npx cdn-security readiness --report readiness-report.json
 
 starter policy はローカルで使えるままにしつつ、本番 CI では弱い WAF posture を止めたい場合は `--fail-on-weak-waf-baseline` を使います。この flag は WAF baseline finding を `fail` に昇格します。対象は WAF 設定なし、rate limit なし、AWS managed rule の signal coverage 不足、`firewall.waf.scope: CLOUDFRONT` で CloudFront WAF logging が無効な場合です。
 
+readiness report には read-only の `wafRecommendations` も含まれます。この engine は policy から `spa-static-site`、`rest-api`、`admin-panel`、`microservice-origin` の posture を推定し、managed WAF rule group と関連設定を、rationale、cost notes、false-positive notes、AWS / Cloudflare target support 付きで提案します。policy は変更しません。推奨の適用は別 change として手動で行ってください。
+
 ## `capabilities`
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,6 +127,8 @@ Exit code is `1` when any finding has severity `fail`. With `--strict`, warning 
 
 Use `--fail-on-weak-waf-baseline` for production CI when starter policies should remain usable locally but weak WAF posture must stop a release. The flag promotes WAF baseline findings to `fail`, including missing WAF config, missing rate limits, missing AWS managed-rule signal coverage, and missing CloudFront WAF logging when `firewall.waf.scope: CLOUDFRONT`.
 
+Readiness reports also include read-only `wafRecommendations`. The engine infers `spa-static-site`, `rest-api`, `admin-panel`, or `microservice-origin` posture from the policy and suggests managed WAF rule groups plus related settings with rationale, cost notes, false-positive notes, and AWS/Cloudflare target support. It never mutates the policy; apply recommendations manually in a follow-up change.
+
 ## `capabilities`
 
 ```bash

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -128,6 +128,57 @@ firewall:
     managed_rules:
       - AWSManagedRulesCommonRuleSet
 `;
+const REST_RECOMMENDATION_POLICY = `
+version: 1
+project: recommendation-rest-api
+metadata:
+  risk_level: balanced
+  description: "REST API protected by CDN security framework."
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, POST, OPTIONS]
+response_headers:
+  hsts: "max-age=31536000"
+  csp_public: "default-src 'none'; frame-ancestors 'none'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie]
+`;
+const MALFORMED_PREFIX_RECOMMENDATION_POLICY = `
+version: 1
+project: malformed-admin-prefix
+metadata:
+  risk_level: balanced
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, POST]
+routes:
+  - name: admin
+    match:
+      path_prefixes: ["/admin", 7]
+    auth_gate:
+      type: static_token
+      header: x-edge-token
+      token_env: EDGE_ADMIN_TOKEN
+response_headers:
+  hsts: "max-age=31536000"
+  csp_public: "default-src 'self'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
 function tmpProject(yamlBody) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
     const policyDir = path.join(tmp, 'policy');
@@ -946,6 +997,111 @@ test('CLI authoring DX: readiness reports target-specific unsupported controls',
         assert.strictEqual(cloudflare.status, 0, cloudflare.stderr);
         const cloudflareReport = JSON.parse(cloudflare.stdout);
         assert.ok(!cloudflareReport.findings.some((finding) => finding.id.startsWith('target.aws.')));
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('CLI authoring DX: readiness emits read-only WAF recommendations with rationale', () => {
+    const ctx = tmpProject(REST_RECOMMENDATION_POLICY);
+    try {
+        const before = fs.readFileSync(ctx.policyPath, 'utf8');
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const result = spawnSync(process.execPath, [
+            cli, 'readiness',
+            '-p', ctx.policyPath,
+            '--target', 'aws',
+            '--json',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 0, `readiness failed: ${result.stderr}`);
+        assert.strictEqual(fs.readFileSync(ctx.policyPath, 'utf8'), before, 'readiness must not mutate policy files');
+        const report = JSON.parse(result.stdout);
+        assert.strictEqual(report.wafRecommendations.readOnly, true);
+        assert.strictEqual(report.wafRecommendations.inferredAppShape, 'rest-api');
+        const rec = report.wafRecommendations.recommendations[0];
+        assert.strictEqual(rec.id, 'waf.recommendation.rest_api');
+        assert.strictEqual(rec.targetSupport.aws, 'supported');
+        assert.strictEqual(rec.targetSupport.cloudflare, 'partial');
+        assert.ok(rec.missingRules.includes('AWSManagedRulesKnownBadInputsRuleSet'));
+        assert.ok(rec.missingRules.includes('AWSManagedRulesSQLiRuleSet'));
+        assert.ok(rec.missingRules.includes('AWSManagedRulesIPReputationList'));
+        assert.ok(rec.settings.some((setting) => setting.includes('rate_limit_rules')));
+        assert.ok(/JSON APIs/.test(rec.rationale));
+        assert.ok(/costs/i.test(rec.cost));
+        assert.ok(/SQLi/.test(rec.falsePositiveRisk));
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('CLI authoring DX: WAF recommendations infer all built-in archetype shapes', () => {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const archetypes = [
+        'spa-static-site',
+        'rest-api',
+        'admin-panel',
+        'microservice-origin',
+    ];
+    for (const shape of archetypes) {
+        const result = spawnSync(process.execPath, [
+            cli, 'readiness',
+            '-p', path.join(repoRoot, 'policy', 'archetypes', `${shape}.yml`),
+            '--target', 'aws',
+            '--json',
+        ], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            env: Object.assign({}, process.env, {
+                EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+                ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+            }),
+        });
+        assert.strictEqual(result.status, 0, `${shape} readiness failed: ${result.stderr}`);
+        const report = JSON.parse(result.stdout);
+        assert.strictEqual(report.wafRecommendations.inferredAppShape, shape);
+        assert.strictEqual(report.wafRecommendations.recommendations.length, 1);
+        const rec = report.wafRecommendations.recommendations[0];
+        assert.strictEqual(rec.appShape, shape);
+        assert.ok(rec.rationale);
+        assert.ok(rec.cost);
+        assert.ok(rec.falsePositiveRisk);
+        if (shape === 'admin-panel') {
+            assert.strictEqual(rec.targetSupport.cloudflare, 'unsupported');
+            assert.ok(/paid/.test(rec.cost));
+            assert.ok(rec.rules.includes('AWSManagedRulesBotControlRuleSet'));
+            assert.ok(rec.rules.includes('AWSManagedRulesATPRuleSet'));
+        }
+    }
+});
+test('CLI authoring DX: WAF recommendation inference does not mask lint errors', () => {
+    const ctx = tmpProject(MALFORMED_PREFIX_RECOMMENDATION_POLICY);
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const result = spawnSync(process.execPath, [
+            cli, 'readiness',
+            '-p', ctx.policyPath,
+            '--target', 'aws',
+            '--json',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env: Object.assign({}, process.env, {
+                EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+            }),
+        });
+        assert.strictEqual(result.status, 1);
+        assert.doesNotThrow(() => JSON.parse(result.stdout));
+        const report = JSON.parse(result.stdout);
+        assert.ok(report.findings.some((finding) => finding.id === 'policy.lint.error' &&
+            /path_prefixes/.test(finding.detail)));
+        assert.strictEqual(report.wafRecommendations.inferredAppShape, 'admin-panel');
     }
     finally {
         ctx.cleanup();

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -957,6 +957,29 @@ type ReadinessEvaluationOptions = {
   failOnWeakWafBaseline?: boolean;
 };
 
+type WafAppShape = 'spa-static-site' | 'rest-api' | 'admin-panel' | 'microservice-origin' | 'unknown';
+type WafTargetSupport = 'supported' | 'partial' | 'unsupported';
+type WafRecommendationTemplate = {
+  id: string;
+  appShape: Exclude<WafAppShape, 'unknown'>;
+  title: string;
+  rules: string[];
+  settings: string[];
+  rationale: string;
+  cost: string;
+  falsePositiveRisk: string;
+};
+type WafRecommendation = WafRecommendationTemplate & {
+  targetSupport: {
+    aws: WafTargetSupport;
+    cloudflare: WafTargetSupport;
+  };
+  configuredRules: string[];
+  missingRules: string[];
+  alreadySatisfied: boolean;
+  notes: string[];
+};
+
 function readinessFinding(
   severity: ReadinessSeverity,
   id: string,
@@ -964,6 +987,194 @@ function readinessFinding(
   recommendation: string
 ): ReadinessFinding {
   return { severity, id, detail, recommendation };
+}
+
+const WAF_RECOMMENDATION_TEMPLATES: Record<Exclude<WafAppShape, 'unknown'>, WafRecommendationTemplate> = {
+  'spa-static-site': {
+    id: 'waf.recommendation.spa_static_site',
+    appShape: 'spa-static-site',
+    title: 'SPA/static site managed-rule baseline',
+    rules: [
+      'AWSManagedRulesCommonRuleSet',
+      'AWSManagedRulesKnownBadInputsRuleSet',
+      'AWSManagedRulesIPReputationList',
+    ],
+    settings: [
+      'Keep request.allow_methods to GET/HEAD for static assets.',
+      'Use a global WAF rate limit around 2000 requests per 5 minutes per IP, then tune from logs.',
+      'Enable WAF logging when scope=CLOUDFRONT before production release.',
+    ],
+    rationale: 'Static sites mostly need traversal, scanner, XSS/cache-poisoning, and known-bad source coverage without heavy auth-specific managed rules.',
+    cost: 'Standard AWS WAF request/WCU costs; no BotControl or ATP paid add-on in this baseline.',
+    falsePositiveRisk: 'Low to medium. KnownBadInputs/OWASP-style rules can catch unusual asset paths, so monitor before enforcing on legacy static content.',
+  },
+  'rest-api': {
+    id: 'waf.recommendation.rest_api',
+    appShape: 'rest-api',
+    title: 'REST API managed-rule baseline',
+    rules: [
+      'AWSManagedRulesCommonRuleSet',
+      'AWSManagedRulesKnownBadInputsRuleSet',
+      'AWSManagedRulesSQLiRuleSet',
+      'AWSManagedRulesIPReputationList',
+    ],
+    settings: [
+      'Add scoped rate_limit_rules for auth, write-heavy, or expensive API paths.',
+      'Keep CORS origins explicit; do not rely on WAF rules to compensate for wildcard credentials.',
+      'Enable WAF logging for CloudFront-scoped APIs before production release.',
+    ],
+    rationale: 'JSON APIs need injection and scanner coverage plus SQLi signatures and reputation filtering, especially on write/query endpoints.',
+    cost: 'Standard AWS WAF request/WCU costs; SQLi adds WCU pressure but avoids BotControl/ATP paid add-ons.',
+    falsePositiveRisk: 'Medium. SQLi signatures can flag unusual query DSLs or search syntax; start in count/monitor mode for affected routes.',
+  },
+  'admin-panel': {
+    id: 'waf.recommendation.admin_panel',
+    appShape: 'admin-panel',
+    title: 'Admin panel managed-rule baseline',
+    rules: [
+      'AWSManagedRulesCommonRuleSet',
+      'AWSManagedRulesKnownBadInputsRuleSet',
+      'AWSManagedRulesIPReputationList',
+      'AWSManagedRulesAnonymousIpList',
+      'AWSManagedRulesBotControlRuleSet',
+      'AWSManagedRulesATPRuleSet',
+    ],
+    settings: [
+      'Use a low global WAF rate limit and a stricter scoped login/admin rate_limit_rule.',
+      'Require WAF logging and redaction for authorization, cookie, and x-api-key fields.',
+      'Combine managed rules with route auth, IP allowlists, VPN, or SSO where possible.',
+    ],
+    rationale: 'Admin panels are high-value targets for credential stuffing, bot traffic, anonymizers, and exploit probes, so stronger managed signals are justified.',
+    cost: 'Higher. BotControl and ATP are paid AWS managed protections and add operational tuning cost.',
+    falsePositiveRisk: 'Medium to high. Bot and ATP controls can challenge or block automation; allowlist known internal tooling before enforce mode.',
+  },
+  'microservice-origin': {
+    id: 'waf.recommendation.microservice_origin',
+    appShape: 'microservice-origin',
+    title: 'Microservice origin managed-rule baseline',
+    rules: [
+      'AWSManagedRulesCommonRuleSet',
+      'AWSManagedRulesKnownBadInputsRuleSet',
+      'AWSManagedRulesIPReputationList',
+    ],
+    settings: [
+      'Prefer signed origin authentication or an IP allowlist so direct-origin bypasses fail closed.',
+      'Add scoped rate_limit_rules for expensive service endpoints instead of only a global limit.',
+      'Enable WAF logging for CloudFront-scoped origins and correlate logs with origin auth failures.',
+    ],
+    rationale: 'Service origins need exploit-probe and reputation coverage, but broad bot or ATP controls may interfere with legitimate service clients.',
+    cost: 'Standard AWS WAF request/WCU costs; avoids paid bot/account-takeover add-ons by default.',
+    falsePositiveRisk: 'Low to medium. Reputation lists can block shared egress ranges used by partners; validate known service clients before enforce mode.',
+  },
+};
+
+function includesAny(text: string, tokens: string[]): boolean {
+  return tokens.some((token) => text.includes(token));
+}
+
+function inferWafAppShape(policy: any): WafAppShape {
+  const metadata = (policy && policy.metadata) || {};
+  const text = [
+    policy && policy.project,
+    metadata.description,
+    metadata.app_shape,
+    metadata.appShape,
+  ].filter(Boolean).join(' ').toLowerCase();
+  if (includesAny(text, ['spa-static-site', 'spa / static', 'static site', 'single-page', 'spa'])) {
+    return 'spa-static-site';
+  }
+  if (includesAny(text, ['rest-api', 'rest api', 'json api'])) {
+    return 'rest-api';
+  }
+  if (includesAny(text, ['admin-panel', 'admin panel', 'back-office', 'ops dashboard'])) {
+    return 'admin-panel';
+  }
+  if (includesAny(text, ['microservice-origin', 'microservice origin', 'service-to-service'])) {
+    return 'microservice-origin';
+  }
+
+  const routes = Array.isArray(policy && policy.routes) ? policy.routes : [];
+  const originAuth = policy && policy.origin && policy.origin.auth;
+  if (originAuth) return 'microservice-origin';
+  if (routes.some((route: any) => route && route.auth_gate && route.auth_gate.type === 'jwt')) {
+    return 'rest-api';
+  }
+  if (routes.some((route: any) => {
+    const gateType = route && route.auth_gate && route.auth_gate.type;
+    const prefixes = route && route.match && Array.isArray(route.match.path_prefixes)
+      ? route.match.path_prefixes
+      : [];
+    return (gateType === 'static_token' || gateType === 'basic_auth') &&
+      prefixes.some((prefix: unknown) => typeof prefix === 'string' && (prefix === '/' || prefix.includes('admin')));
+  })) {
+    return 'admin-panel';
+  }
+
+  const methods = Array.isArray(policy && policy.request && policy.request.allow_methods)
+    ? policy.request.allow_methods.map((m: string) => String(m).toUpperCase()).sort()
+    : [];
+  if (methods.length > 0 && methods.every((method: string) => method === 'GET' || method === 'HEAD')) {
+    return 'spa-static-site';
+  }
+  if (methods.includes('OPTIONS') || (policy && policy.response_headers && policy.response_headers.cors)) {
+    return 'rest-api';
+  }
+  return 'unknown';
+}
+
+function cloudflareSupportForRules(rules: string[]): { support: WafTargetSupport; notes: string[] } {
+  const { classifyManagedRule } = require(path.join(pkgRoot, 'scripts', 'lib', 'cloudflare-waf-parity.js'));
+  const notes: string[] = [];
+  let support: WafTargetSupport = 'supported';
+  for (const rule of rules) {
+    const entry = classifyManagedRule(rule);
+    if (entry.status === 'unsupported') {
+      support = 'unsupported';
+    } else if (entry.status === 'approximate' && support !== 'unsupported') {
+      support = 'partial';
+    }
+    if (entry.status !== 'equivalent') {
+      const target = entry.cloudflare && entry.cloudflare.rulesetName
+        ? entry.cloudflare.rulesetName
+        : 'no direct Cloudflare ruleset target';
+      notes.push(`${rule}: ${entry.status} on Cloudflare (${target}).`);
+    }
+  }
+  return { support, notes };
+}
+
+function buildWafRecommendation(template: WafRecommendationTemplate, policy: any): WafRecommendation {
+  const managed = policy && policy.firewall && policy.firewall.waf && Array.isArray(policy.firewall.waf.managed_rules)
+    ? policy.firewall.waf.managed_rules
+    : [];
+  const configuredRules = template.rules.filter((rule) => managed.includes(rule));
+  const missingRules = template.rules.filter((rule) => !managed.includes(rule));
+  const cloudflare = cloudflareSupportForRules(template.rules);
+  return Object.assign({}, template, {
+    targetSupport: {
+      aws: 'supported' as WafTargetSupport,
+      cloudflare: cloudflare.support,
+    },
+    configuredRules,
+    missingRules,
+    alreadySatisfied: missingRules.length === 0,
+    notes: cloudflare.notes,
+  });
+}
+
+function buildWafRecommendations(policy: any, policyPath: string, target: string) {
+  const inferredAppShape = inferWafAppShape(policy);
+  const templates = inferredAppShape === 'unknown'
+    ? Object.values(WAF_RECOMMENDATION_TEMPLATES)
+    : [WAF_RECOMMENDATION_TEMPLATES[inferredAppShape]];
+  const recommendations = templates.map((template) => buildWafRecommendation(template, policy));
+  return {
+    policyPath,
+    target,
+    inferredAppShape,
+    readOnly: true,
+    recommendations,
+  };
 }
 
 function weakWafSeverity(options: ReadinessEvaluationOptions): ReadinessSeverity {
@@ -1157,13 +1368,29 @@ function printReadinessReport(report: any): void {
   console.log(`Readiness: ${report.status.toUpperCase()} (target=${report.target}, policy=${report.policyPath})`);
   if (report.findings.length === 0) {
     console.log('[OK] No production readiness findings.');
-    return;
+  } else {
+    for (const finding of report.findings) {
+      const marker = finding.severity === 'fail' ? 'FAIL' : 'WARN';
+      const stream = finding.severity === 'fail' ? console.error : console.warn;
+      stream(`[${marker}] ${finding.id}: ${finding.detail}`);
+      stream(`       ${finding.recommendation}`);
+    }
   }
-  for (const finding of report.findings) {
-    const marker = finding.severity === 'fail' ? 'FAIL' : 'WARN';
-    const stream = finding.severity === 'fail' ? console.error : console.warn;
-    stream(`[${marker}] ${finding.id}: ${finding.detail}`);
-    stream(`       ${finding.recommendation}`);
+  const waf = report.wafRecommendations;
+  if (waf && Array.isArray(waf.recommendations) && waf.recommendations.length > 0) {
+    console.log('');
+    console.log(`WAF recommendations: inferred_app_shape=${waf.inferredAppShape}, read_only=${waf.readOnly}`);
+    for (const rec of waf.recommendations) {
+      console.log(`- ${rec.id}: ${rec.title}`);
+      console.log(`  Target support: aws=${rec.targetSupport.aws}, cloudflare=${rec.targetSupport.cloudflare}`);
+      console.log(`  Recommended managed rules: ${rec.rules.join(', ')}`);
+      console.log(`  Missing managed rules: ${rec.missingRules.length > 0 ? rec.missingRules.join(', ') : 'none'}`);
+      console.log(`  Related settings: ${rec.settings.join('; ')}`);
+      console.log(`  Rationale: ${rec.rationale}`);
+      console.log(`  Cost: ${rec.cost}`);
+      console.log(`  False-positive risk: ${rec.falsePositiveRisk}`);
+      if (rec.notes.length > 0) console.log(`  Target notes: ${rec.notes.join(' ')}`);
+    }
   }
 }
 
@@ -1772,6 +1999,7 @@ program
     }
 
     let policy = null;
+    let wafRecommendations = null;
     const lint = lintPolicy({ policyPath, pkgRoot, env: process.env });
     lint.errors.forEach((error: string) => findings.push(readinessFinding(
       'fail',
@@ -1784,6 +2012,7 @@ program
       findings.push(...evaluateReadiness(policy, target, lint.warnings, {
         failOnWeakWafBaseline: Boolean(opts.failOnWeakWafBaseline),
       }));
+      wafRecommendations = buildWafRecommendations(policy, policyPath, target);
     }
 
     const failCount = findings.filter((f) => f.severity === 'fail').length;
@@ -1802,6 +2031,7 @@ program
       exitCode,
       summary: { fail: failCount, warn: warnCount },
       findings,
+      wafRecommendations,
     };
 
     if (opts.report) {

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -135,6 +135,59 @@ firewall:
       - AWSManagedRulesCommonRuleSet
 `;
 
+const REST_RECOMMENDATION_POLICY = `
+version: 1
+project: recommendation-rest-api
+metadata:
+  risk_level: balanced
+  description: "REST API protected by CDN security framework."
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, POST, OPTIONS]
+response_headers:
+  hsts: "max-age=31536000"
+  csp_public: "default-src 'none'; frame-ancestors 'none'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+    logging:
+      enabled: true
+      destination_arn_env: WAF_LOG_DESTINATION_ARN
+      redacted_fields: [authorization, cookie]
+`;
+
+const MALFORMED_PREFIX_RECOMMENDATION_POLICY = `
+version: 1
+project: malformed-admin-prefix
+metadata:
+  risk_level: balanced
+defaults:
+  mode: enforce
+request:
+  allow_methods: [GET, POST]
+routes:
+  - name: admin
+    match:
+      path_prefixes: ["/admin", 7]
+    auth_gate:
+      type: static_token
+      header: x-edge-token
+      token_env: EDGE_ADMIN_TOKEN
+response_headers:
+  hsts: "max-age=31536000"
+  csp_public: "default-src 'self'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    rate_limit: 1000
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
+
 function tmpProject(yamlBody: string) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
   const policyDir = path.join(tmp, 'policy');
@@ -1003,6 +1056,114 @@ test('CLI authoring DX: readiness reports target-specific unsupported controls',
     assert.strictEqual(cloudflare.status, 0, cloudflare.stderr);
     const cloudflareReport = JSON.parse(cloudflare.stdout);
     assert.ok(!cloudflareReport.findings.some((finding: any) => finding.id.startsWith('target.aws.')));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('CLI authoring DX: readiness emits read-only WAF recommendations with rationale', () => {
+  const ctx = tmpProject(REST_RECOMMENDATION_POLICY);
+  try {
+    const before = fs.readFileSync(ctx.policyPath, 'utf8');
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'readiness',
+      '-p', ctx.policyPath,
+      '--target', 'aws',
+      '--json',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 0, `readiness failed: ${result.stderr}`);
+    assert.strictEqual(fs.readFileSync(ctx.policyPath, 'utf8'), before, 'readiness must not mutate policy files');
+    const report = JSON.parse(result.stdout);
+    assert.strictEqual(report.wafRecommendations.readOnly, true);
+    assert.strictEqual(report.wafRecommendations.inferredAppShape, 'rest-api');
+    const rec = report.wafRecommendations.recommendations[0];
+    assert.strictEqual(rec.id, 'waf.recommendation.rest_api');
+    assert.strictEqual(rec.targetSupport.aws, 'supported');
+    assert.strictEqual(rec.targetSupport.cloudflare, 'partial');
+    assert.ok(rec.missingRules.includes('AWSManagedRulesKnownBadInputsRuleSet'));
+    assert.ok(rec.missingRules.includes('AWSManagedRulesSQLiRuleSet'));
+    assert.ok(rec.missingRules.includes('AWSManagedRulesIPReputationList'));
+    assert.ok(rec.settings.some((setting: string) => setting.includes('rate_limit_rules')));
+    assert.ok(/JSON APIs/.test(rec.rationale));
+    assert.ok(/costs/i.test(rec.cost));
+    assert.ok(/SQLi/.test(rec.falsePositiveRisk));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('CLI authoring DX: WAF recommendations infer all built-in archetype shapes', () => {
+  const { spawnSync } = require('child_process');
+  const cli = path.join(repoRoot, 'bin', 'cli.js');
+  const archetypes = [
+    'spa-static-site',
+    'rest-api',
+    'admin-panel',
+    'microservice-origin',
+  ];
+  for (const shape of archetypes) {
+    const result: any = spawnSync(process.execPath, [
+      cli, 'readiness',
+      '-p', path.join(repoRoot, 'policy', 'archetypes', `${shape}.yml`),
+      '--target', 'aws',
+      '--json',
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.status, 0, `${shape} readiness failed: ${result.stderr}`);
+    const report = JSON.parse(result.stdout);
+    assert.strictEqual(report.wafRecommendations.inferredAppShape, shape);
+    assert.strictEqual(report.wafRecommendations.recommendations.length, 1);
+    const rec = report.wafRecommendations.recommendations[0];
+    assert.strictEqual(rec.appShape, shape);
+    assert.ok(rec.rationale);
+    assert.ok(rec.cost);
+    assert.ok(rec.falsePositiveRisk);
+    if (shape === 'admin-panel') {
+      assert.strictEqual(rec.targetSupport.cloudflare, 'unsupported');
+      assert.ok(/paid/.test(rec.cost));
+      assert.ok(rec.rules.includes('AWSManagedRulesBotControlRuleSet'));
+      assert.ok(rec.rules.includes('AWSManagedRulesATPRuleSet'));
+    }
+  }
+});
+
+test('CLI authoring DX: WAF recommendation inference does not mask lint errors', () => {
+  const ctx = tmpProject(MALFORMED_PREFIX_RECOMMENDATION_POLICY);
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'readiness',
+      '-p', ctx.policyPath,
+      '--target', 'aws',
+      '--json',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.status, 1);
+    assert.doesNotThrow(() => JSON.parse(result.stdout));
+    const report = JSON.parse(result.stdout);
+    assert.ok(report.findings.some((finding: any) =>
+      finding.id === 'policy.lint.error' &&
+      /path_prefixes/.test(finding.detail)
+    ));
+    assert.strictEqual(report.wafRecommendations.inferredAppShape, 'admin-panel');
   } finally {
     ctx.cleanup();
   }


### PR DESCRIPTION
## Summary
- add read-only `wafRecommendations` to `readiness` reports for SPA/static site, REST API, admin panel, and microservice-origin policies
- include managed rule suggestions, related settings, rationale, cost notes, false-positive notes, and AWS/Cloudflare target support
- infer app shape from archetype metadata, project/description, routes, methods, CORS, and origin auth without mutating policy files

## Tests
- `npm run test:unit`
- `npm run lint:policy:ci`
- `npm run typecheck:cli-strict`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run build:test-fixtures`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run test:runtime`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy node bin/cli.js readiness -p policy/archetypes/admin-panel.yml --target aws`

Closes #130
