### PR TITLE
feat(cli): add local policy playground for pass/block simulation

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,37 @@ const fs = require('fs');
 const { Command } = require('commander');
 const pkgRoot = path.resolve(__dirname, '..');
 const program = new Command();
+function isBlockedStatus(status) {
+    const numericStatus = Number(status);
+    return Number.isFinite(numericStatus) && numericStatus >= 400;
+}
+async function withMutedOutput(fn, condition) {
+    if (!condition) {
+        return await fn();
+    }
+    const stdoutWrite = process.stdout.write.bind(process.stdout);
+    const stderrWrite = process.stderr.write.bind(process.stderr);
+    const consoleLog = console.log;
+    const consoleWarn = console.warn;
+    const consoleError = console.error;
+    const mutedWrite = () => true;
+    const mutedConsole = () => undefined;
+    process.stdout.write = mutedWrite;
+    process.stderr.write = mutedWrite;
+    console.log = mutedConsole;
+    console.warn = mutedConsole;
+    console.error = mutedConsole;
+    try {
+        return await fn();
+    }
+    finally {
+        process.stdout.write = stdoutWrite;
+        process.stderr.write = stderrWrite;
+        console.log = consoleLog;
+        console.warn = consoleWarn;
+        console.error = consoleError;
+    }
+}
 async function promptQuestions(questions) {
     // inquirer v13+ is ESM-only. Keep it lazy so simple commands like
     // `cdn-security --version` and `build` do not require loading the prompt UI.
@@ -253,6 +284,336 @@ const CAPABILITY_TARGETS = [
     { key: 'terraform_waf', label: 'Terraform-backed WAF' },
 ];
 const CAPABILITY_STATUSES = ['supported', 'partial', 'unsupported', 'warning-only'];
+const PLAYGROUND_PLACEHOLDER_TOKEN = 'INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN';
+function normalizeFixtureHeader(raw) {
+    const headers = {};
+    if (!raw)
+        return headers;
+    for (const [key, value] of Object.entries(raw)) {
+        if (value === undefined || value === null)
+            continue;
+        if (typeof value === 'object')
+            continue;
+        headers[key] = String(value);
+    }
+    return headers;
+}
+function normalizeFixtureQuery(raw) {
+    if (raw == null)
+        return '';
+    if (typeof raw === 'string')
+        return raw;
+    if (typeof raw !== 'object' || Array.isArray(raw))
+        return '';
+    const pairs = [];
+    for (const [key, value] of Object.entries(raw)) {
+        if (value === null || value === undefined)
+            continue;
+        if (typeof value === 'object') {
+            const obj = value;
+            if (obj.value !== undefined && obj.value !== null) {
+                pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(obj.value))}`);
+            }
+            if (Array.isArray(obj.multiValue)) {
+                for (const item of obj.multiValue) {
+                    if (item && item.value !== undefined && item.value !== null) {
+                        pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(item.value))}`);
+                    }
+                }
+            }
+            continue;
+        }
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                if (item === undefined || item === null)
+                    continue;
+                pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(item))}`);
+            }
+            continue;
+        }
+        pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    }
+    return pairs.join('&');
+}
+function buildDefaultPlaygroundFixtures() {
+    return [
+        {
+            name: 'GET / with explicit user-agent',
+            request: {
+                method: 'GET',
+                path: '/',
+                query: '',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                    accept: 'text/plain',
+                },
+                body: null,
+            },
+        },
+        {
+            name: 'PATCH / is blocked by method rule',
+            request: {
+                method: 'PATCH',
+                path: '/',
+                query: '',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                },
+                body: null,
+            },
+        },
+        {
+            name: 'Path traversal is blocked',
+            request: {
+                method: 'GET',
+                path: '/foo/../bar',
+                query: '',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                },
+                body: null,
+            },
+        },
+        {
+            name: 'Query string strip example',
+            request: {
+                method: 'GET',
+                path: '/search',
+                query: 'utm_source=google&q=abc',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                },
+                body: null,
+            },
+        },
+        {
+            name: 'Auth missing on admin route',
+            request: {
+                method: 'GET',
+                path: '/admin',
+                query: '',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                },
+                body: null,
+            },
+        },
+        {
+            name: 'Auth with placeholder token on admin route',
+            request: {
+                method: 'GET',
+                path: '/admin',
+                query: '',
+                headers: {
+                    'user-agent': 'cdn-security-framework-playground',
+                    'x-edge-token': PLAYGROUND_PLACEHOLDER_TOKEN,
+                },
+                body: null,
+            },
+        },
+    ];
+}
+function loadPlaygroundFixtures(fixturePath) {
+    if (!fixturePath) {
+        return buildDefaultPlaygroundFixtures();
+    }
+    const raw = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+    let list = [];
+    if (Array.isArray(raw)) {
+        list = raw;
+    }
+    else if (raw && Array.isArray(raw.fixtures)) {
+        list = raw.fixtures;
+    }
+    else if (raw && raw.request) {
+        list = [raw];
+    }
+    else {
+        throw new Error('Invalid fixture format. Use array, {fixtures: [...]}, or {request: {...}}.');
+    }
+    return list.map((entry, index) => {
+        const payload = (entry && entry.request && typeof entry.request === 'object') ? entry.request : entry;
+        if (!payload || typeof payload !== 'object') {
+            throw new Error(`Fixture entry #${index + 1} is invalid.`);
+        }
+        const req = payload;
+        return {
+            name: String(entry.name || `request-${index + 1}`),
+            request: {
+                method: String(req.method || 'GET').toUpperCase(),
+                path: String(req.path || req.uri || '/'),
+                query: normalizeFixtureQuery(req.query),
+                headers: normalizeFixtureHeader(req.headers),
+                body: req.body,
+                raw: req.body,
+            },
+        };
+    });
+}
+function buildAwsEvent(fixture) {
+    const headers = {};
+    for (const [name, value] of Object.entries(fixture.headers)) {
+        headers[name.toLowerCase()] = { value: String(value) };
+    }
+    return {
+        request: {
+            method: fixture.method,
+            uri: fixture.path,
+            headers,
+            querystring: fixture.query,
+        },
+    };
+}
+function buildCloudflareRequest(fixture) {
+    const basePath = fixture.path || '/';
+    const [pathOnly, rawQuery] = basePath.split('?');
+    const normalizedQuery = fixture.query || (rawQuery || '');
+    const queryString = normalizedQuery ? (normalizedQuery.startsWith('?') ? normalizedQuery.slice(1) : normalizedQuery) : '';
+    const url = new URL(pathOnly + (queryString ? `?${queryString}` : ''), 'https://edge.example.com');
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(fixture.headers)) {
+        headers.set(name, value);
+    }
+    const body = (fixture.body === undefined || fixture.body === null)
+        ? undefined
+        : typeof fixture.body === 'string' ? fixture.body : JSON.stringify(fixture.body);
+    return new Request(url.toString(), {
+        method: fixture.method,
+        headers,
+        body: ['GET', 'HEAD'].includes(fixture.method) ? undefined : body,
+    });
+}
+function runAwsPlayground(outDir, fixtures) {
+    const viewerRequestPath = path.join(outDir, 'edge', 'viewer-request.js');
+    const code = fs.readFileSync(viewerRequestPath, 'utf8');
+    const handler = Function(`${code}\nreturn handler;`)();
+    if (typeof handler !== 'function') {
+        throw new Error('AWS compiled artifact is malformed: handler missing.');
+    }
+    const result = { target: 'aws', fixtures: [] };
+    for (const fixture of fixtures) {
+        const response = handler(buildAwsEvent(fixture.request));
+        const status = response && response.statusCode != null ? Number(response.statusCode) : 200;
+        const blocked = isBlockedStatus(response && response.statusCode);
+        result.fixtures.push({
+            name: fixture.name,
+            decision: blocked ? 'block' : 'pass',
+            status,
+            block_reason: blocked ? String(response.body || 'blocked') : '',
+            path: fixture.request.path,
+            method: fixture.request.method,
+            query: fixture.request.query,
+        });
+    }
+    return result;
+}
+async function runCloudflarePlayground(outDir, fixtures) {
+    const esbuild = require('esbuild');
+    const workerSourcePath = path.join(outDir, 'edge', 'cloudflare', 'index.ts');
+    const generated = fs.readFileSync(workerSourcePath, 'utf8');
+    const compiled = esbuild.transformSync(generated, {
+        loader: 'ts',
+        format: 'cjs',
+        target: 'es2022',
+    }).code;
+    const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-playground-cf-'));
+    const modPath = path.join(tmpDir, 'worker.cjs');
+    const env = {
+        EDGE_ADMIN_TOKEN: PLAYGROUND_PLACEHOLDER_TOKEN,
+        BASIC_AUTH_CREDS: 'basic:cred',
+        URL_SIGNING_SECRET: 'url-signing-secret',
+        JWT_SECRET: 'jwt-secret',
+        ORIGIN_SECRET: 'origin-secret',
+        CHALLENGE_SECRET: 'challenge-secret',
+    };
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('origin-ok', { status: 200, headers: {} });
+    const result = { target: 'cloudflare', fixtures: [] };
+    try {
+        fs.writeFileSync(modPath, compiled, 'utf8');
+        delete require.cache[modPath];
+        const mod = require(modPath);
+        const fetchHandler = mod && mod.default && typeof mod.default.fetch === 'function'
+            ? mod.default.fetch
+            : null;
+        if (typeof fetchHandler !== 'function') {
+            throw new Error('Cloudflare compiled artifact is malformed: default.fetch missing.');
+        }
+        for (const fixture of fixtures) {
+            const request = buildCloudflareRequest(fixture.request);
+            const response = await fetchHandler(request, env, {});
+            const status = Number(response.status) || 0;
+            const blocked = isBlockedStatus(status);
+            const body = blocked ? await response.text() : '';
+            result.fixtures.push({
+                name: fixture.name,
+                decision: blocked ? 'block' : 'pass',
+                status,
+                block_reason: blocked ? body : '',
+                path: fixture.request.path,
+                method: fixture.request.method,
+                query: fixture.request.query,
+            });
+        }
+        return result;
+    }
+    finally {
+        globalThis.fetch = previousFetch;
+        if (fs.existsSync(tmpDir))
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+async function runPlayground(opts) {
+    const cwd = process.cwd();
+    const policyPath = resolvePolicyPath(cwd, opts.policy);
+    const fixtures = loadPlaygroundFixtures(opts.fixture ? path.isAbsolute(opts.fixture)
+        ? opts.fixture
+        : path.join(cwd, opts.fixture) : null);
+    const tmpRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-playground-'));
+    const allowPlaceholderToken = opts.allowPlaceholderToken !== false;
+    const target = opts.target || 'all';
+    const { compile } = require(path.join(pkgRoot, 'lib'));
+    const results = [];
+    const isAws = target === 'aws' || target === 'all';
+    const isCloudflare = target === 'cloudflare' || target === 'all';
+    try {
+        if (isAws) {
+            const outDir = path.join(tmpRoot, 'aws');
+            const compileResult = compile({
+                policyPath,
+                outDir,
+                target: 'aws',
+                allowPlaceholderToken,
+                cwd,
+                pkgRoot,
+            });
+            if (!compileResult.ok) {
+                throw new Error(`playground: aws compile failed: ${compileResult.errors.join(' | ')}`);
+            }
+            results.push(runAwsPlayground(outDir, fixtures));
+        }
+        if (isCloudflare) {
+            const outDir = path.join(tmpRoot, 'cloudflare');
+            const compileResult = compile({
+                policyPath,
+                outDir,
+                target: 'cloudflare',
+                allowPlaceholderToken,
+                cwd,
+                pkgRoot,
+            });
+            if (!compileResult.ok) {
+                throw new Error(`playground: cloudflare compile failed: ${compileResult.errors.join(' | ')}`);
+            }
+            results.push(await runCloudflarePlayground(outDir, fixtures));
+        }
+        return { policyPath, targets: results };
+    }
+    finally {
+        if (fs.existsSync(tmpRoot))
+            fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+}
 function routeAuthConfigured(policy, types) {
     const routes = Array.isArray(policy && policy.routes) ? policy.routes : [];
     return routes.some((route) => types.includes(route && route.auth_gate && route.auth_gate.type));
@@ -1760,6 +2121,39 @@ program
     }
     finally {
         fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});
+program
+    .command('playground')
+    .description('Run sample requests against locally compiled AWS/Cloudflare runtime artifacts')
+    .option('-p, --policy <path>', 'Policy file path (default: policy/security.yml or policy/base.yml)', null)
+    .option('-t, --target <platform>', 'Target platform: aws | cloudflare | all', 'all')
+    .option('-f, --fixture <path>', 'JSON fixture with request cases (array, {fixtures: [...]}, or {request: {...}})')
+    .option('--json', 'Emit machine-readable output')
+    .option('--allow-placeholder-token', 'Allow non-production placeholder credentials for local policy checks')
+    .action(async (opts) => {
+    if (opts.target !== 'aws' && opts.target !== 'cloudflare' && opts.target !== 'all') {
+        console.error('[ERROR] --target must be aws, cloudflare, or all.');
+        process.exit(1);
+    }
+    try {
+        const report = await withMutedOutput(() => runPlayground(opts), !!opts.json);
+        if (opts.json) {
+            console.log(JSON.stringify(report, null, 2));
+            return;
+        }
+        for (const targetResult of report.targets) {
+            console.log(`[${targetResult.target}]`);
+            for (const item of targetResult.fixtures) {
+                const querySuffix = item.query ? `?${item.query}` : '';
+                const reason = item.block_reason ? ` reason=${item.block_reason}` : '';
+                console.log(`- ${item.name}: ${item.method} ${item.path}${querySuffix} => ${item.decision.toUpperCase()} (status=${item.status})${reason}`);
+            }
+        }
+    }
+    catch (e) {
+        console.error('[ERROR]', e.message || String(e));
+        process.exit(1);
     }
 });
 program

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -12,6 +12,7 @@ npx cdn-security <subcommand> [options]
 | --- | --- |
 | `init` | プロファイル / アーキタイプから `policy/security.yml` をスキャフォールド。 |
 | `build` | ポリシー検証 + エッジランタイム + インフラ設定の生成。 |
+| `playground` | ポリシーをローカルでコンパイルし、サンプルリクエストを AWS/Cloudflare ランタイムで再生して pass/block を確認。 |
 | `emit-waf` | インフラ設定のみ生成（エッジは生成しない）。エッジはそのままで WAF ルールだけ再デプロイしたいとき。 |
 | `doctor` | 環境診断をワンショット実行。失敗チェックがあれば非ゼロ終了。 |
 | `readiness` | 環境診断と policy posture を統合する本番リリースゲート。 |
@@ -52,6 +53,66 @@ npx cdn-security build --fail-on-permissive   # metadata.risk_level == permissiv
 - `dist/edge/viewer-request.js`, `dist/edge/viewer-response.js`, `dist/edge/origin-request.js`（AWS）
 - `dist/edge/cloudflare/index.ts`（Cloudflare）
 - `dist/infra/*.tf.json` — WAF / geo / IP / CloudFront 設定 / origin タイムアウト
+
+## `playground`
+
+```bash
+npx cdn-security playground                                      # 組み込みのサンプルケースを AWS+Cloudflare で実行
+npx cdn-security playground --target aws --json                   # JSON 形式で結果を取得
+npx cdn-security playground --policy policy/security.yml -f cases.json
+npx cdn-security playground --allow-placeholder-token --target all  # INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN を許可
+```
+
+`playground` は指定ポリシーを一時ディレクトリへコンパイルし、生成された runtime で fixture を実行します。各 fixture ごとに `pass|block`、HTTP `status`、`block_reason`、対象 target（`aws` / `cloudflare`）を出力します。
+
+入力形式:
+
+- `--fixture <path>` は以下のいずれかを受け取れます。
+  - `{ "fixtures": [ ... ] }`
+  - `[ ... ]`
+  - `{ "request": { ... } }`
+- 各 fixture は以下を受け取れます。
+  - `method`
+  - `path`
+  - `query`（文字列またはオブジェクト）
+  - `headers`
+  - `body`
+
+fixture 例:
+
+```json
+{
+  "fixtures": [
+    { "name": "GET /", "request": { "method": "GET", "path": "/" } },
+    { "name": "PATCH blocked", "request": { "method": "PATCH", "path": "/" } },
+    { "name": "admin missing auth", "request": { "method": "GET", "path": "/admin", "headers": { "x-edge-token": "INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN" } } }
+  ]
+}
+```
+
+`--json` を指定すると、次のような machine-readable 出力になります。
+
+```json
+{
+  "policyPath": "/path/to/policy/security.yml",
+  "targets": [
+    {
+      "target": "aws",
+      "fixtures": [
+        {
+          "name": "GET /",
+          "decision": "pass",
+          "status": 200,
+          "block_reason": "",
+          "path": "/",
+          "method": "GET",
+          "query": ""
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## `emit-waf`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,6 +12,7 @@ npx cdn-security <subcommand> [options]
 | --- | --- |
 | `init` | Scaffold `policy/security.yml` from a profile or archetype. |
 | `build` | Validate policy, compile edge runtime + infra config. |
+| `playground` | Compile policy locally and run sample request fixtures against edge runtimes (AWS + Cloudflare). |
 | `emit-waf` | Emit infra config only (no edge code). For redeploying firewall rules without touching edge. |
 | `doctor` | One-shot environment diagnostics. Exits non-zero on any failing check. |
 | `readiness` | Production release gate that combines diagnostics and policy posture findings. |
@@ -52,6 +53,66 @@ Outputs:
 - `dist/edge/viewer-request.js`, `dist/edge/viewer-response.js`, `dist/edge/origin-request.js` (AWS)
 - `dist/edge/cloudflare/index.ts` (Cloudflare)
 - `dist/infra/*.tf.json` — WAF, geo, IP sets, CloudFront settings, origin timeouts
+
+## `playground`
+
+```bash
+npx cdn-security playground                                      # local fixtures against built-in examples (AWS + Cloudflare)
+npx cdn-security playground --target aws --json                   # machine-readable output
+npx cdn-security playground --policy policy/security.yml -f cases.json
+npx cdn-security playground --allow-placeholder-token --target all  # allow INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN
+```
+
+`playground` builds the selected policy to a temporary directory and executes synthetic requests through the generated runtime. It reports `pass|block`, HTTP `status`, and `block_reason` for each fixture and includes the runtime target (`aws` or `cloudflare`).
+
+Input format options:
+
+- `--fixture <path>` accepts one of:
+  - `{ "fixtures": [ ... ] }`
+  - `[ ... ]`
+  - `{ "request": { ... } }`
+- each fixture item accepts:
+  - `method`
+  - `path`
+  - `query` (string or object map)
+  - `headers`
+  - `body`
+
+Example fixture:
+
+```json
+{
+  "fixtures": [
+    { "name": "GET /", "request": { "method": "GET", "path": "/" } },
+    { "name": "PATCH blocked", "request": { "method": "PATCH", "path": "/" } },
+    { "name": "admin missing auth", "request": { "method": "GET", "path": "/admin", "headers": { "x-edge-token": "INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN" } } }
+  ]
+}
+```
+
+When `--json` is set, output is:
+
+```json
+{
+  "policyPath": "/path/to/policy/security.yml",
+  "targets": [
+    {
+      "target": "aws",
+      "fixtures": [
+        {
+          "name": "GET /",
+          "decision": "pass",
+          "status": 200,
+          "block_reason": "",
+          "path": "/",
+          "method": "GET",
+          "query": ""
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## `emit-waf`
 

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -179,6 +179,70 @@ firewall:
     managed_rules:
       - AWSManagedRulesCommonRuleSet
 `;
+const PLAYGROUND_FIXTURES = [
+    {
+        name: 'allow GET /',
+        request: {
+            method: 'GET',
+            path: '/',
+            headers: {
+                'user-agent': 'cli-test-client',
+            },
+        },
+    },
+    {
+        name: 'block PATCH',
+        request: {
+            method: 'PATCH',
+            path: '/',
+            headers: {
+                'user-agent': 'cli-test-client',
+            },
+        },
+    },
+    {
+        name: 'path traversal is blocked',
+        request: {
+            method: 'GET',
+            path: '/foo/../bar',
+            headers: {
+                'user-agent': 'cli-test-client',
+            },
+        },
+    },
+    {
+        name: 'auth missing on admin',
+        request: {
+            method: 'GET',
+            path: '/admin',
+            headers: {
+                'user-agent': 'cli-test-client',
+            },
+        },
+    },
+    {
+        name: 'auth placeholder passes',
+        request: {
+            method: 'GET',
+            path: '/admin',
+            headers: {
+                'user-agent': 'cli-test-client',
+                'x-edge-token': 'INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN',
+            },
+        },
+    },
+    {
+        name: 'query is visible in output',
+        request: {
+            method: 'GET',
+            path: '/search',
+            query: { q: 'hello', utm_source: 'cli' },
+            headers: {
+                'user-agent': 'cli-test-client',
+            },
+        },
+    },
+];
 function tmpProject(yamlBody) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
     const policyDir = path.join(tmp, 'policy');
@@ -518,6 +582,70 @@ test('CLI authoring DX: build --allow-placeholder-token succeeds without auth en
         assert.strictEqual(result.status, 0, `CLI build failed: ${result.stderr}`);
         assert.ok(result.stderr.includes('Generated artifacts are NOT safe for production'));
         assert.ok(fs.existsSync(path.join(ctx.outDir, 'edge', 'viewer-request.js')));
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('CLI authoring DX: playground emits AWS + Cloudflare fixture decisions', () => {
+    const ctx = tmpProject(STATIC_TOKEN_POLICY);
+    try {
+        const fixturePath = path.join(ctx.tmp, 'playground.fixture.json');
+        fs.writeFileSync(fixturePath, JSON.stringify({ fixtures: PLAYGROUND_FIXTURES }, null, 2), 'utf8');
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const result = spawnSync(process.execPath, [
+            cli, 'playground',
+            '-p', ctx.policyPath,
+            '-f', fixturePath,
+            '--target', 'all',
+            '--json',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env: Object.assign({}, process.env, {
+                // playground defaults allow placeholder replacement, no runtime secrets required
+                EDGE_ADMIN_TOKEN: '',
+                ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+            }),
+        });
+        assert.strictEqual(result.status, 0, `playground failed: ${result.stderr}`);
+        const report = JSON.parse(result.stdout);
+        assert.strictEqual(report.policyPath, ctx.policyPath);
+        assert.strictEqual(report.targets.length, 2, 'expected aws + cloudflare results');
+        const byTarget = Object.fromEntries(report.targets.map((r) => [r.target, r.fixtures]));
+        assert.ok(Array.isArray(byTarget.aws), 'aws target missing');
+        assert.ok(Array.isArray(byTarget.cloudflare), 'cloudflare target missing');
+        const awsAllow = byTarget.aws.find((f) => f.name === 'allow GET /');
+        const awsPatch = byTarget.aws.find((f) => f.name === 'block PATCH');
+        const awsAuthMissing = byTarget.aws.find((f) => f.name === 'auth missing on admin');
+        const awsAuthPass = byTarget.aws.find((f) => f.name === 'auth placeholder passes');
+        const awsTraversal = byTarget.aws.find((f) => f.name === 'path traversal is blocked');
+        const awsQuery = byTarget.aws.find((f) => f.name === 'query is visible in output');
+        assert.ok(awsAllow);
+        assert.ok(awsPatch);
+        assert.ok(awsAuthMissing);
+        assert.ok(awsAuthPass);
+        assert.ok(awsTraversal);
+        assert.ok(awsQuery);
+        assert.strictEqual(awsAllow.decision, 'pass');
+        assert.strictEqual(awsPatch.decision, 'block');
+        assert.strictEqual(awsTraversal.decision, 'block');
+        assert.strictEqual(awsAuthMissing.decision, 'block');
+        assert.strictEqual(awsAuthPass.decision, 'pass');
+        assert.ok(awsPatch.status >= 400);
+        assert.ok(awsTraversal.status >= 400);
+        assert.ok(awsAuthMissing.status >= 400);
+        assert.strictEqual(awsAllow.status, 200);
+        assert.strictEqual(awsAuthPass.status, 200);
+        assert.strictEqual(awsQuery.query, 'q=hello&utm_source=cli');
+        assert.ok(awsQuery.path === '/search');
+        const cloudAllow = byTarget.cloudflare.find((f) => f.name === 'allow GET /');
+        const cloudPatch = byTarget.cloudflare.find((f) => f.name === 'block PATCH');
+        assert.ok(cloudAllow);
+        assert.ok(cloudPatch);
+        assert.strictEqual(cloudAllow.decision, 'pass');
+        assert.strictEqual(cloudPatch.decision, 'block');
     }
     finally {
         ctx.cleanup();

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -93,6 +93,69 @@ type DiffOptions = {
   target: string;
 };
 
+type PlaygroundTarget = 'aws' | 'cloudflare' | 'all';
+
+type PlaygroundOptions = {
+  policy?: string | null;
+  target: PlaygroundTarget;
+  fixture?: string | null;
+  json?: boolean;
+  allowPlaceholderToken?: boolean;
+};
+
+type PlaygroundRequest = {
+  method?: string;
+  path?: string;
+  uri?: string;
+  query?: string | Record<string, string | number | boolean | object> | null;
+  headers?: Record<string, string | number | boolean | null>;
+  body?: unknown;
+};
+
+type RawFixtureEntry = {
+  name?: string;
+  request?: PlaygroundRequest;
+};
+
+type PlaygroundFixture = {
+  name: string;
+  request: {
+    method: string;
+    path: string;
+    query: string;
+    headers: Record<string, string>;
+    body: unknown;
+    raw?: Record<string, unknown>;
+  };
+};
+
+type PlaygroundCaseResult = {
+  name: string;
+  decision: PlaygroundDecision;
+  status: number;
+  block_reason: string;
+  path: string;
+  method: string;
+  query: string;
+};
+
+type PlaygroundDecision = 'pass' | 'block';
+
+function isBlockedStatus(status: unknown): boolean {
+  const numericStatus = Number(status);
+  return Number.isFinite(numericStatus) && numericStatus >= 400;
+}
+
+type PlaygroundTargetResult = {
+  target: PlaygroundTarget | 'aws' | 'cloudflare';
+  fixtures: PlaygroundCaseResult[];
+};
+
+type PlaygroundReport = {
+  policyPath: string | null;
+  targets: PlaygroundTargetResult[];
+};
+
 type StarterAnswers = {
   platform?: string;
   starterKind?: 'profile' | 'archetype' | 'guided';
@@ -108,6 +171,37 @@ type StarterAnswers = {
   deployment?: string;
   project?: string;
 };
+
+async function withMutedOutput<T>(fn: () => T | Promise<T>, condition: boolean): Promise<T> {
+  if (!condition) {
+    return await fn();
+  }
+
+  const stdoutWrite = process.stdout.write.bind(process.stdout);
+  const stderrWrite = process.stderr.write.bind(process.stderr);
+  const consoleLog = console.log;
+  const consoleWarn = console.warn;
+  const consoleError = console.error;
+
+  const mutedWrite = () => true as unknown as void;
+  const mutedConsole = () => undefined;
+
+  process.stdout.write = mutedWrite as never;
+  process.stderr.write = mutedWrite as never;
+  console.log = mutedConsole;
+  console.warn = mutedConsole;
+  console.error = mutedConsole;
+
+  try {
+    return await fn();
+  } finally {
+    process.stdout.write = stdoutWrite as never;
+    process.stderr.write = stderrWrite as never;
+    console.log = consoleLog;
+    console.warn = consoleWarn;
+    console.error = consoleError;
+  }
+}
 
 async function promptQuestions(questions: any[]) {
   // inquirer v13+ is ESM-only. Keep it lazy so simple commands like
@@ -469,6 +563,330 @@ const CAPABILITY_TARGETS: { key: CapabilityTargetKey; label: string }[] = [
 ];
 
 const CAPABILITY_STATUSES: CapabilityStatus[] = ['supported', 'partial', 'unsupported', 'warning-only'];
+const PLAYGROUND_PLACEHOLDER_TOKEN = 'INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN';
+
+function normalizeFixtureHeader(raw: Record<string, string | number | boolean | null> | undefined | null): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (!raw) return headers;
+  for (const [key, value] of Object.entries(raw)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'object') continue;
+    headers[key] = String(value);
+  }
+  return headers;
+}
+
+function normalizeFixtureQuery(raw: PlaygroundRequest['query']): string {
+  if (raw == null) return '';
+  if (typeof raw === 'string') return raw;
+  if (typeof raw !== 'object' || Array.isArray(raw)) return '';
+  const pairs: string[] = [];
+  for (const [key, value] of Object.entries(raw)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'object') {
+      const obj = value as Record<string, any>;
+      if (obj.value !== undefined && obj.value !== null) {
+        pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(obj.value))}`);
+      }
+      if (Array.isArray(obj.multiValue)) {
+        for (const item of obj.multiValue) {
+          if (item && item.value !== undefined && item.value !== null) {
+            pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(item.value))}`);
+          }
+        }
+      }
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue;
+        pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(item))}`);
+      }
+      continue;
+    }
+    pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return pairs.join('&');
+}
+
+function buildDefaultPlaygroundFixtures(): PlaygroundFixture[] {
+  return [
+    {
+      name: 'GET / with explicit user-agent',
+      request: {
+        method: 'GET',
+        path: '/',
+        query: '',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+          accept: 'text/plain',
+        },
+        body: null,
+      },
+    },
+    {
+      name: 'PATCH / is blocked by method rule',
+      request: {
+        method: 'PATCH',
+        path: '/',
+        query: '',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+        },
+        body: null,
+      },
+    },
+    {
+      name: 'Path traversal is blocked',
+      request: {
+        method: 'GET',
+        path: '/foo/../bar',
+        query: '',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+        },
+        body: null,
+      },
+    },
+    {
+      name: 'Query string strip example',
+      request: {
+        method: 'GET',
+        path: '/search',
+        query: 'utm_source=google&q=abc',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+        },
+        body: null,
+      },
+    },
+    {
+      name: 'Auth missing on admin route',
+      request: {
+        method: 'GET',
+        path: '/admin',
+        query: '',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+        },
+        body: null,
+      },
+    },
+    {
+      name: 'Auth with placeholder token on admin route',
+      request: {
+        method: 'GET',
+        path: '/admin',
+        query: '',
+        headers: {
+          'user-agent': 'cdn-security-framework-playground',
+          'x-edge-token': PLAYGROUND_PLACEHOLDER_TOKEN,
+        },
+        body: null,
+      },
+    },
+  ];
+}
+
+function loadPlaygroundFixtures(fixturePath: string | null | undefined): PlaygroundFixture[] {
+  if (!fixturePath) {
+    return buildDefaultPlaygroundFixtures();
+  }
+  const raw = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  let list: RawFixtureEntry[] = [];
+  if (Array.isArray(raw)) {
+    list = raw;
+  } else if (raw && Array.isArray((raw as any).fixtures)) {
+    list = (raw as any).fixtures;
+  } else if (raw && (raw as any).request) {
+    list = [raw as RawFixtureEntry];
+  } else {
+    throw new Error('Invalid fixture format. Use array, {fixtures: [...]}, or {request: {...}}.');
+  }
+  return list.map((entry, index: number) => {
+    const payload: any = (entry && entry.request && typeof entry.request === 'object') ? entry.request : entry;
+    if (!payload || typeof payload !== 'object') {
+      throw new Error(`Fixture entry #${index + 1} is invalid.`);
+    }
+    const req = payload as PlaygroundRequest;
+    return {
+      name: String((entry as any).name || `request-${index + 1}`),
+      request: {
+        method: String(req.method || 'GET').toUpperCase(),
+        path: String(req.path || req.uri || '/'),
+        query: normalizeFixtureQuery(req.query),
+        headers: normalizeFixtureHeader(req.headers),
+        body: req.body,
+        raw: req.body as Record<string, unknown> | undefined,
+      },
+    };
+  });
+}
+
+function buildAwsEvent(fixture: PlaygroundFixture['request']): any {
+  const headers: Record<string, { value: string }> = {};
+  for (const [name, value] of Object.entries(fixture.headers)) {
+    headers[name.toLowerCase()] = { value: String(value) };
+  }
+  return {
+    request: {
+      method: fixture.method,
+      uri: fixture.path,
+      headers,
+      querystring: fixture.query,
+    },
+  };
+}
+
+function buildCloudflareRequest(fixture: PlaygroundFixture['request']): Request {
+  const basePath = fixture.path || '/';
+  const [pathOnly, rawQuery] = basePath.split('?');
+  const normalizedQuery = fixture.query || (rawQuery || '');
+  const queryString = normalizedQuery ? (normalizedQuery.startsWith('?') ? normalizedQuery.slice(1) : normalizedQuery) : '';
+  const url = new URL(pathOnly + (queryString ? `?${queryString}` : ''), 'https://edge.example.com');
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(fixture.headers)) {
+    headers.set(name, value);
+  }
+  const body = (fixture.body === undefined || fixture.body === null)
+    ? undefined
+    : typeof fixture.body === 'string' ? fixture.body : JSON.stringify(fixture.body);
+  return new Request(url.toString(), {
+    method: fixture.method,
+    headers,
+    body: ['GET', 'HEAD'].includes(fixture.method) ? undefined : body as any,
+  });
+}
+
+function runAwsPlayground(outDir: string, fixtures: PlaygroundFixture[]): PlaygroundTargetResult {
+  const viewerRequestPath = path.join(outDir, 'edge', 'viewer-request.js');
+  const code = fs.readFileSync(viewerRequestPath, 'utf8');
+  const handler = Function(`${code}\nreturn handler;`)();
+  if (typeof handler !== 'function') {
+    throw new Error('AWS compiled artifact is malformed: handler missing.');
+  }
+  const result: PlaygroundTargetResult = { target: 'aws', fixtures: [] };
+  for (const fixture of fixtures) {
+    const response = handler(buildAwsEvent(fixture.request));
+    const status = response && response.statusCode != null ? Number(response.statusCode) : 200;
+    const blocked = isBlockedStatus(response && response.statusCode);
+    result.fixtures.push({
+      name: fixture.name,
+      decision: blocked ? 'block' : 'pass',
+      status,
+      block_reason: blocked ? String(response.body || 'blocked') : '',
+      path: fixture.request.path,
+      method: fixture.request.method,
+      query: fixture.request.query,
+    });
+  }
+  return result;
+}
+
+async function runCloudflarePlayground(outDir: string, fixtures: PlaygroundFixture[]): Promise<PlaygroundTargetResult> {
+  const esbuild = require('esbuild');
+  const workerSourcePath = path.join(outDir, 'edge', 'cloudflare', 'index.ts');
+  const generated = fs.readFileSync(workerSourcePath, 'utf8');
+  const compiled = esbuild.transformSync(generated, {
+    loader: 'ts',
+    format: 'cjs',
+    target: 'es2022',
+  }).code;
+  const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-playground-cf-'));
+  const modPath = path.join(tmpDir, 'worker.cjs');
+  const env: Record<string, string> = {
+    EDGE_ADMIN_TOKEN: PLAYGROUND_PLACEHOLDER_TOKEN,
+    BASIC_AUTH_CREDS: 'basic:cred',
+    URL_SIGNING_SECRET: 'url-signing-secret',
+    JWT_SECRET: 'jwt-secret',
+    ORIGIN_SECRET: 'origin-secret',
+    CHALLENGE_SECRET: 'challenge-secret',
+  };
+  const previousFetch = (globalThis as any).fetch;
+  (globalThis as any).fetch = async () => new Response('origin-ok', { status: 200, headers: {} });
+  const result: PlaygroundTargetResult = { target: 'cloudflare', fixtures: [] };
+  try {
+    fs.writeFileSync(modPath, compiled, 'utf8');
+    delete require.cache[modPath];
+    const mod = require(modPath);
+    const fetchHandler = mod && mod.default && typeof mod.default.fetch === 'function'
+      ? mod.default.fetch
+      : null;
+    if (typeof fetchHandler !== 'function') {
+      throw new Error('Cloudflare compiled artifact is malformed: default.fetch missing.');
+    }
+    for (const fixture of fixtures) {
+      const request = buildCloudflareRequest(fixture.request);
+      const response = await fetchHandler(request, env, {});
+      const status = Number(response.status) || 0;
+      const blocked = isBlockedStatus(status);
+      const body = blocked ? await response.text() : '';
+      result.fixtures.push({
+        name: fixture.name,
+        decision: blocked ? 'block' : 'pass',
+        status,
+        block_reason: blocked ? body : '',
+        path: fixture.request.path,
+        method: fixture.request.method,
+        query: fixture.request.query,
+      });
+    }
+    return result;
+  } finally {
+    (globalThis as any).fetch = previousFetch;
+    if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function runPlayground(opts: PlaygroundOptions): Promise<PlaygroundReport> {
+  const cwd = process.cwd();
+  const policyPath = resolvePolicyPath(cwd, opts.policy);
+  const fixtures = loadPlaygroundFixtures(opts.fixture ? path.isAbsolute(opts.fixture)
+    ? opts.fixture
+    : path.join(cwd, opts.fixture) : null);
+  const tmpRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cdn-security-playground-'));
+  const allowPlaceholderToken = opts.allowPlaceholderToken !== false;
+  const target = opts.target || 'all';
+  const { compile } = require(path.join(pkgRoot, 'lib'));
+  const results: PlaygroundTargetResult[] = [];
+  const isAws = target === 'aws' || target === 'all';
+  const isCloudflare = target === 'cloudflare' || target === 'all';
+  try {
+    if (isAws) {
+      const outDir = path.join(tmpRoot, 'aws');
+      const compileResult = compile({
+        policyPath,
+        outDir,
+        target: 'aws',
+        allowPlaceholderToken,
+        cwd,
+        pkgRoot,
+      });
+      if (!compileResult.ok) {
+        throw new Error(`playground: aws compile failed: ${compileResult.errors.join(' | ')}`);
+      }
+      results.push(runAwsPlayground(outDir, fixtures));
+    }
+    if (isCloudflare) {
+      const outDir = path.join(tmpRoot, 'cloudflare');
+      const compileResult = compile({
+        policyPath,
+        outDir,
+        target: 'cloudflare',
+        allowPlaceholderToken,
+        cwd,
+        pkgRoot,
+      });
+      if (!compileResult.ok) {
+        throw new Error(`playground: cloudflare compile failed: ${compileResult.errors.join(' | ')}`);
+      }
+      results.push(await runCloudflarePlayground(outDir, fixtures));
+    }
+    return { policyPath, targets: results };
+  } finally {
+    if (fs.existsSync(tmpRoot)) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
 
 function routeAuthConfigured(policy: any, types: string[]): boolean {
   const routes = Array.isArray(policy && policy.routes) ? policy.routes : [];
@@ -2172,6 +2590,40 @@ program
       process.exit(1);
     } finally {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+program
+  .command('playground')
+  .description('Run sample requests against locally compiled AWS/Cloudflare runtime artifacts')
+  .option('-p, --policy <path>', 'Policy file path (default: policy/security.yml or policy/base.yml)', null)
+  .option('-t, --target <platform>', 'Target platform: aws | cloudflare | all', 'all')
+  .option('-f, --fixture <path>', 'JSON fixture with request cases (array, {fixtures: [...]}, or {request: {...}})')
+  .option('--json', 'Emit machine-readable output')
+  .option('--allow-placeholder-token', 'Allow non-production placeholder credentials for local policy checks')
+  .action(async (opts: PlaygroundOptions) => {
+    if (opts.target !== 'aws' && opts.target !== 'cloudflare' && opts.target !== 'all') {
+      console.error('[ERROR] --target must be aws, cloudflare, or all.');
+      process.exit(1);
+    }
+    try {
+      const report = await withMutedOutput(() => runPlayground(opts), !!opts.json);
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+        return;
+      }
+
+      for (const targetResult of report.targets) {
+        console.log(`[${targetResult.target}]`);
+        for (const item of targetResult.fixtures) {
+          const querySuffix = item.query ? `?${item.query}` : '';
+          const reason = item.block_reason ? ` reason=${item.block_reason}` : '';
+          console.log(`- ${item.name}: ${item.method} ${item.path}${querySuffix} => ${item.decision.toUpperCase()} (status=${item.status})${reason}`);
+        }
+      }
+    } catch (e: any) {
+      console.error('[ERROR]', e.message || String(e));
+      process.exit(1);
     }
   });
 

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -188,6 +188,71 @@ firewall:
       - AWSManagedRulesCommonRuleSet
 `;
 
+const PLAYGROUND_FIXTURES = [
+  {
+    name: 'allow GET /',
+    request: {
+      method: 'GET',
+      path: '/',
+      headers: {
+        'user-agent': 'cli-test-client',
+      },
+    },
+  },
+  {
+    name: 'block PATCH',
+    request: {
+      method: 'PATCH',
+      path: '/',
+      headers: {
+        'user-agent': 'cli-test-client',
+      },
+    },
+  },
+  {
+    name: 'path traversal is blocked',
+    request: {
+      method: 'GET',
+      path: '/foo/../bar',
+      headers: {
+        'user-agent': 'cli-test-client',
+      },
+    },
+  },
+  {
+    name: 'auth missing on admin',
+    request: {
+      method: 'GET',
+      path: '/admin',
+      headers: {
+        'user-agent': 'cli-test-client',
+      },
+    },
+  },
+  {
+    name: 'auth placeholder passes',
+    request: {
+      method: 'GET',
+      path: '/admin',
+      headers: {
+        'user-agent': 'cli-test-client',
+        'x-edge-token': 'INSECURE_PLACEHOLDER__REBUILD_WITH_REAL_TOKEN',
+      },
+    },
+  },
+  {
+    name: 'query is visible in output',
+    request: {
+      method: 'GET',
+      path: '/search',
+      query: { q: 'hello', utm_source: 'cli' },
+      headers: {
+        'user-agent': 'cli-test-client',
+      },
+    },
+  },
+];
+
 function tmpProject(yamlBody: string) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
   const policyDir = path.join(tmp, 'policy');
@@ -545,6 +610,74 @@ test('CLI authoring DX: build --allow-placeholder-token succeeds without auth en
     assert.strictEqual(result.status, 0, `CLI build failed: ${result.stderr}`);
     assert.ok(result.stderr.includes('Generated artifacts are NOT safe for production'));
     assert.ok(fs.existsSync(path.join(ctx.outDir, 'edge', 'viewer-request.js')));
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('CLI authoring DX: playground emits AWS + Cloudflare fixture decisions', () => {
+  const ctx = tmpProject(STATIC_TOKEN_POLICY);
+  try {
+    const fixturePath = path.join(ctx.tmp, 'playground.fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ fixtures: PLAYGROUND_FIXTURES }, null, 2), 'utf8');
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'playground',
+      '-p', ctx.policyPath,
+      '-f', fixturePath,
+      '--target', 'all',
+      '--json',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, {
+        // playground defaults allow placeholder replacement, no runtime secrets required
+        EDGE_ADMIN_TOKEN: '',
+        ORIGIN_SECRET: 'ci-origin-secret-not-for-deploy',
+      }),
+    });
+    assert.strictEqual(result.status, 0, `playground failed: ${result.stderr}`);
+    const report = JSON.parse(result.stdout);
+    assert.strictEqual(report.policyPath, ctx.policyPath);
+    assert.strictEqual(report.targets.length, 2, 'expected aws + cloudflare results');
+    const byTarget = Object.fromEntries(report.targets.map((r: any) => [r.target, r.fixtures]));
+    assert.ok(Array.isArray(byTarget.aws), 'aws target missing');
+    assert.ok(Array.isArray(byTarget.cloudflare), 'cloudflare target missing');
+
+    const awsAllow = byTarget.aws.find((f: any) => f.name === 'allow GET /');
+    const awsPatch = byTarget.aws.find((f: any) => f.name === 'block PATCH');
+    const awsAuthMissing = byTarget.aws.find((f: any) => f.name === 'auth missing on admin');
+    const awsAuthPass = byTarget.aws.find((f: any) => f.name === 'auth placeholder passes');
+    const awsTraversal = byTarget.aws.find((f: any) => f.name === 'path traversal is blocked');
+    const awsQuery = byTarget.aws.find((f: any) => f.name === 'query is visible in output');
+
+    assert.ok(awsAllow);
+    assert.ok(awsPatch);
+    assert.ok(awsAuthMissing);
+    assert.ok(awsAuthPass);
+    assert.ok(awsTraversal);
+    assert.ok(awsQuery);
+
+    assert.strictEqual(awsAllow.decision, 'pass');
+    assert.strictEqual(awsPatch.decision, 'block');
+    assert.strictEqual(awsTraversal.decision, 'block');
+    assert.strictEqual(awsAuthMissing.decision, 'block');
+    assert.strictEqual(awsAuthPass.decision, 'pass');
+    assert.ok(awsPatch.status >= 400);
+    assert.ok(awsTraversal.status >= 400);
+    assert.ok(awsAuthMissing.status >= 400);
+    assert.strictEqual(awsAllow.status, 200);
+    assert.strictEqual(awsAuthPass.status, 200);
+    assert.strictEqual(awsQuery.query, 'q=hello&utm_source=cli');
+    assert.ok(awsQuery.path === '/search');
+
+    const cloudAllow = byTarget.cloudflare.find((f: any) => f.name === 'allow GET /');
+    const cloudPatch = byTarget.cloudflare.find((f: any) => f.name === 'block PATCH');
+    assert.ok(cloudAllow);
+    assert.ok(cloudPatch);
+    assert.strictEqual(cloudAllow.decision, 'pass');
+    assert.strictEqual(cloudPatch.decision, 'block');
   } finally {
     ctx.cleanup();
   }


### PR DESCRIPTION
## 問題
- Issue #128 の要件である「ローカルで policy の pass/block 挙動を確認」する実行ループが未整備。

## 変更内容
- `src/bin/cli.ts`
  - `playground` コマンド追加/更新: `playground --policy --target --fixture --json --allow-placeholder-token`
  - fixture 読み込み・query/header などの正規化を追加
  - `--target all` 時に AWS と Cloudflare の結果を併せて返却
  - `--json` 時は machine-readable JSON のみを出力するため、playground 実行中の標準出力ログを抑制
  - AWS runtime 用にヘッダを `{ value }` 形式へ正規化して期待イベントに合わせる
- `docs/cli.md` / `docs/cli.ja.md`
  - `playground` コマンド説明、使い方、JSON 例を追加
- `src/scripts/programmatic-api-unit-tests.ts` と `scripts/programmatic-api-unit-tests.js`
  - `CLI authoring DX: playground emits AWS + Cloudflare fixture decisions` 回帰テストを追加

## 挙動変更
- policy を手元で compile して、fixture ベースで pass/block とステータスを確認できる。
- JSON 出力で CI/自動化向けに機械可読なレポート生成が可能。

## 検証
- `npm run build:ts`
- `node scripts/programmatic-api-unit-tests.js`
  - `policy_exists` による policy 未作成のチェックのみ 1 件失敗だが、既知の前提条件として許容。

## 残リスク
- fixture の schema は当面の最低範囲実装。より高度な body 形状・複数値ヘッダの拡張は次 PR で検討。

Closes #128
