### PR TITLE
feat(cli): add semantic policy diff review mode

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -246,6 +246,440 @@ function explainPolicy(policy) {
     lines.push(`Response headers: ${headerKeys.join(', ') || '(defaults only)'}`);
     return lines;
 }
+function asStringArray(value) {
+    if (!Array.isArray(value))
+        return [];
+    return value
+        .map((item) => String(item))
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .sort();
+}
+function asPolicyObject(policy) {
+    return (policy && typeof policy === 'object') ? policy : {};
+}
+function getPolicyPathValue(policy, path) {
+    let current = asPolicyObject(policy);
+    for (const part of path.split('.')) {
+        if (!current || typeof current !== 'object' || !Object.prototype.hasOwnProperty.call(current, part)) {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+}
+function toSortedString(value) {
+    if (value === undefined || value === null)
+        return 'unset';
+    if (Array.isArray(value))
+        return value.map((item) => String(item)).sort().join(', ');
+    if (typeof value === 'object')
+        return JSON.stringify(value);
+    return String(value);
+}
+function buildPolicyFinding(findings, params) {
+    findings.push({
+        id: params.id,
+        category: params.category,
+        severity: params.severity,
+        summary: params.summary,
+        before: toSortedString(params.before),
+        after: toSortedString(params.after),
+        impact: params.impact,
+    });
+}
+function cspRiskScore(csp) {
+    const normalized = csp.toLowerCase();
+    let score = 0;
+    if (normalized.includes("'unsafe-inline'"))
+        score += 3;
+    if (normalized.includes("'unsafe-eval'"))
+        score += 3;
+    if (/\s'\*'/.test(normalized))
+        score += 2;
+    if (!/default-src/.test(normalized))
+        score += 1;
+    return score;
+}
+function routeSignature(route, index) {
+    const routeName = typeof route?.name === 'string' ? route.name : `route-${index}`;
+    const prefixes = asStringArray(route?.match?.path_prefixes).join('|') || '<no-path-prefixes>';
+    const methods = asStringArray(route?.match?.methods).join('|') || '<all-methods>';
+    return `${routeName}|${prefixes}|${methods}`;
+}
+function collectAuthGates(policy) {
+    const routes = Array.isArray(policy?.routes) ? policy.routes : [];
+    const map = new Map();
+    for (let i = 0; i < routes.length; i += 1) {
+        const route = routes[i];
+        const gate = route && route.auth_gate;
+        map.set(routeSignature(route, i), gate && typeof gate.type === 'string' ? gate.type : 'none');
+    }
+    return map;
+}
+function compareCapabilitySupportFindings(baseline, candidate, baselinePolicyPath, candidatePolicyPath, targetList, findings) {
+    const statusRank = {
+        supported: 3,
+        partial: 2,
+        'warning-only': 1,
+        unsupported: 0,
+    };
+    for (const deployTarget of targetList) {
+        const baselineEvaluation = evaluatePolicyCapabilities(baseline, baselinePolicyPath, deployTarget);
+        const candidateEvaluation = evaluatePolicyCapabilities(candidate, candidatePolicyPath, deployTarget);
+        const baselineMap = new Map();
+        const candidateMap = new Map();
+        const policyIds = new Set();
+        for (const control of baselineEvaluation.configuredControls) {
+            baselineMap.set(control.id, control.targetSupport[deployTarget]);
+            policyIds.add(control.id);
+        }
+        for (const control of candidateEvaluation.configuredControls) {
+            candidateMap.set(control.id, control.targetSupport[deployTarget]);
+            policyIds.add(control.id);
+        }
+        for (const id of policyIds) {
+            const before = baselineMap.get(id);
+            const after = candidateMap.get(id);
+            if (!before || !after || before === after)
+                continue;
+            const beforeScore = statusRank[before];
+            const afterScore = statusRank[after];
+            buildPolicyFinding(findings, {
+                id: `capability.${deployTarget}.${id}`,
+                category: 'Capability support',
+                severity: afterScore < beforeScore ? 'medium' : 'low',
+                summary: `Target support for ${id} changed from ${before} to ${after} on ${deployTarget}.`,
+                before,
+                after,
+                impact: afterScore < beforeScore
+                    ? 'Target-specific behavior may become non-enforcing or unsupported.'
+                    : 'Target support improvement reduces operational surprises.',
+            });
+        }
+    }
+}
+function compareSecurityPostureFindings(baselinePolicy, candidatePolicy, baselinePolicyPath, candidatePolicyPath, target) {
+    const findings = [];
+    const baseline = asPolicyObject(baselinePolicy);
+    const candidate = asPolicyObject(candidatePolicy);
+    const baselineMethods = asStringArray(getPolicyPathValue(baseline, 'request.allow_methods'));
+    const candidateMethods = asStringArray(getPolicyPathValue(candidate, 'request.allow_methods'));
+    const baselineMethodSet = new Set(baselineMethods);
+    const candidateMethodSet = new Set(candidateMethods);
+    for (const method of baselineMethods) {
+        if (!candidateMethodSet.has(method)) {
+            buildPolicyFinding(findings, {
+                id: `request.allow_methods.removed.${method}`,
+                category: 'Request posture',
+                severity: 'low',
+                summary: `Method ${method} was removed from allowlist.`,
+                before: baselineMethods,
+                after: candidateMethods,
+                impact: 'Stricter method allowlist reduces exposed surface.',
+            });
+        }
+    }
+    for (const method of candidateMethods) {
+        if (!baselineMethodSet.has(method)) {
+            buildPolicyFinding(findings, {
+                id: `request.allow_methods.added.${method}`,
+                category: 'Request posture',
+                severity: method === 'TRACE' ? 'high' : 'medium',
+                summary: `Method ${method} was added to allowlist.`,
+                before: baselineMethods,
+                after: candidateMethods,
+                impact: method === 'TRACE'
+                    ? 'TRACE expands attack surface and should usually be blocked in production.'
+                    : 'Broader allowed methods can increase risk of unauthorized state changes.',
+            });
+        }
+    }
+    const baselineLimits = asPolicyObject(getPolicyPathValue(baseline, 'request.limits'));
+    const candidateLimits = asPolicyObject(getPolicyPathValue(candidate, 'request.limits'));
+    const limitKeys = new Set([
+        ...Object.keys(baselineLimits),
+        ...Object.keys(candidateLimits),
+    ]);
+    for (const key of limitKeys) {
+        const baselineValue = baselineLimits[key];
+        const candidateValue = candidateLimits[key];
+        const hasBaseline = typeof baselineValue === 'number';
+        const hasCandidate = typeof candidateValue === 'number';
+        if (!hasBaseline && hasCandidate) {
+            buildPolicyFinding(findings, {
+                id: `request.limits.added.${key}`,
+                category: 'Request posture',
+                severity: 'low',
+                summary: `New request limit ${key} was added.`,
+                before: undefined,
+                after: candidateValue,
+                impact: 'Added request limit usually improves enforcement posture.',
+            });
+            continue;
+        }
+        if (hasBaseline && !hasCandidate) {
+            buildPolicyFinding(findings, {
+                id: `request.limits.removed.${key}`,
+                category: 'Request posture',
+                severity: 'medium',
+                summary: `Request limit ${key} was removed.`,
+                before: baselineValue,
+                after: undefined,
+                impact: 'Removing request limits can increase DoS/abuse exposure.',
+            });
+            continue;
+        }
+        if (hasBaseline && hasCandidate && candidateValue !== baselineValue) {
+            const isRelaxed = candidateValue > baselineValue;
+            buildPolicyFinding(findings, {
+                id: `request.limits.changed.${key}`,
+                category: 'Request posture',
+                severity: isRelaxed ? 'medium' : 'low',
+                summary: `Request limit ${key} changed from ${baselineValue} to ${candidateValue}.`,
+                before: baselineValue,
+                after: candidateValue,
+                impact: isRelaxed
+                    ? 'Higher limits may allow heavier requests and slower filtering at edge.'
+                    : 'Lower limits usually tighten request validation.',
+            });
+        }
+    }
+    const baselineMode = String(getPolicyPathValue(baseline, 'defaults.mode') || 'enforce');
+    const candidateMode = String(getPolicyPathValue(candidate, 'defaults.mode') || 'enforce');
+    if (baselineMode !== candidateMode) {
+        const severity = candidateMode === 'enforce' ? 'low' : 'medium';
+        buildPolicyFinding(findings, {
+            id: 'defaults.mode',
+            category: 'Operations',
+            severity,
+            summary: `defaults.mode changed from ${baselineMode} to ${candidateMode}.`,
+            before: baselineMode,
+            after: candidateMode,
+            impact: candidateMode === 'enforce'
+                ? 'Switching to enforce tightens production behavior.'
+                : 'Switching away from enforce introduces report/monitor behavior and less blocking.',
+        });
+    }
+    const riskRank = { permissive: 1, balanced: 2, strict: 3 };
+    const baselineRisk = String(getPolicyPathValue(baseline, 'metadata.risk_level') || 'unset');
+    const candidateRisk = String(getPolicyPathValue(candidate, 'metadata.risk_level') || 'unset');
+    if (baselineRisk !== candidateRisk) {
+        const baselineWeight = riskRank[baselineRisk] || 2;
+        const candidateWeight = riskRank[candidateRisk] || 2;
+        const isLoosened = candidateWeight < baselineWeight;
+        buildPolicyFinding(findings, {
+            id: 'metadata.risk_level',
+            category: 'Policy posture',
+            severity: isLoosened ? 'medium' : 'low',
+            summary: `metadata.risk_level changed from ${baselineRisk} to ${candidateRisk}.`,
+            before: baselineRisk,
+            after: candidateRisk,
+            impact: isLoosened
+                ? 'Lowering risk level typically relaxes policy intent and may increase permissiveness.'
+                : 'Raising risk level usually indicates stricter posture.',
+        });
+    }
+    const cspHeaders = ['csp_public', 'csp_admin', 'csp_report_only'];
+    for (const header of cspHeaders) {
+        const before = String(getPolicyPathValue(baseline, `response_headers.${header}`) || '');
+        const after = String(getPolicyPathValue(candidate, `response_headers.${header}`) || '');
+        if (before === after)
+            continue;
+        if (!before) {
+            buildPolicyFinding(findings, {
+                id: `response_headers.${header}.added`,
+                category: 'Response security',
+                severity: 'low',
+                summary: `${header} was added to response policy.`,
+                before: '(missing)',
+                after,
+                impact: 'Adding CSP reduces browser-side attack surface.',
+            });
+            continue;
+        }
+        if (!after) {
+            buildPolicyFinding(findings, {
+                id: `response_headers.${header}.removed`,
+                category: 'Response security',
+                severity: 'medium',
+                summary: `${header} was removed from response policy.`,
+                before,
+                after: '(missing)',
+                impact: 'Removing CSP can broaden script/iframe and injection risk.',
+            });
+            continue;
+        }
+        const beforeRisk = cspRiskScore(before);
+        const afterRisk = cspRiskScore(after);
+        if (afterRisk > beforeRisk) {
+            buildPolicyFinding(findings, {
+                id: `response_headers.${header}.weakened`,
+                category: 'Response security',
+                severity: 'medium',
+                summary: `${header} became more permissive.`,
+                before,
+                after,
+                impact: 'Relaxed CSP directives can increase CSP bypass opportunities.',
+            });
+        }
+        else if (afterRisk < beforeRisk) {
+            buildPolicyFinding(findings, {
+                id: `response_headers.${header}.tightened`,
+                category: 'Response security',
+                severity: 'low',
+                summary: `${header} became stricter.`,
+                before,
+                after,
+                impact: 'Stronger CSP directives reduce XSS/preload risk.',
+            });
+        }
+    }
+    const baselineManagedRules = new Set(asStringArray(getPolicyPathValue(baseline, 'firewall.waf.managed_rules')).map((rule) => rule.toLowerCase()));
+    const candidateManagedRules = new Set(asStringArray(getPolicyPathValue(candidate, 'firewall.waf.managed_rules')).map((rule) => rule.toLowerCase()));
+    for (const rule of baselineManagedRules) {
+        if (!candidateManagedRules.has(rule)) {
+            buildPolicyFinding(findings, {
+                id: `firewall.waf.managed_rules.removed.${rule}`,
+                category: 'WAF',
+                severity: 'high',
+                summary: `Managed rule ${rule} was removed.`,
+                before: [...baselineManagedRules].sort().join(','),
+                after: [...candidateManagedRules].sort().join(','),
+                impact: 'Removing managed WAF rules can weaken managed protections.',
+            });
+        }
+    }
+    for (const rule of candidateManagedRules) {
+        if (!baselineManagedRules.has(rule)) {
+            buildPolicyFinding(findings, {
+                id: `firewall.waf.managed_rules.added.${rule}`,
+                category: 'WAF',
+                severity: 'low',
+                summary: `Managed rule ${rule} was added.`,
+                before: [...baselineManagedRules].sort().join(','),
+                after: [...candidateManagedRules].sort().join(','),
+                impact: 'Adding managed rules generally improves attack coverage.',
+            });
+        }
+    }
+    const baseAuthBySignature = collectAuthGates(baseline);
+    const candidateAuthBySignature = collectAuthGates(candidate);
+    for (const [signature, baseType] of baseAuthBySignature.entries()) {
+        const candidateType = candidateAuthBySignature.get(signature);
+        if (candidateType === undefined)
+            continue;
+        if (baseType === candidateType)
+            continue;
+        const isRegression = baseType !== 'none' && candidateType === 'none';
+        buildPolicyFinding(findings, {
+            id: `routes.auth_gate.changed.${signature}`,
+            category: 'Authentication',
+            severity: isRegression ? 'high' : 'low',
+            summary: `Route ${signature} auth gate changed from ${baseType} to ${candidateType}.`,
+            before: baseType,
+            after: candidateType,
+            impact: isRegression
+                ? 'Authentication gate removal can expose protected routes to unauthorized traffic.'
+                : 'Auth gate strengthening can reduce unauthenticated access.',
+        });
+    }
+    const gqlKeys = new Set([
+        ...Object.keys(asPolicyObject(getPolicyPathValue(baseline, 'request.graphql_guard') || {})),
+        ...Object.keys(asPolicyObject(getPolicyPathValue(candidate, 'request.graphql_guard') || {})),
+    ]);
+    const baseGraphql = asPolicyObject(getPolicyPathValue(baseline, 'request.graphql_guard') || {});
+    const candidateGraphql = asPolicyObject(getPolicyPathValue(candidate, 'request.graphql_guard') || {});
+    if (gqlKeys.size > 0) {
+        const baseEnabled = Boolean(baseGraphql.enabled);
+        const candidateEnabled = Boolean(candidateGraphql.enabled);
+        if (baseEnabled !== candidateEnabled) {
+            buildPolicyFinding(findings, {
+                id: 'request.graphql_guard.enabled',
+                category: 'Edge controls',
+                severity: !candidateEnabled ? 'medium' : 'low',
+                summary: `GraphQL guard ${candidateEnabled ? 'enabled' : 'disabled'}.`,
+                before: baseEnabled,
+                after: candidateEnabled,
+                impact: candidateEnabled
+                    ? 'GraphQL guard adds request-body-aware abuse protection.'
+                    : 'Disabling GraphQL guard removes a body-based abuse control.',
+            });
+        }
+        for (const key of gqlKeys) {
+            const baselineValue = baseGraphql[key];
+            const candidateValue = candidateGraphql[key];
+            if (baselineValue === candidateValue)
+                continue;
+            if (typeof baselineValue === 'number' && typeof candidateValue === 'number' && key.includes('limit')) {
+                const isRelaxed = candidateValue > baselineValue;
+                buildPolicyFinding(findings, {
+                    id: `request.graphql_guard.${key}`,
+                    category: 'Edge controls',
+                    severity: isRelaxed ? 'medium' : 'low',
+                    summary: `GraphQL guard ${key} changed from ${baselineValue} to ${candidateValue}.`,
+                    before: baselineValue,
+                    after: candidateValue,
+                    impact: isRelaxed
+                        ? 'Higher GraphQL guard thresholds increase body complexity and runtime cost.'
+                        : 'Lower limits can reduce exploitability from expensive queries.',
+                });
+            }
+        }
+    }
+    if (target === 'all' || target === 'aws' || target === 'cloudflare') {
+        const targetList = target === 'all'
+            ? ['aws', 'cloudflare']
+            : [target];
+        compareCapabilitySupportFindings(baseline, candidate, baselinePolicyPath, candidatePolicyPath, targetList, findings);
+    }
+    const dedupedFindings = [];
+    const seen = new Set();
+    for (const finding of findings) {
+        const key = `${finding.category}:${finding.id}`;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        dedupedFindings.push(finding);
+    }
+    return {
+        generatedAt: new Date().toISOString(),
+        mode: 'semantic',
+        baselinePolicyPath,
+        candidatePolicyPath,
+        target,
+        findings: dedupedFindings,
+        summary: {
+            total: dedupedFindings.length,
+            high: dedupedFindings.filter((finding) => finding.severity === 'high').length,
+            medium: dedupedFindings.filter((finding) => finding.severity === 'medium').length,
+            low: dedupedFindings.filter((finding) => finding.severity === 'low').length,
+            info: dedupedFindings.filter((finding) => finding.severity === 'info').length,
+            regressions: dedupedFindings.filter((finding) => finding.severity === 'high' || finding.severity === 'medium').length,
+            improvements: dedupedFindings.filter((finding) => finding.severity === 'low' || finding.severity === 'info').length,
+        },
+    };
+}
+function printPolicyDiffReport(mode, jsonOutput) {
+    if (jsonOutput) {
+        console.log(JSON.stringify(mode, null, 2));
+        return mode.summary.regressions > 0 ? 1 : 0;
+    }
+    console.log(`Semantic policy diff: ${mode.baselinePolicyPath} -> ${mode.candidatePolicyPath} (target=${mode.target})`);
+    if (mode.findings.length === 0) {
+        console.log('[OK] No semantic posture regressions detected.');
+        return 0;
+    }
+    console.log(`Summary: regressions=${mode.summary.regressions}, improvements=${mode.summary.improvements}, total=${mode.summary.total}`);
+    for (const finding of mode.findings) {
+        console.log(`[${finding.severity.toUpperCase()}] ${finding.id} (${finding.category})`);
+        console.log(`  summary: ${finding.summary}`);
+        console.log(`  before: ${finding.before}`);
+        console.log(`  after: ${finding.after}`);
+        console.log(`  impact: ${finding.impact}`);
+    }
+    return mode.summary.regressions > 0 ? 1 : 0;
+}
 const CAPABILITY_TARGETS = [
     { key: 'cloudfront_functions', label: 'AWS CloudFront Functions' },
     { key: 'lambda_edge', label: 'AWS Lambda@Edge' },
@@ -1489,13 +1923,44 @@ program
 });
 program
     .command('diff')
-    .description('Compare current generated output with a fresh build from policy')
+    .description('Compare generated output or policy posture changes between two policies')
     .option('-p, --policy <path>', 'Policy file path (default: policy/security.yml or policy/base.yml)', null)
     .option('-o, --out-dir <dir>', 'Existing output directory to compare', 'dist')
-    .option('-t, --target <platform>', 'Target platform (aws | cloudflare)', 'aws')
+    .option('-t, --target <platform>', 'Target platform (aws | cloudflare | all)', 'aws')
+    .option('--baseline <path>', 'Baseline policy file path for semantic diff', null)
+    .option('--semantic', 'Show security posture findings instead of file artifact diff')
+    .option('--json', 'Output semantic policy diff as JSON')
     .action((opts) => {
     const cwd = process.cwd();
     const policyPath = resolvePolicyPath(cwd, opts.policy);
+    const target = opts.target === 'all' || opts.target === 'aws' || opts.target === 'cloudflare'
+        ? opts.target
+        : 'aws';
+    if (opts.semantic) {
+        const baselinePolicyPath = opts.baseline
+            ? (path.isAbsolute(opts.baseline) ? opts.baseline : path.join(cwd, opts.baseline))
+            : path.join(cwd, 'policy', 'base.yml');
+        if (!fs.existsSync(baselinePolicyPath)) {
+            console.error('[ERROR] Baseline policy file not found:', baselinePolicyPath);
+            process.exit(1);
+        }
+        if (!fs.existsSync(policyPath)) {
+            console.error('[ERROR] Candidate policy file not found:', policyPath);
+            process.exit(1);
+        }
+        try {
+            const baselinePolicy = loadPolicyDocument(baselinePolicyPath);
+            const candidatePolicy = loadPolicyDocument(policyPath);
+            const report = compareSecurityPostureFindings(baselinePolicy, candidatePolicy, baselinePolicyPath, policyPath, target);
+            const exitCode = printPolicyDiffReport(report, !!opts.json);
+            process.exit(exitCode);
+        }
+        catch (e) {
+            console.error('[ERROR] Failed to evaluate policy diff:', e.message);
+            process.exit(1);
+        }
+        return;
+    }
     const existingOutDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
     const tmpRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-diff-'));
     const freshOutDir = path.join(tmpRoot, 'dist');
@@ -1504,7 +1969,7 @@ program
         const result = compile({
             policyPath,
             outDir: freshOutDir,
-            target: opts.target,
+            target,
             cwd,
             pkgRoot,
             env: process.env,

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -18,7 +18,7 @@ npx cdn-security <subcommand> [options]
 | `capabilities` | target 対応状況の matrix を表示し、任意で policy control を target 別に評価。 |
 | `deploy-template` | AWS / Cloudflare の artifact deployment 用 GitHub Actions workflow template を生成。 |
 | `explain` | レビューやオンボーディング向けにポリシーの要点を表示。 |
-| `diff` | 現在の `dist/` と再生成結果を比較し、drift があれば失敗。 |
+| `diff` | 生成物の drift または policy posture の差分を比較。 |
 | `migrate` | スキーマのバージョン間マイグレーション（現状 v1 のみの stub）。 |
 
 ---
@@ -165,9 +165,18 @@ npx cdn-security explain --policy policy/security.yml
 npx cdn-security diff
 npx cdn-security diff --target cloudflare
 npx cdn-security diff --out-dir dist
+npx cdn-security diff --semantic --baseline policy/security.previous.yml --policy policy/security.yml --target aws
 ```
 
 選択したポリシーを一時ディレクトリへコンパイルし、現在の出力ツリーと比較します。`MISSING`、`EXTRA`、`CHANGED` を表示し、生成物が古い場合は exit `1` で失敗します。
+
+`--semantic` を付けると、2 つの policy ファイルを比較して posture 変更を表示します。PR レビュー向けに、認証ゲート削除、許可メソッド追加、CSP 弱体化、WAF ルール変更、ターゲット別の capability 差分を検知できます。
+
+- `--policy` は比較対象（候補）policy のパスです。省略時は `policy/security.yml`（無ければ `policy/base.yml`）。
+- `--baseline` は比較元 policy のパスです。省略時は `policy/base.yml` を使用します。
+- `--target` は `aws` / `cloudflare` / `all` を指定し、ターゲット別の capability 変化を表示します。
+- `--json` は posture diff を JSON 出力します。
+- `--semantic` を付けると drift 比較ではなく posture 比較になります。
 
 ## `migrate`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ npx cdn-security <subcommand> [options]
 | `capabilities` | Print target support matrix and optionally evaluate policy controls against a target. |
 | `deploy-template` | Generate GitHub Actions workflow templates for AWS and Cloudflare artifact deployment. |
 | `explain` | Print a concise policy posture summary for review and onboarding. |
-| `diff` | Compare generated output against the current `dist/` tree and fail on drift. |
+| `diff` | Compare generated output drift or semantic policy posture changes between policies. |
 | `migrate` | Migrate a policy file between schema versions (stub — v1 is the only shipped version today). |
 
 ---
@@ -165,9 +165,18 @@ Prints the policy's schema, mode, allowed methods, request limits, host and rout
 npx cdn-security diff
 npx cdn-security diff --target cloudflare
 npx cdn-security diff --out-dir dist
+npx cdn-security diff --semantic --baseline policy/security.previous.yml --policy policy/security.yml --target aws
 ```
 
 Compiles the selected policy to a temporary directory and compares it with the current output tree. It prints `MISSING`, `EXTRA`, and `CHANGED` entries and exits `1` when generated artifacts are out of date.
+
+With `--semantic`, `diff` compares two policy files and reports posture changes instead of file-level drift. The command is useful for PR review: it can detect removed auth gates, added permissive methods, CSP risk changes, WAF rule changes, and target-specific capability support shifts.
+
+- `--policy` sets the candidate policy path (default: `policy/security.yml` or fallback `policy/base.yml`).
+- `--baseline` sets the baseline policy path. If omitted, `policy/base.yml` is used.
+- `--target` accepts `aws`, `cloudflare`, or `all` to check target-specific capability support.
+- `--json` emits semantic findings as machine-readable JSON.
+- `--semantic` switches from drift mode to security-posture mode.
 
 ## `migrate`
 

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -128,6 +128,39 @@ firewall:
     managed_rules:
       - AWSManagedRulesCommonRuleSet
 `;
+const DIFF_SEMANTIC_BASELINE = `
+version: 1
+project: diff-test
+request:
+  allow_methods: [GET, POST]
+  limits:
+    max_query_length: 1024
+response_headers:
+  csp_public: "default-src 'self'; frame-ancestors 'none'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesIPReputationList
+`;
+const DIFF_SEMANTIC_CANDIDATE = `
+version: 1
+project: diff-test
+request:
+  allow_methods: [GET, POST, TRACE]
+  limits:
+    max_query_length: 4096
+defaults:
+  mode: monitor
+response_headers:
+  csp_public: "default-src *"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
 function tmpProject(yamlBody) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
     const policyDir = path.join(tmp, 'policy');
@@ -923,6 +956,60 @@ test('CLI authoring DX: diff detects generated output drift', () => {
         ], { cwd: ctx.tmp, encoding: 'utf8', env });
         assert.strictEqual(dirtyDiff.status, 1);
         assert.ok(/CHANGED edge\/viewer-request\.js/.test(dirtyDiff.stdout));
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('CLI authoring DX: diff --semantic surfaces posture drift', () => {
+    const ctx = tmpProject(DIFF_SEMANTIC_BASELINE);
+    const baselinePath = path.join(ctx.tmp, 'policy', 'baseline.yml');
+    fs.writeFileSync(baselinePath, DIFF_SEMANTIC_BASELINE, 'utf8');
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const env = Object.assign({}, process.env, {
+        EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+    });
+    try {
+        const cleanSemantic = spawnSync(process.execPath, [
+            cli, 'diff',
+            '--semantic',
+            '--baseline', baselinePath,
+            '--policy', ctx.policyPath,
+            '--target', 'aws',
+            '--json',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env,
+        });
+        assert.strictEqual(cleanSemantic.status, 0, `semantic diff baseline compare should be clean: ${cleanSemantic.stderr}`);
+        const noChangeReport = JSON.parse(cleanSemantic.stdout);
+        assert.strictEqual(noChangeReport.mode, 'semantic');
+        assert.ok(noChangeReport.findings.length >= 0);
+        assert.strictEqual(noChangeReport.summary.total, 0);
+        fs.writeFileSync(ctx.policyPath, DIFF_SEMANTIC_CANDIDATE, 'utf8');
+        const semanticDrift = spawnSync(process.execPath, [
+            cli, 'diff',
+            '--semantic',
+            '--baseline', baselinePath,
+            '--policy', ctx.policyPath,
+            '--target', 'aws',
+            '--json',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env,
+        });
+        assert.strictEqual(semanticDrift.status, 1, `semantic diff should detect posture regression: ${semanticDrift.stderr}`);
+        const report = JSON.parse(semanticDrift.stdout);
+        assert.strictEqual(report.mode, 'semantic');
+        assert.strictEqual(report.target, 'aws');
+        assert.ok(report.summary.regressions >= 1);
+        assert.ok(Array.isArray(report.findings));
+        assert.ok(report.findings.some((finding) => finding.id === 'request.allow_methods.added.TRACE'));
+        assert.ok(report.findings.some((finding) => finding.id === 'firewall.waf.managed_rules.removed.awsmanagedrulesipreputationlist'));
     }
     finally {
         ctx.cleanup();

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -90,6 +90,9 @@ type DiffOptions = {
   policy?: string | null;
   outDir: string;
   target: string;
+  baseline?: string | null;
+  semantic?: boolean;
+  json?: boolean;
 };
 
 type StarterAnswers = {
@@ -432,6 +435,507 @@ function explainPolicy(policy: any): string[] {
   lines.push(`Response headers: ${headerKeys.join(', ') || '(defaults only)'}`);
   return lines;
 }
+
+type PolicyDiffSeverity = 'high' | 'medium' | 'low' | 'info';
+type PolicyDiffFinding = {
+  id: string;
+  category: string;
+  severity: PolicyDiffSeverity;
+  summary: string;
+  before: string;
+  after: string;
+  impact: string;
+};
+
+type PolicyDiffReport = {
+  generatedAt: string;
+  mode: 'semantic';
+  baselinePolicyPath: string;
+  candidatePolicyPath: string;
+  target: 'aws' | 'cloudflare' | 'all';
+  findings: PolicyDiffFinding[];
+  summary: {
+    total: number;
+    high: number;
+    medium: number;
+    low: number;
+    info: number;
+    regressions: number;
+    improvements: number;
+  };
+};
+
+function asStringArray(value: any): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => String(item))
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+function asPolicyObject(policy: any): Record<string, any> {
+  return (policy && typeof policy === 'object') ? policy : {};
+}
+
+function getPolicyPathValue(policy: any, path: string): any {
+  let current = asPolicyObject(policy);
+  for (const part of path.split('.')) {
+    if (!current || typeof current !== 'object' || !Object.prototype.hasOwnProperty.call(current, part)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return current;
+}
+
+function toSortedString(value: any): string {
+  if (value === undefined || value === null) return 'unset';
+  if (Array.isArray(value)) return value.map((item) => String(item)).sort().join(', ');
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function buildPolicyFinding(
+  findings: PolicyDiffFinding[],
+  params: {
+    id: string;
+    category: string;
+    severity: PolicyDiffSeverity;
+    summary: string;
+    before: any;
+    after: any;
+    impact: string;
+  }
+) {
+  findings.push({
+    id: params.id,
+    category: params.category,
+    severity: params.severity,
+    summary: params.summary,
+    before: toSortedString(params.before),
+    after: toSortedString(params.after),
+    impact: params.impact,
+  });
+}
+
+function cspRiskScore(csp: string): number {
+  const normalized = csp.toLowerCase();
+  let score = 0;
+  if (normalized.includes("'unsafe-inline'")) score += 3;
+  if (normalized.includes("'unsafe-eval'")) score += 3;
+  if (/\s'\*'/.test(normalized)) score += 2;
+  if (!/default-src/.test(normalized)) score += 1;
+  return score;
+}
+
+type RouteAuthMap = Map<string, string>;
+
+function routeSignature(route: any, index: number): string {
+  const routeName = typeof route?.name === 'string' ? route.name : `route-${index}`;
+  const prefixes = asStringArray(route?.match?.path_prefixes).join('|') || '<no-path-prefixes>';
+  const methods = asStringArray(route?.match?.methods).join('|') || '<all-methods>';
+  return `${routeName}|${prefixes}|${methods}`;
+}
+
+function collectAuthGates(policy: any): RouteAuthMap {
+  const routes = Array.isArray(policy?.routes) ? policy.routes : [];
+  const map = new Map<string, string>();
+  for (let i = 0; i < routes.length; i += 1) {
+    const route = routes[i];
+    const gate = route && route.auth_gate;
+    map.set(routeSignature(route, i), gate && typeof gate.type === 'string' ? gate.type : 'none');
+  }
+  return map;
+}
+
+function compareCapabilitySupportFindings(
+  baseline: any,
+  candidate: any,
+  baselinePolicyPath: string,
+  candidatePolicyPath: string,
+  targetList: Array<'aws' | 'cloudflare'>,
+  findings: PolicyDiffFinding[]
+) {
+  const statusRank: Record<CapabilityStatus, number> = {
+    supported: 3,
+    partial: 2,
+    'warning-only': 1,
+    unsupported: 0,
+  };
+
+  for (const deployTarget of targetList) {
+    const baselineEvaluation = evaluatePolicyCapabilities(baseline, baselinePolicyPath, deployTarget);
+    const candidateEvaluation = evaluatePolicyCapabilities(candidate, candidatePolicyPath, deployTarget);
+
+    const baselineMap = new Map<string, CapabilityStatus>();
+    const candidateMap = new Map<string, CapabilityStatus>();
+    const policyIds = new Set<string>();
+
+    for (const control of baselineEvaluation.configuredControls) {
+      baselineMap.set(control.id, control.targetSupport[deployTarget]);
+      policyIds.add(control.id);
+    }
+    for (const control of candidateEvaluation.configuredControls) {
+      candidateMap.set(control.id, control.targetSupport[deployTarget]);
+      policyIds.add(control.id);
+    }
+
+    for (const id of policyIds) {
+      const before = baselineMap.get(id);
+      const after = candidateMap.get(id);
+      if (!before || !after || before === after) continue;
+      const beforeScore = statusRank[before];
+      const afterScore = statusRank[after];
+      buildPolicyFinding(findings, {
+        id: `capability.${deployTarget}.${id}`,
+        category: 'Capability support',
+        severity: afterScore < beforeScore ? 'medium' : 'low',
+        summary: `Target support for ${id} changed from ${before} to ${after} on ${deployTarget}.`,
+        before,
+        after,
+        impact: afterScore < beforeScore
+          ? 'Target-specific behavior may become non-enforcing or unsupported.'
+          : 'Target support improvement reduces operational surprises.',
+      });
+    }
+  }
+}
+
+function compareSecurityPostureFindings(
+  baselinePolicy: any,
+  candidatePolicy: any,
+  baselinePolicyPath: string,
+  candidatePolicyPath: string,
+  target: 'aws' | 'cloudflare' | 'all',
+): PolicyDiffReport {
+  const findings: PolicyDiffFinding[] = [];
+  const baseline = asPolicyObject(baselinePolicy);
+  const candidate = asPolicyObject(candidatePolicy);
+
+  const baselineMethods = asStringArray(getPolicyPathValue(baseline, 'request.allow_methods'));
+  const candidateMethods = asStringArray(getPolicyPathValue(candidate, 'request.allow_methods'));
+  const baselineMethodSet = new Set(baselineMethods);
+  const candidateMethodSet = new Set(candidateMethods);
+  for (const method of baselineMethods) {
+    if (!candidateMethodSet.has(method)) {
+      buildPolicyFinding(findings, {
+        id: `request.allow_methods.removed.${method}`,
+        category: 'Request posture',
+        severity: 'low',
+        summary: `Method ${method} was removed from allowlist.`,
+        before: baselineMethods,
+        after: candidateMethods,
+        impact: 'Stricter method allowlist reduces exposed surface.',
+      });
+    }
+  }
+  for (const method of candidateMethods) {
+    if (!baselineMethodSet.has(method)) {
+      buildPolicyFinding(findings, {
+        id: `request.allow_methods.added.${method}`,
+        category: 'Request posture',
+        severity: method === 'TRACE' ? 'high' : 'medium',
+        summary: `Method ${method} was added to allowlist.`,
+        before: baselineMethods,
+        after: candidateMethods,
+        impact: method === 'TRACE'
+          ? 'TRACE expands attack surface and should usually be blocked in production.'
+          : 'Broader allowed methods can increase risk of unauthorized state changes.',
+      });
+    }
+  }
+
+  const baselineLimits = asPolicyObject(getPolicyPathValue(baseline, 'request.limits'));
+  const candidateLimits = asPolicyObject(getPolicyPathValue(candidate, 'request.limits'));
+  const limitKeys = new Set<string>([
+    ...Object.keys(baselineLimits),
+    ...Object.keys(candidateLimits),
+  ]);
+  for (const key of limitKeys) {
+    const baselineValue = baselineLimits[key];
+    const candidateValue = candidateLimits[key];
+    const hasBaseline = typeof baselineValue === 'number';
+    const hasCandidate = typeof candidateValue === 'number';
+    if (!hasBaseline && hasCandidate) {
+      buildPolicyFinding(findings, {
+        id: `request.limits.added.${key}`,
+        category: 'Request posture',
+        severity: 'low',
+        summary: `New request limit ${key} was added.`,
+        before: undefined,
+        after: candidateValue,
+        impact: 'Added request limit usually improves enforcement posture.',
+      });
+      continue;
+    }
+    if (hasBaseline && !hasCandidate) {
+      buildPolicyFinding(findings, {
+        id: `request.limits.removed.${key}`,
+        category: 'Request posture',
+        severity: 'medium',
+        summary: `Request limit ${key} was removed.`,
+        before: baselineValue,
+        after: undefined,
+        impact: 'Removing request limits can increase DoS/abuse exposure.',
+      });
+      continue;
+    }
+    if (hasBaseline && hasCandidate && candidateValue !== baselineValue) {
+      const isRelaxed = candidateValue > baselineValue;
+      buildPolicyFinding(findings, {
+        id: `request.limits.changed.${key}`,
+        category: 'Request posture',
+        severity: isRelaxed ? 'medium' : 'low',
+        summary: `Request limit ${key} changed from ${baselineValue} to ${candidateValue}.`,
+        before: baselineValue,
+        after: candidateValue,
+        impact: isRelaxed
+          ? 'Higher limits may allow heavier requests and slower filtering at edge.'
+          : 'Lower limits usually tighten request validation.',
+      });
+    }
+  }
+
+  const baselineMode = String(getPolicyPathValue(baseline, 'defaults.mode') || 'enforce');
+  const candidateMode = String(getPolicyPathValue(candidate, 'defaults.mode') || 'enforce');
+  if (baselineMode !== candidateMode) {
+    const severity: PolicyDiffSeverity = candidateMode === 'enforce' ? 'low' : 'medium';
+    buildPolicyFinding(findings, {
+      id: 'defaults.mode',
+      category: 'Operations',
+      severity,
+      summary: `defaults.mode changed from ${baselineMode} to ${candidateMode}.`,
+      before: baselineMode,
+      after: candidateMode,
+      impact: candidateMode === 'enforce'
+        ? 'Switching to enforce tightens production behavior.'
+        : 'Switching away from enforce introduces report/monitor behavior and less blocking.',
+    });
+  }
+
+  const riskRank: Record<string, number> = { permissive: 1, balanced: 2, strict: 3 };
+  const baselineRisk = String(getPolicyPathValue(baseline, 'metadata.risk_level') || 'unset');
+  const candidateRisk = String(getPolicyPathValue(candidate, 'metadata.risk_level') || 'unset');
+  if (baselineRisk !== candidateRisk) {
+    const baselineWeight = riskRank[baselineRisk] || 2;
+    const candidateWeight = riskRank[candidateRisk] || 2;
+    const isLoosened = candidateWeight < baselineWeight;
+    buildPolicyFinding(findings, {
+      id: 'metadata.risk_level',
+      category: 'Policy posture',
+      severity: isLoosened ? 'medium' : 'low',
+      summary: `metadata.risk_level changed from ${baselineRisk} to ${candidateRisk}.`,
+      before: baselineRisk,
+      after: candidateRisk,
+      impact: isLoosened
+        ? 'Lowering risk level typically relaxes policy intent and may increase permissiveness.'
+        : 'Raising risk level usually indicates stricter posture.',
+    });
+  }
+
+  const cspHeaders = ['csp_public', 'csp_admin', 'csp_report_only'];
+  for (const header of cspHeaders) {
+    const before = String(getPolicyPathValue(baseline, `response_headers.${header}`) || '');
+    const after = String(getPolicyPathValue(candidate, `response_headers.${header}`) || '');
+    if (before === after) continue;
+    if (!before) {
+      buildPolicyFinding(findings, {
+        id: `response_headers.${header}.added`,
+        category: 'Response security',
+        severity: 'low',
+        summary: `${header} was added to response policy.`,
+        before: '(missing)',
+        after,
+        impact: 'Adding CSP reduces browser-side attack surface.',
+      });
+      continue;
+    }
+    if (!after) {
+      buildPolicyFinding(findings, {
+        id: `response_headers.${header}.removed`,
+        category: 'Response security',
+        severity: 'medium',
+        summary: `${header} was removed from response policy.`,
+        before,
+        after: '(missing)',
+        impact: 'Removing CSP can broaden script/iframe and injection risk.',
+      });
+      continue;
+    }
+    const beforeRisk = cspRiskScore(before);
+    const afterRisk = cspRiskScore(after);
+    if (afterRisk > beforeRisk) {
+      buildPolicyFinding(findings, {
+        id: `response_headers.${header}.weakened`,
+        category: 'Response security',
+        severity: 'medium',
+        summary: `${header} became more permissive.`,
+        before,
+        after,
+        impact: 'Relaxed CSP directives can increase CSP bypass opportunities.',
+      });
+    } else if (afterRisk < beforeRisk) {
+      buildPolicyFinding(findings, {
+        id: `response_headers.${header}.tightened`,
+        category: 'Response security',
+        severity: 'low',
+        summary: `${header} became stricter.`,
+        before,
+        after,
+        impact: 'Stronger CSP directives reduce XSS/preload risk.',
+      });
+    }
+  }
+
+  const baselineManagedRules = new Set(asStringArray(getPolicyPathValue(baseline, 'firewall.waf.managed_rules')).map((rule) => rule.toLowerCase()));
+  const candidateManagedRules = new Set(asStringArray(getPolicyPathValue(candidate, 'firewall.waf.managed_rules')).map((rule) => rule.toLowerCase()));
+  for (const rule of baselineManagedRules) {
+    if (!candidateManagedRules.has(rule)) {
+      buildPolicyFinding(findings, {
+        id: `firewall.waf.managed_rules.removed.${rule}`,
+        category: 'WAF',
+        severity: 'high',
+        summary: `Managed rule ${rule} was removed.`,
+        before: [...baselineManagedRules].sort().join(','),
+        after: [...candidateManagedRules].sort().join(','),
+        impact: 'Removing managed WAF rules can weaken managed protections.',
+      });
+    }
+  }
+  for (const rule of candidateManagedRules) {
+    if (!baselineManagedRules.has(rule)) {
+      buildPolicyFinding(findings, {
+        id: `firewall.waf.managed_rules.added.${rule}`,
+        category: 'WAF',
+        severity: 'low',
+        summary: `Managed rule ${rule} was added.`,
+        before: [...baselineManagedRules].sort().join(','),
+        after: [...candidateManagedRules].sort().join(','),
+        impact: 'Adding managed rules generally improves attack coverage.',
+      });
+    }
+  }
+
+  const baseAuthBySignature = collectAuthGates(baseline);
+  const candidateAuthBySignature = collectAuthGates(candidate);
+  for (const [signature, baseType] of baseAuthBySignature.entries()) {
+    const candidateType = candidateAuthBySignature.get(signature);
+    if (candidateType === undefined) continue;
+    if (baseType === candidateType) continue;
+    const isRegression = baseType !== 'none' && candidateType === 'none';
+    buildPolicyFinding(findings, {
+      id: `routes.auth_gate.changed.${signature}`,
+      category: 'Authentication',
+      severity: isRegression ? 'high' : 'low',
+      summary: `Route ${signature} auth gate changed from ${baseType} to ${candidateType}.`,
+      before: baseType,
+      after: candidateType,
+      impact: isRegression
+        ? 'Authentication gate removal can expose protected routes to unauthorized traffic.'
+        : 'Auth gate strengthening can reduce unauthenticated access.',
+    });
+  }
+
+  const gqlKeys = new Set<string>([
+    ...Object.keys(asPolicyObject(getPolicyPathValue(baseline, 'request.graphql_guard') || {})),
+    ...Object.keys(asPolicyObject(getPolicyPathValue(candidate, 'request.graphql_guard') || {})),
+  ]);
+  const baseGraphql = asPolicyObject(getPolicyPathValue(baseline, 'request.graphql_guard') || {});
+  const candidateGraphql = asPolicyObject(getPolicyPathValue(candidate, 'request.graphql_guard') || {});
+  if (gqlKeys.size > 0) {
+    const baseEnabled = Boolean(baseGraphql.enabled);
+    const candidateEnabled = Boolean(candidateGraphql.enabled);
+    if (baseEnabled !== candidateEnabled) {
+      buildPolicyFinding(findings, {
+        id: 'request.graphql_guard.enabled',
+        category: 'Edge controls',
+        severity: !candidateEnabled ? 'medium' : 'low',
+        summary: `GraphQL guard ${candidateEnabled ? 'enabled' : 'disabled'}.`,
+        before: baseEnabled,
+        after: candidateEnabled,
+        impact: candidateEnabled
+          ? 'GraphQL guard adds request-body-aware abuse protection.'
+          : 'Disabling GraphQL guard removes a body-based abuse control.',
+      });
+    }
+    for (const key of gqlKeys) {
+      const baselineValue = baseGraphql[key];
+      const candidateValue = candidateGraphql[key];
+      if (baselineValue === candidateValue) continue;
+      if (typeof baselineValue === 'number' && typeof candidateValue === 'number' && key.includes('limit')) {
+        const isRelaxed = candidateValue > baselineValue;
+        buildPolicyFinding(findings, {
+          id: `request.graphql_guard.${key}`,
+          category: 'Edge controls',
+          severity: isRelaxed ? 'medium' : 'low',
+          summary: `GraphQL guard ${key} changed from ${baselineValue} to ${candidateValue}.`,
+          before: baselineValue,
+          after: candidateValue,
+          impact: isRelaxed
+            ? 'Higher GraphQL guard thresholds increase body complexity and runtime cost.'
+            : 'Lower limits can reduce exploitability from expensive queries.',
+        });
+      }
+    }
+  }
+
+  if (target === 'all' || target === 'aws' || target === 'cloudflare') {
+    const targetList: Array<'aws' | 'cloudflare'> = target === 'all'
+      ? ['aws', 'cloudflare']
+      : [target];
+    compareCapabilitySupportFindings(baseline, candidate, baselinePolicyPath, candidatePolicyPath, targetList, findings);
+  }
+
+  const dedupedFindings: PolicyDiffFinding[] = [];
+  const seen = new Set<string>();
+  for (const finding of findings) {
+    const key = `${finding.category}:${finding.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dedupedFindings.push(finding);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'semantic',
+    baselinePolicyPath,
+    candidatePolicyPath,
+    target,
+    findings: dedupedFindings,
+    summary: {
+      total: dedupedFindings.length,
+      high: dedupedFindings.filter((finding) => finding.severity === 'high').length,
+      medium: dedupedFindings.filter((finding) => finding.severity === 'medium').length,
+      low: dedupedFindings.filter((finding) => finding.severity === 'low').length,
+      info: dedupedFindings.filter((finding) => finding.severity === 'info').length,
+      regressions: dedupedFindings.filter((finding) => finding.severity === 'high' || finding.severity === 'medium').length,
+      improvements: dedupedFindings.filter((finding) => finding.severity === 'low' || finding.severity === 'info').length,
+    },
+  };
+}
+
+function printPolicyDiffReport(mode: PolicyDiffReport, jsonOutput: boolean): number {
+  if (jsonOutput) {
+    console.log(JSON.stringify(mode, null, 2));
+    return mode.summary.regressions > 0 ? 1 : 0;
+  }
+  console.log(`Semantic policy diff: ${mode.baselinePolicyPath} -> ${mode.candidatePolicyPath} (target=${mode.target})`);
+  if (mode.findings.length === 0) {
+    console.log('[OK] No semantic posture regressions detected.');
+    return 0;
+  }
+  console.log(`Summary: regressions=${mode.summary.regressions}, improvements=${mode.summary.improvements}, total=${mode.summary.total}`);
+  for (const finding of mode.findings) {
+    console.log(`[${finding.severity.toUpperCase()}] ${finding.id} (${finding.category})`);
+    console.log(`  summary: ${finding.summary}`);
+    console.log(`  before: ${finding.before}`);
+    console.log(`  after: ${finding.after}`);
+    console.log(`  impact: ${finding.impact}`);
+  }
+  return mode.summary.regressions > 0 ? 1 : 0;
+}
+
 
 type CapabilityStatus = 'supported' | 'partial' | 'unsupported' | 'warning-only';
 type CapabilityTargetKey = 'cloudfront_functions' | 'lambda_edge' | 'cloudflare_workers' | 'terraform_waf';
@@ -1859,13 +2363,51 @@ program
 
 program
   .command('diff')
-  .description('Compare current generated output with a fresh build from policy')
+  .description('Compare generated output or policy posture changes between two policies')
   .option('-p, --policy <path>', 'Policy file path (default: policy/security.yml or policy/base.yml)', null)
   .option('-o, --out-dir <dir>', 'Existing output directory to compare', 'dist')
-  .option('-t, --target <platform>', 'Target platform (aws | cloudflare)', 'aws')
+  .option('-t, --target <platform>', 'Target platform (aws | cloudflare | all)', 'aws')
+  .option('--baseline <path>', 'Baseline policy file path for semantic diff', null)
+  .option('--semantic', 'Show security posture findings instead of file artifact diff')
+  .option('--json', 'Output semantic policy diff as JSON')
   .action((opts: DiffOptions) => {
     const cwd = process.cwd();
     const policyPath = resolvePolicyPath(cwd, opts.policy);
+    const target = opts.target === 'all' || opts.target === 'aws' || opts.target === 'cloudflare'
+      ? opts.target
+      : 'aws';
+
+    if (opts.semantic) {
+      const baselinePolicyPath = opts.baseline
+        ? (path.isAbsolute(opts.baseline) ? opts.baseline : path.join(cwd, opts.baseline))
+        : path.join(cwd, 'policy', 'base.yml');
+      if (!fs.existsSync(baselinePolicyPath)) {
+        console.error('[ERROR] Baseline policy file not found:', baselinePolicyPath);
+        process.exit(1);
+      }
+      if (!fs.existsSync(policyPath)) {
+        console.error('[ERROR] Candidate policy file not found:', policyPath);
+        process.exit(1);
+      }
+      try {
+        const baselinePolicy = loadPolicyDocument(baselinePolicyPath);
+        const candidatePolicy = loadPolicyDocument(policyPath);
+        const report = compareSecurityPostureFindings(
+          baselinePolicy,
+          candidatePolicy,
+          baselinePolicyPath,
+          policyPath,
+          target,
+        );
+        const exitCode = printPolicyDiffReport(report, !!opts.json);
+        process.exit(exitCode);
+      } catch (e: any) {
+        console.error('[ERROR] Failed to evaluate policy diff:', e.message);
+        process.exit(1);
+      }
+      return;
+    }
+
     const existingOutDir = path.isAbsolute(opts.outDir) ? opts.outDir : path.join(cwd, opts.outDir);
     const tmpRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-diff-'));
     const freshOutDir = path.join(tmpRoot, 'dist');
@@ -1874,7 +2416,7 @@ program
       const result = compile({
         policyPath,
         outDir: freshOutDir,
-        target: opts.target,
+        target,
         cwd,
         pkgRoot,
         env: process.env,

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -135,6 +135,41 @@ firewall:
       - AWSManagedRulesCommonRuleSet
 `;
 
+const DIFF_SEMANTIC_BASELINE = `
+version: 1
+project: diff-test
+request:
+  allow_methods: [GET, POST]
+  limits:
+    max_query_length: 1024
+response_headers:
+  csp_public: "default-src 'self'; frame-ancestors 'none'"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+      - AWSManagedRulesIPReputationList
+`;
+
+const DIFF_SEMANTIC_CANDIDATE = `
+version: 1
+project: diff-test
+request:
+  allow_methods: [GET, POST, TRACE]
+  limits:
+    max_query_length: 4096
+defaults:
+  mode: monitor
+response_headers:
+  csp_public: "default-src *"
+firewall:
+  waf:
+    scope: CLOUDFRONT
+    managed_rules:
+      - AWSManagedRulesCommonRuleSet
+`;
+
 function tmpProject(yamlBody: string) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
   const policyDir = path.join(tmp, 'policy');
@@ -964,6 +999,61 @@ test('CLI authoring DX: diff detects generated output drift', () => {
     ], { cwd: ctx.tmp, encoding: 'utf8', env });
     assert.strictEqual(dirtyDiff.status, 1);
     assert.ok(/CHANGED edge\/viewer-request\.js/.test(dirtyDiff.stdout));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('CLI authoring DX: diff --semantic surfaces posture drift', () => {
+  const ctx = tmpProject(DIFF_SEMANTIC_BASELINE);
+  const baselinePath = path.join(ctx.tmp, 'policy', 'baseline.yml');
+  fs.writeFileSync(baselinePath, DIFF_SEMANTIC_BASELINE, 'utf8');
+  const { spawnSync } = require('child_process');
+  const cli = path.join(repoRoot, 'bin', 'cli.js');
+  const env = Object.assign({}, process.env, {
+    EDGE_ADMIN_TOKEN: 'ci-build-token-not-for-deploy',
+    ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+  });
+  try {
+    const cleanSemantic: any = spawnSync(process.execPath, [
+      cli, 'diff',
+      '--semantic',
+      '--baseline', baselinePath,
+      '--policy', ctx.policyPath,
+      '--target', 'aws',
+      '--json',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env,
+    });
+    assert.strictEqual(cleanSemantic.status, 0, `semantic diff baseline compare should be clean: ${cleanSemantic.stderr}`);
+    const noChangeReport = JSON.parse(cleanSemantic.stdout);
+    assert.strictEqual(noChangeReport.mode, 'semantic');
+    assert.ok(noChangeReport.findings.length >= 0);
+    assert.strictEqual(noChangeReport.summary.total, 0);
+
+    fs.writeFileSync(ctx.policyPath, DIFF_SEMANTIC_CANDIDATE, 'utf8');
+    const semanticDrift: any = spawnSync(process.execPath, [
+      cli, 'diff',
+      '--semantic',
+      '--baseline', baselinePath,
+      '--policy', ctx.policyPath,
+      '--target', 'aws',
+      '--json',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env,
+    });
+    assert.strictEqual(semanticDrift.status, 1, `semantic diff should detect posture regression: ${semanticDrift.stderr}`);
+    const report = JSON.parse(semanticDrift.stdout);
+    assert.strictEqual(report.mode, 'semantic');
+    assert.strictEqual(report.target, 'aws');
+    assert.ok(report.summary.regressions >= 1);
+    assert.ok(Array.isArray(report.findings));
+    assert.ok(report.findings.some((finding: any) => finding.id === 'request.allow_methods.added.TRACE'));
+    assert.ok(report.findings.some((finding: any) => finding.id === 'firewall.waf.managed_rules.removed.awsmanagedrulesipreputationlist'));
   } finally {
     ctx.cleanup();
   }


### PR DESCRIPTION
## Problem
Issue #125 requested a semantic policy diff in `cdn-security diff` that reports meaningful security posture changes (allow methods, CSP changes, auth gate changes, WAF controls, target support shifts) rather than only generated file drift.

## What changed
- Added `--semantic`, `--baseline`, and `--json` options to `cdn-security diff`.
- In semantic mode, command now compares baseline and candidate policies (defaulting baseline to `policy/base.yml`) and emits posture findings in human-readable format.
- Implemented comparison coverage for request methods/limits, defaults/risk level, CSP risk changes, route auth gate changes, GraphQL guard toggles/limits, managed rule additions/removals, and target capability support deltas.
- Kept existing artifact drift behavior unchanged when `--semantic` is not set.
- Added CLI regression test for semantic diff (`src/scripts/programmatic-api-unit-tests.ts`) and mirrored compiled JS test artifact.
- Updated `docs/cli.md` and `docs/cli.ja.md` with semantic diff usage and option docs.

## Behavior after merge
- `npx cdn-security diff --semantic --baseline policy/base.yml --policy policy/security.yml` prints posture findings and exits non-zero on regressions.
- `--target aws|cloudflare|all` controls target-specific capability sections.
- `--json` returns machine-readable structured report suitable for CI bots/PR comments.

## Verification
- `npm install`
- `npm run build:ts`
- `node scripts/programmatic-api-unit-tests.js`

Output confirmed semantic diff test pass (`CLI authoring DX: diff --semantic surfaces posture drift`).

## Remaining risks / follow-up
- This is a rule-set-based heuristic diff; newly added schema fields may require follow-up updates to coverage.
- `--baseline` defaults to `policy/base.yml` when omitted; if required, stricter required-baseline validation can be added in a follow-up.

Closes #125
