### PR TITLE
feat(policy): add policy inheritance and environment overlays

### DIFF
--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -54,6 +54,13 @@ npx cdn-security build --fail-on-permissive   # metadata.risk_level == permissiv
 - `dist/edge/cloudflare/index.ts`（Cloudflare）
 - `dist/infra/*.tf.json` — WAF / geo / IP / CloudFront 設定 / origin タイムアウト
 
+`build` では top-level の `extends` をサポートします。
+
+- 選択したポリシーが別ポリシーを継承し、共通設定を再利用できます。
+- `extends` は子ポリシーからの相対パスで解決されます。
+- マージはオブジェクトは深い階層で子優先、配列は親→子の順で append です。
+- スカラー置換は親サブツリーを上書きし、inheritance は `child` → `parent` → `grandparent` のような連鎖も有効です。
+
 ## `playground`
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,16 @@ Outputs:
 - `dist/edge/cloudflare/index.ts` (Cloudflare)
 - `dist/infra/*.tf.json` — WAF, geo, IP sets, CloudFront settings, origin timeouts
 
+Build supports inheritance via top-level `extends`:
+
+- `policy` can point to another policy file and reuse defaults across services.
+- `extends` path is resolved relative to the selected policy file.
+- Merge behavior is deep-merge for objects and append for arrays:
+  - object key collisions are resolved by child
+  - arrays from parent then child
+  - scalar replacement replaces the parent subtree
+- Inheritance is transitive (supports `child` -> `parent` -> `grandparent`).
+
 ## `playground`
 
 ```bash

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -31,7 +31,7 @@ function lintPolicy(opts = {}) {
         return {
             ok: false,
             errors: parsed.errors,
-            warnings: [],
+            warnings: parsed.warnings,
             policy: parsed.policy,
         };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +213,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -417,9 +417,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1656,9 +1656,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1669,32 +1669,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/parser/index.d.ts
+++ b/parser/index.d.ts
@@ -5,6 +5,7 @@ export type ParsePolicyOptions = {
 export type ParsePolicyResult = {
     ok: boolean;
     errors: string[];
+    warnings: string[];
     policy: Partial<CDNSecurityFrameworkPolicy> | null;
 };
 export declare function parsePolicyFile(opts?: ParsePolicyOptions): ParsePolicyResult;

--- a/parser/index.js
+++ b/parser/index.js
@@ -2,24 +2,151 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.parsePolicyFile = parsePolicyFile;
 const fs = require('fs');
+const path = require('path');
 const yaml = require('js-yaml');
-function parsePolicyFile(opts = {}) {
-    const policyPath = opts && opts.policyPath;
-    if (!policyPath) {
-        return { ok: false, errors: ['policyPath is required'], policy: null };
+function isPlainObject(value) {
+    return (typeof value === 'object'
+        && value !== null
+        && !Array.isArray(value)
+        && (value.constructor === Object || Object.getPrototypeOf(value) === null));
+}
+function collectDeepKeys(value, prefix = '') {
+    if (!isPlainObject(value))
+        return [];
+    const entries = [];
+    for (const [key, child] of Object.entries(value)) {
+        const p = prefix ? `${prefix}.${key}` : key;
+        entries.push(p);
+        entries.push(...collectDeepKeys(child, p));
     }
+    return entries;
+}
+function mergePolicyValues(base, override, warnings, pathHint = '') {
+    if (Array.isArray(base) || Array.isArray(override)) {
+        if (Array.isArray(base) && Array.isArray(override)) {
+            return [...base, ...override];
+        }
+        if (override !== undefined) {
+            if (base !== undefined) {
+                warnings.push(`[policy] unreachable keys in ${pathHint || '<root>'}: replaced base subtree by non-array value.`);
+            }
+            return override;
+        }
+        return base;
+    }
+    if (isPlainObject(base) && isPlainObject(override)) {
+        const merged = { ...base };
+        for (const [key, value] of Object.entries(override)) {
+            if (key === 'extends')
+                continue;
+            const childPath = pathHint ? `${pathHint}.${key}` : key;
+            if (Object.prototype.hasOwnProperty.call(base, key)) {
+                merged[key] = mergePolicyValues(base[key], value, warnings, childPath);
+            }
+            else {
+                merged[key] = value;
+            }
+        }
+        return merged;
+    }
+    if (override !== undefined) {
+        if (base !== undefined) {
+            const unreachableKeys = collectDeepKeys(base, pathHint);
+            if (unreachableKeys.length > 0) {
+                warnings.push(`[policy] unreachable keys at ${pathHint || '<root>'}: ${unreachableKeys.join(', ')}`);
+            }
+        }
+        return override;
+    }
+    return base;
+}
+function loadPolicyFile(policyPath, stack, warnings) {
+    const absPath = path.resolve(policyPath);
+    if (stack.includes(absPath)) {
+        const cycle = [...stack, absPath].join(' -> ');
+        return { __error: `cyclic extends detected: ${cycle}` };
+    }
+    let raw;
     try {
-        const policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
-        return { ok: true, errors: [], policy };
+        raw = yaml.load(fs.readFileSync(absPath, 'utf8'));
     }
     catch (e) {
         if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
-            return { ok: false, errors: [`policy file not found: ${policyPath}`], policy: null };
+            throw e;
+        }
+        throw new Error(`failed to parse YAML at ${absPath}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    if (raw === null || raw === undefined || Array.isArray(raw) || typeof raw !== 'object') {
+        throw new Error(`policy YAML at ${absPath} must be an object`);
+    }
+    const doc = raw;
+    const extendsPath = doc.extends;
+    if (extendsPath === undefined) {
+        const filtered = { ...doc };
+        delete filtered.extends;
+        return filtered;
+    }
+    if (typeof extendsPath !== 'string' || extendsPath.trim() === '') {
+        throw new Error(`invalid extends in ${absPath}: value must be a non-empty string`);
+    }
+    const nextPath = path.resolve(path.dirname(absPath), extendsPath.trim());
+    let parent;
+    try {
+        parent = loadPolicyFile(nextPath, [...stack, absPath], warnings);
+    }
+    catch (e) {
+        if (e && typeof e === 'object' && e.__error) {
+            throw e;
+        }
+        throw e;
+    }
+    if (parent && typeof parent === 'object' && '__error' in parent) {
+        throw new Error(String(parent.__error));
+    }
+    if (!isPlainObject(parent)) {
+        throw new Error(`extends target must be an object: ${nextPath}`);
+    }
+    const child = { ...doc };
+    delete child.extends;
+    if (Object.keys(parent).length === 0) {
+        return child;
+    }
+    return mergePolicyValues(parent, child, warnings, '');
+}
+function isFileMissingError(e) {
+    return typeof e === 'object' && e !== null && 'code' in e && e.code === 'ENOENT';
+}
+function parsePolicyFile(opts = {}) {
+    const policyPath = opts && opts.policyPath;
+    if (!policyPath) {
+        return { ok: false, errors: ['policyPath is required'], warnings: [], policy: null };
+    }
+    try {
+        const warnings = [];
+        const policy = loadPolicyFile(policyPath, [], warnings);
+        if (isPlainObject(policy)) {
+            return { ok: true, errors: [], warnings, policy: policy };
+        }
+        if (policy && typeof policy === 'object' && '__error' in policy) {
+            const message = String(policy.__error);
+            return { ok: false, errors: [message], warnings, policy: null };
+        }
+        return {
+            ok: false,
+            warnings,
+            errors: ['loaded policy is not an object'],
+            policy: null,
+        };
+    }
+    catch (e) {
+        if (isFileMissingError(e)) {
+            return { ok: false, errors: [`policy file not found: ${policyPath}`], warnings: [], policy: null };
         }
         const message = e instanceof Error ? e.message : String(e);
         return {
             ok: false,
             errors: [`failed to parse policy YAML: ${message}`],
+            warnings: [],
             policy: null,
         };
     }

--- a/policy/README.ja.md
+++ b/policy/README.ja.md
@@ -27,6 +27,35 @@ build は `policy/security.yml` を優先して参照し、なければ `policy/
 | `profiles/strict.yml` | 制限を強め、ブロックを増やす。クライアントを制御できる場合向け。 |
 | `profiles/permissive.yml` | 制限を緩め、ブロックを減らす。API・スクリプト・レガシークライアント向け。 |
 
+## ポリシー継承（環境オーバーレイ）
+
+サービス横断または環境別運用で、共通の基盤ポリシーを切り出し、`extends` で差分だけを重ねます。
+
+```yml
+# policy/base.yml
+version: 1
+defaults:
+  mode: monitor
+project: web-frontend
+
+# policy/prod.yml
+extends: ./base.yml
+defaults:
+  mode: enforce
+firewall:
+  waf:
+    rate_limit_rules:
+      - name: api-limit
+        limit: 500
+```
+
+`extends` のパスは子ポリシーファイルからの相対パスで解決されます。
+
+- オブジェクトは深い階層で再帰マージし、子が親キーを上書き
+- 配列は末尾へ追記（親が先、子が後）
+- スカラー値は該当サブツリーを置換
+- `prod.yml` -> `base.yml` -> `global.yml` のような階層継承（transitive extends）に対応
+
 ---
 
 ## プロファイルの選び方（base.yml を使う場合）

--- a/policy/README.md
+++ b/policy/README.md
@@ -27,6 +27,35 @@ Build looks for `policy/security.yml` first; if it does not exist, it uses `poli
 | `profiles/strict.yml` | Stricter limits and more blocks; best when you control clients. |
 | `profiles/permissive.yml` | Looser limits and fewer blocks; for APIs, scripts, legacy clients. |
 
+## Policy inheritance with overlays
+
+For multi-service or environment-specific policy sets, keep shared policy in a base file and create overlays with `extends`:
+
+```yml
+# policy/base.yml
+version: 1
+defaults:
+  mode: monitor
+project: web-frontend
+
+# policy/prod.yml
+extends: ./base.yml
+defaults:
+  mode: enforce
+firewall:
+  waf:
+    rate_limit_rules:
+      - name: api-limit
+        limit: 500
+```
+
+The `extends` path is resolved relative to the child policy file.
+
+- Object fields merge recursively (child keys override parent keys)
+- Arrays append in source order (parent entries first, child entries after)
+- Scalar values replace the parent subtree
+- Transitive inheritance is supported (`prod.yml` -> `base.yml` -> `global.yml`)
+
 ---
 
 ## Choosing a Profile (when using base.yml)

--- a/policy/schema.json
+++ b/policy/schema.json
@@ -7,6 +7,10 @@
   "required": ["version", "request", "response_headers"],
   "properties": {
     "version": { "type": "integer", "const": 1 },
+    "extends": {
+      "type": "string",
+      "description": "Optional base policy path to extend. Path is resolved relative to the current policy file."
+    },
     "project": { "type": "string" },
     "metadata": {
       "description": "Optional profile / policy metadata. `risk_level` hints the intended security posture — `permissive` triggers a build-time warning so operators do not accidentally ship a loose policy to production.",

--- a/scripts/compile-cloudflare-waf.js
+++ b/scripts/compile-cloudflare-waf.js
@@ -18,7 +18,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const parity = require('./lib/cloudflare-waf-parity');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -55,9 +55,31 @@ function recordParity(entry) {
     parityWarnings.push(msg);
     sawApproximationOrUnsupported = true;
 }
+function reportPolicyWarnings(warnings) {
+    if (warnings.length === 0)
+        return;
+    console.warn('Policy parse warnings:', policyPath);
+    for (const warning of warnings) {
+        console.warn('  - ' + warning);
+    }
+}
+function loadPolicyWithWarnings(policyPath) {
+    const parsed = parsePolicyFile({ policyPath });
+    if (!parsed.ok) {
+        const message = parsed.errors.join('; ') || 'failed to parse policy';
+        const e = new Error(message);
+        if (message.startsWith('policy file not found:')) {
+            e.code = 'ENOENT';
+        }
+        throw e;
+    }
+    return parsed;
+}
 let policy;
 try {
-    policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+    const parsed = loadPolicyWithWarnings(policyPath);
+    reportPolicyWarnings(parsed.warnings || []);
+    policy = parsed.policy;
 }
 catch (e) {
     if (e.code === 'ENOENT') {

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -7,7 +7,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const { parsePathPatterns, regexesLiteralCode, validateAuthGates, hasAllowPlaceholderFlag, hasFailOnPermissiveFlag, hasCatastrophicBacktrackShape, compileRegexOrThrow, warnIfPermissive, warnSignedUrlReplay, buildChallengeConfig, buildGraphqlGuardConfig, buildAnomalyGuardConfig, buildObsConfig, } = require('./lib/compile-core');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
 const repoRoot = path.join(__dirname, '..');
@@ -37,10 +37,31 @@ for (let i = 0; i < argv.length; i++) {
 }
 const allowPlaceholderToken = hasAllowPlaceholderFlag(argv);
 const failOnPermissive = hasFailOnPermissiveFlag(argv);
+function reportPolicyWarnings(warnings) {
+    if (warnings.length === 0)
+        return;
+    console.warn('Policy parse warnings:', policyPath);
+    for (const warning of warnings) {
+        console.warn('  - ' + warning);
+    }
+}
+function loadPolicyWithWarnings(policyPath) {
+    const parsed = parsePolicyFile({ policyPath });
+    if (!parsed.ok) {
+        const message = parsed.errors.join('; ') || 'failed to parse policy';
+        const e = new Error(message);
+        if (message.startsWith('policy file not found:')) {
+            e.code = 'ENOENT';
+        }
+        throw e;
+    }
+    return parsed;
+}
 let policy;
 try {
-    const content = fs.readFileSync(policyPath, 'utf8');
-    policy = yaml.load(content);
+    const parsed = loadPolicyWithWarnings(policyPath);
+    reportPolicyWarnings(parsed.warnings || []);
+    policy = parsed.policy;
 }
 catch (e) {
     if (e.code === 'ENOENT') {

--- a/scripts/compile-infra.js
+++ b/scripts/compile-infra.js
@@ -13,7 +13,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
 const securityPath = path.join(repoRoot, 'policy', 'security.yml');
@@ -49,10 +49,31 @@ if (!['full', 'rule-group'].includes(outputMode)) {
     console.error('Error: invalid --output-mode. Use "full" or "rule-group".');
     process.exit(1);
 }
+function reportPolicyWarnings(warnings) {
+    if (warnings.length === 0)
+        return;
+    console.warn('Policy parse warnings:', policyPath);
+    for (const warning of warnings) {
+        console.warn('  - ' + warning);
+    }
+}
+function loadPolicyWithWarnings(policyPath) {
+    const parsed = parsePolicyFile({ policyPath });
+    if (!parsed.ok) {
+        const message = parsed.errors.join('; ') || 'failed to parse policy';
+        const e = new Error(message);
+        if (message.startsWith('policy file not found:')) {
+            e.code = 'ENOENT';
+        }
+        throw e;
+    }
+    return parsed;
+}
 let policy;
 try {
-    const content = fs.readFileSync(policyPath, 'utf8');
-    policy = yaml.load(content);
+    const parsed = loadPolicyWithWarnings(policyPath);
+    reportPolicyWarnings(parsed.warnings || []);
+    policy = parsed.policy;
 }
 catch (e) {
     if (e.code === 'ENOENT') {

--- a/scripts/compiler-phase-unit-tests.js
+++ b/scripts/compiler-phase-unit-tests.js
@@ -37,6 +37,95 @@ test('parser phase: parses YAML without invoking validation or emission', () => 
         fs.rmSync(tmp, { recursive: true, force: true });
     }
 });
+test('parser phase: resolves transitive extends with deep merge', () => {
+    const tmp = mktmp();
+    const globalPath = path.join(tmp, 'global.yml');
+    const basePath = path.join(tmp, 'base.yml');
+    const childPath = path.join(tmp, 'child.yml');
+    fs.writeFileSync(globalPath, `version: 1
+defaults:
+  mode: monitor
+request:
+  allow_methods: [GET]
+  limits:
+    max_query_length: 1024
+response_headers:
+  hsts: "max-age=31536000"\n`, 'utf8');
+    fs.writeFileSync(basePath, `version: 1
+extends: ./global.yml
+request:
+  limits:
+    max_query_params: 30
+response_headers:
+  csp: "default-src 'self'"\n`, 'utf8');
+    fs.writeFileSync(childPath, `extends: ./base.yml
+defaults:
+  mode: enforce
+request:
+  limits:
+    max_query_params: 60
+`, 'utf8');
+    try {
+        const result = parsePolicyFile({ policyPath: childPath });
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(result.policy.defaults.mode, 'enforce');
+        assert.strictEqual(result.policy.request.limits.max_query_length, 1024);
+        assert.strictEqual(result.policy.request.limits.max_query_params, 60);
+        assert.deepStrictEqual(result.policy.request.allow_methods, ['GET']);
+        assert.strictEqual(result.policy.response_headers.csp, "default-src 'self'");
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+test('parser phase: appends array entries from child to parent on inheritance', () => {
+    const tmp = mktmp();
+    const basePath = path.join(tmp, 'base.yml');
+    const childPath = path.join(tmp, 'child.yml');
+    fs.writeFileSync(basePath, `version: 1\nrequest:\n  allow_methods: [GET]\nresponse_headers: {}\n`, 'utf8');
+    fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  allow_methods: [POST]\nresponse_headers: {}\n`, 'utf8');
+    try {
+        const result = parsePolicyFile({ policyPath: childPath });
+        assert.strictEqual(result.ok, true);
+        assert.deepStrictEqual(result.policy.request.allow_methods, ['GET', 'POST']);
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+test('parser phase: merges nested objects with child overrides', () => {
+    const tmp = mktmp();
+    const basePath = path.join(tmp, 'base.yml');
+    const childPath = path.join(tmp, 'child.yml');
+    fs.writeFileSync(basePath, `version: 1\nrequest:\n  limits:\n    max_query_length: 1024\n    max_query_params: 20\nresponse_headers: {}\n`, 'utf8');
+    fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  limits:\n    max_query_params: 30\n    max_uri_length: 2048\nresponse_headers: {}\n`, 'utf8');
+    try {
+        const result = parsePolicyFile({ policyPath: childPath });
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(result.policy.request.limits.max_query_length, 1024);
+        assert.strictEqual(result.policy.request.limits.max_query_params, 30);
+        assert.strictEqual(result.policy.request.limits.max_uri_length, 2048);
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+test('parser phase: emits unreachable-key warning when scalar replaces subtree', () => {
+    const tmp = mktmp();
+    const basePath = path.join(tmp, 'base.yml');
+    const childPath = path.join(tmp, 'child.yml');
+    fs.writeFileSync(basePath, `version: 1\nrequest:\n  limits:\n    max_query_length: 1024\nresponse_headers: {}\n`, 'utf8');
+    fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  limits: null\nresponse_headers: {}\n`, 'utf8');
+    try {
+        const result = parsePolicyFile({ policyPath: childPath });
+        assert.strictEqual(result.ok, true);
+        assert.ok(Array.isArray(result.warnings));
+        assert.ok(result.warnings.some((warning) => warning.includes('request.limits')));
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
 test('validator phase: validates an already-parsed policy without emitting files', () => {
     const tmp = mktmp();
     try {

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../../parser');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./template-inject');
 const repoRoot = path.join(__dirname, '..', '..');
 const DEFAULT_CONTAINS = ['/../', '%2e%2e', '%2f..', '..%2f', '%5c'];
@@ -31,8 +31,28 @@ function parseArgs(argv, rootDir = repoRoot) {
     return { policyPath, outDir };
 }
 function loadPolicy(policyPath) {
-    const content = fs.readFileSync(policyPath, 'utf8');
-    return yaml.load(content);
+    return loadPolicyWithWarnings(policyPath).policy;
+}
+function loadPolicyWithWarnings(policyPath) {
+    const parsed = parsePolicyFile({ policyPath });
+    if (!parsed.ok) {
+        const message = parsed.errors.join('; ') || 'failed to parse policy';
+        const err = new Error(message);
+        if (message.startsWith('policy file not found:')) {
+            err.code = 'ENOENT';
+        }
+        throw err;
+    }
+    return { policy: parsed.policy, warnings: parsed.warnings };
+}
+function reportPolicyWarnings(warnings) {
+    if (warnings.length === 0) {
+        return;
+    }
+    console.warn('Policy parse warnings:');
+    for (const warning of warnings) {
+        console.warn('  - ' + warning);
+    }
 }
 function extractRegex(source) {
     // Convert `(?i)...` to { pattern: '...', flags: 'i' }; else use the source as pattern.
@@ -852,8 +872,11 @@ function main(argv = process.argv.slice(2)) {
     const failOnPermissive = hasFailOnPermissiveFlag(argv);
     const strictOriginAuth = hasStrictOriginAuthFlag(argv);
     let policy;
+    let policyWarnings = [];
     try {
-        policy = loadPolicy(policyPath);
+        const parsed = loadPolicyWithWarnings(policyPath);
+        policy = parsed.policy;
+        policyWarnings = parsed.warnings;
     }
     catch (e) {
         if (e.code === 'ENOENT') {
@@ -863,6 +886,7 @@ function main(argv = process.argv.slice(2)) {
         console.error('Error: failed to parse policy YAML:', e.message);
         process.exit(1);
     }
+    reportPolicyWarnings(policyWarnings);
     // Surface permissive-profile warning before wasting build time.
     const permissive = warnIfPermissive(policy, { failOnPermissive });
     if (permissive.failed) {

--- a/scripts/policy-lint.js
+++ b/scripts/policy-lint.js
@@ -10,7 +10,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const Ajv = require('ajv');
 const { validateAuthGates, parsePathPatterns } = require('./lib/compile-core');
 const repoRoot = path.join(__dirname, '..');
@@ -18,9 +18,6 @@ const schemaPath = path.join(repoRoot, 'policy', 'schema.json');
 const defaultPolicyPath = path.join(repoRoot, 'policy', 'base.yml');
 function loadJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
-function loadYaml(filePath) {
-    return yaml.load(fs.readFileSync(filePath, 'utf8'));
 }
 function formatAjvErrors(errors) {
     return errors.map((err) => {
@@ -43,12 +40,34 @@ function validateCorsCredentials(policy) {
         '  - response_headers.cors: allow_origins cannot include "*" when allow_credentials is true',
     ];
 }
+function loadPolicyFileWithWarnings(policyPath) {
+    const parsed = parsePolicyFile({ policyPath });
+    if (!parsed.ok) {
+        const message = parsed.errors.join('; ') || 'failed to parse policy';
+        const e = new Error(message);
+        if (message.startsWith('policy file not found:')) {
+            e.code = 'ENOENT';
+        }
+        throw e;
+    }
+    return parsed;
+}
+function reportPolicyWarnings(policyPath, warnings) {
+    if (warnings.length === 0)
+        return;
+    console.warn('Policy parse warnings:', policyPath);
+    for (const warning of warnings) {
+        console.warn('  - ' + warning);
+    }
+}
 function main() {
     const policyPath = process.argv[2] || defaultPolicyPath;
     const errors = [];
     let policy;
     try {
-        policy = loadYaml(policyPath);
+        const parsed = loadPolicyFileWithWarnings(policyPath);
+        policy = parsed.policy;
+        reportPolicyWarnings(String(policyPath), parsed.warnings);
     }
     catch (e) {
         if (e.code === 'ENOENT') {

--- a/scripts/schema-lint-tests.js
+++ b/scripts/schema-lint-tests.js
@@ -64,6 +64,51 @@ test('lint accepts in-range request.limits', () => {
         fs.rmSync(dir, { recursive: true, force: true });
     }
 });
+test('lint accepts policy inherited via extends', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-lint-'));
+    const basePath = path.join(dir, 'base.yml');
+    const childPath = path.join(dir, 'prod.yml');
+    fs.writeFileSync(basePath, basePolicy({}), 'utf8');
+    fs.writeFileSync(childPath, `
+extends: ./base.yml
+defaults:
+  mode: enforce
+`, 'utf8');
+    try {
+        const result = runLint(childPath);
+        assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+    }
+    finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+test('lint accepts transitive inheritance', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-lint-'));
+    const basePath = path.join(dir, 'base.yml');
+    const midPath = path.join(dir, 'mid.yml');
+    const childPath = path.join(dir, 'prod.yml');
+    fs.writeFileSync(basePath, basePolicy({}), 'utf8');
+    fs.writeFileSync(midPath, `
+extends: ./base.yml
+project: schema-lint-test
+request:
+  limits:
+    max_query_params: 40
+`, 'utf8');
+    fs.writeFileSync(childPath, `
+extends: ./mid.yml
+request:
+  limits:
+    max_uri_length: 4096
+`, 'utf8');
+    try {
+        const result = runLint(childPath);
+        assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+    }
+    finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
 test('lint rejects max_query_length below minimum', () => {
     const { dir, file } = writeTempPolicy(basePolicy({ max_query_length: 0 }));
     try {

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -49,7 +49,7 @@ function lintPolicy(opts: LintPolicyOptions = {}): LintPolicyResult {
     return {
       ok: false,
       errors: parsed.errors,
-      warnings: [],
+      warnings: parsed.warnings,
       policy: parsed.policy,
     };
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const yaml = require('js-yaml');
 
 import type { CDNSecurityFrameworkPolicy } from '../types/policy';
@@ -10,26 +11,169 @@ export type ParsePolicyOptions = {
 export type ParsePolicyResult = {
   ok: boolean;
   errors: string[];
+  warnings: string[];
   policy: Partial<CDNSecurityFrameworkPolicy> | null;
 };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && (value.constructor === Object || Object.getPrototypeOf(value) === null)
+  );
+}
+
+function collectDeepKeys(value: unknown, prefix = ''): string[] {
+  if (!isPlainObject(value)) return [];
+  const entries: string[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    const p = prefix ? `${prefix}.${key}` : key;
+    entries.push(p);
+    entries.push(...collectDeepKeys(child, p));
+  }
+  return entries;
+}
+
+function mergePolicyValues(
+  base: unknown,
+  override: unknown,
+  warnings: string[],
+  pathHint = '',
+): unknown {
+  if (Array.isArray(base) || Array.isArray(override)) {
+    if (Array.isArray(base) && Array.isArray(override)) {
+      return [...base, ...override];
+    }
+    if (override !== undefined) {
+      if (base !== undefined) {
+        warnings.push(`[policy] unreachable keys in ${pathHint || '<root>'}: replaced base subtree by non-array value.`);
+      }
+      return override;
+    }
+    return base;
+  }
+
+  if (isPlainObject(base) && isPlainObject(override)) {
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(override)) {
+      if (key === 'extends') continue;
+      const childPath = pathHint ? `${pathHint}.${key}` : key;
+      if (Object.prototype.hasOwnProperty.call(base, key)) {
+        merged[key] = mergePolicyValues(base[key], value, warnings, childPath);
+      } else {
+        merged[key] = value;
+      }
+    }
+    return merged;
+  }
+
+  if (override !== undefined) {
+    if (base !== undefined) {
+      const unreachableKeys = collectDeepKeys(base, pathHint);
+      if (unreachableKeys.length > 0) {
+        warnings.push(
+          `[policy] unreachable keys at ${pathHint || '<root>'}: ${unreachableKeys.join(', ')}`,
+        );
+      }
+    }
+    return override;
+  }
+
+  return base;
+}
+
+function loadPolicyFile(policyPath: string, stack: string[], warnings: string[]): unknown {
+  const absPath = path.resolve(policyPath);
+  if (stack.includes(absPath)) {
+    const cycle = [...stack, absPath].join(' -> ');
+    return { __error: `cyclic extends detected: ${cycle}` };
+  }
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(fs.readFileSync(absPath, 'utf8'));
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
+      throw e;
+    }
+    throw new Error(`failed to parse YAML at ${absPath}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (raw === null || raw === undefined || Array.isArray(raw) || typeof raw !== 'object') {
+    throw new Error(`policy YAML at ${absPath} must be an object`);
+  }
+
+  const doc = raw as Record<string, unknown>;
+  const extendsPath = doc.extends;
+  if (extendsPath === undefined) {
+    const filtered = { ...doc };
+    delete filtered.extends;
+    return filtered;
+  }
+  if (typeof extendsPath !== 'string' || extendsPath.trim() === '') {
+    throw new Error(`invalid extends in ${absPath}: value must be a non-empty string`);
+  }
+
+  const nextPath = path.resolve(path.dirname(absPath), extendsPath.trim());
+  let parent: unknown;
+  try {
+    parent = loadPolicyFile(nextPath, [...stack, absPath], warnings);
+  } catch (e) {
+    if (e && typeof e === 'object' && (e as { __error?: string }).__error) {
+      throw e;
+    }
+    throw e;
+  }
+  if (parent && typeof parent === 'object' && '__error' in parent) {
+    throw new Error(String((parent as { __error: string }).__error));
+  }
+  if (!isPlainObject(parent)) {
+    throw new Error(`extends target must be an object: ${nextPath}`);
+  }
+  const child = { ...doc };
+  delete child.extends;
+  if (Object.keys(parent).length === 0) {
+    return child;
+  }
+  return mergePolicyValues(parent, child, warnings, '');
+}
+
+function isFileMissingError(e: unknown): e is { code: string } {
+  return typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'ENOENT';
+}
 
 export function parsePolicyFile(opts: ParsePolicyOptions = {}): ParsePolicyResult {
   const policyPath = opts && opts.policyPath;
   if (!policyPath) {
-    return { ok: false, errors: ['policyPath is required'], policy: null };
+    return { ok: false, errors: ['policyPath is required'], warnings: [], policy: null };
   }
 
   try {
-    const policy = yaml.load(fs.readFileSync(policyPath, 'utf8')) as Partial<CDNSecurityFrameworkPolicy>;
-    return { ok: true, errors: [], policy };
+    const warnings: string[] = [];
+    const policy = loadPolicyFile(policyPath, [], warnings);
+    if (isPlainObject(policy)) {
+      return { ok: true, errors: [], warnings, policy: policy as Partial<CDNSecurityFrameworkPolicy> };
+    }
+    if (policy && typeof policy === 'object' && '__error' in policy) {
+      const message = String((policy as { __error: string }).__error);
+      return { ok: false, errors: [message], warnings, policy: null };
+    }
+    return {
+      ok: false,
+      warnings,
+      errors: ['loaded policy is not an object'],
+      policy: null,
+    };
   } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
-      return { ok: false, errors: [`policy file not found: ${policyPath}`], policy: null };
+    if (isFileMissingError(e)) {
+      return { ok: false, errors: [`policy file not found: ${policyPath}`], warnings: [], policy: null };
     }
     const message = e instanceof Error ? e.message : String(e);
     return {
       ok: false,
       errors: [`failed to parse policy YAML: ${message}`],
+      warnings: [],
       policy: null,
     };
   }

--- a/src/scripts/compile-cloudflare-waf.ts
+++ b/src/scripts/compile-cloudflare-waf.ts
@@ -17,7 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 
 const parity = require('./lib/cloudflare-waf-parity');
 
@@ -46,9 +46,32 @@ function recordParity(entry: any) {
   sawApproximationOrUnsupported = true;
 }
 
+function reportPolicyWarnings(warnings: string[]) {
+  if (warnings.length === 0) return;
+  console.warn('Policy parse warnings:', policyPath);
+  for (const warning of warnings) {
+    console.warn('  - ' + warning);
+  }
+}
+
+function loadPolicyWithWarnings(policyPath: string) {
+  const parsed = parsePolicyFile({ policyPath });
+  if (!parsed.ok) {
+    const message = parsed.errors.join('; ') || 'failed to parse policy';
+    const e: any = new Error(message);
+    if (message.startsWith('policy file not found:')) {
+      e.code = 'ENOENT';
+    }
+    throw e;
+  }
+  return parsed;
+}
+
 let policy;
 try {
-  policy = yaml.load(fs.readFileSync(policyPath, 'utf8'));
+  const parsed = loadPolicyWithWarnings(policyPath);
+  reportPolicyWarnings(parsed.warnings || []);
+  policy = parsed.policy;
 } catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -6,7 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const {
   parsePathPatterns,
   regexesLiteralCode,
@@ -45,10 +45,32 @@ for (let i = 0; i < argv.length; i++) {
 const allowPlaceholderToken = hasAllowPlaceholderFlag(argv);
 const failOnPermissive = hasFailOnPermissiveFlag(argv);
 
+function reportPolicyWarnings(warnings: string[]) {
+  if (warnings.length === 0) return;
+  console.warn('Policy parse warnings:', policyPath);
+  for (const warning of warnings) {
+    console.warn('  - ' + warning);
+  }
+}
+
+function loadPolicyWithWarnings(policyPath: string) {
+  const parsed = parsePolicyFile({ policyPath });
+  if (!parsed.ok) {
+    const message = parsed.errors.join('; ') || 'failed to parse policy';
+    const e: any = new Error(message);
+    if (message.startsWith('policy file not found:')) {
+      e.code = 'ENOENT';
+    }
+    throw e;
+  }
+  return parsed;
+}
+
 let policy;
 try {
-  const content = fs.readFileSync(policyPath, 'utf8');
-  policy = yaml.load(content);
+  const parsed = loadPolicyWithWarnings(policyPath);
+  reportPolicyWarnings(parsed.warnings || []);
+  policy = parsed.policy;
 } catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);

--- a/src/scripts/compile-infra.ts
+++ b/src/scripts/compile-infra.ts
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -36,10 +36,32 @@ if (!['full', 'rule-group'].includes(outputMode)) {
   process.exit(1);
 }
 
+function reportPolicyWarnings(warnings: string[]) {
+  if (warnings.length === 0) return;
+  console.warn('Policy parse warnings:', policyPath);
+  for (const warning of warnings) {
+    console.warn('  - ' + warning);
+  }
+}
+
+function loadPolicyWithWarnings(policyPath: string) {
+  const parsed = parsePolicyFile({ policyPath });
+  if (!parsed.ok) {
+    const message = parsed.errors.join('; ') || 'failed to parse policy';
+    const e: any = new Error(message);
+    if (message.startsWith('policy file not found:')) {
+      e.code = 'ENOENT';
+    }
+    throw e;
+  }
+  return parsed;
+}
+
 let policy;
 try {
-  const content = fs.readFileSync(policyPath, 'utf8');
-  policy = yaml.load(content);
+  const parsed = loadPolicyWithWarnings(policyPath);
+  reportPolicyWarnings(parsed.warnings || []);
+  policy = parsed.policy;
 } catch (e: any) {
   if (e.code === 'ENOENT') {
     console.error('Error: policy file not found:', policyPath);

--- a/src/scripts/compiler-phase-unit-tests.ts
+++ b/src/scripts/compiler-phase-unit-tests.ts
@@ -39,6 +39,95 @@ test('parser phase: parses YAML without invoking validation or emission', () => 
   }
 });
 
+test('parser phase: resolves transitive extends with deep merge', () => {
+  const tmp = mktmp();
+  const globalPath = path.join(tmp, 'global.yml');
+  const basePath = path.join(tmp, 'base.yml');
+  const childPath = path.join(tmp, 'child.yml');
+  fs.writeFileSync(globalPath, `version: 1
+defaults:
+  mode: monitor
+request:
+  allow_methods: [GET]
+  limits:
+    max_query_length: 1024
+response_headers:
+  hsts: "max-age=31536000"\n`, 'utf8');
+  fs.writeFileSync(basePath, `version: 1
+extends: ./global.yml
+request:
+  limits:
+    max_query_params: 30
+response_headers:
+  csp: "default-src 'self'"\n`, 'utf8');
+  fs.writeFileSync(childPath, `extends: ./base.yml
+defaults:
+  mode: enforce
+request:
+  limits:
+    max_query_params: 60
+`, 'utf8');
+  try {
+    const result = parsePolicyFile({ policyPath: childPath });
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.policy.defaults.mode, 'enforce');
+    assert.strictEqual(result.policy.request.limits.max_query_length, 1024);
+    assert.strictEqual(result.policy.request.limits.max_query_params, 60);
+    assert.deepStrictEqual(result.policy.request.allow_methods, ['GET']);
+    assert.strictEqual(result.policy.response_headers.csp, "default-src 'self'");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('parser phase: appends array entries from child to parent on inheritance', () => {
+  const tmp = mktmp();
+  const basePath = path.join(tmp, 'base.yml');
+  const childPath = path.join(tmp, 'child.yml');
+  fs.writeFileSync(basePath, `version: 1\nrequest:\n  allow_methods: [GET]\nresponse_headers: {}\n`, 'utf8');
+  fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  allow_methods: [POST]\nresponse_headers: {}\n`, 'utf8');
+  try {
+    const result = parsePolicyFile({ policyPath: childPath });
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.policy.request.allow_methods, ['GET', 'POST']);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('parser phase: merges nested objects with child overrides', () => {
+  const tmp = mktmp();
+  const basePath = path.join(tmp, 'base.yml');
+  const childPath = path.join(tmp, 'child.yml');
+  fs.writeFileSync(basePath, `version: 1\nrequest:\n  limits:\n    max_query_length: 1024\n    max_query_params: 20\nresponse_headers: {}\n`, 'utf8');
+  fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  limits:\n    max_query_params: 30\n    max_uri_length: 2048\nresponse_headers: {}\n`, 'utf8');
+  try {
+    const result = parsePolicyFile({ policyPath: childPath });
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.policy.request.limits.max_query_length, 1024);
+    assert.strictEqual(result.policy.request.limits.max_query_params, 30);
+    assert.strictEqual(result.policy.request.limits.max_uri_length, 2048);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('parser phase: emits unreachable-key warning when scalar replaces subtree', () => {
+  const tmp = mktmp();
+  const basePath = path.join(tmp, 'base.yml');
+  const childPath = path.join(tmp, 'child.yml');
+  fs.writeFileSync(basePath, `version: 1\nrequest:\n  limits:\n    max_query_length: 1024\nresponse_headers: {}\n`, 'utf8');
+  fs.writeFileSync(childPath, `version: 1\nextends: ./base.yml\nrequest:\n  limits: null\nresponse_headers: {}\n`, 'utf8');
+  try {
+    const result = parsePolicyFile({ policyPath: childPath });
+    assert.strictEqual(result.ok, true);
+    assert.ok(Array.isArray(result.warnings));
+    assert.ok(result.warnings.some((warning: string) => warning.includes('request.limits')));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('validator phase: validates an already-parsed policy without emitting files', () => {
   const tmp = mktmp();
   try {

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../../parser');
 const {
   assertInjectedConstDeclarations,
   injectTemplateCode,
@@ -40,8 +40,30 @@ function parseArgs(argv: string[], rootDir = repoRoot) {
 }
 
 function loadPolicy(policyPath: string) {
-  const content = fs.readFileSync(policyPath, 'utf8');
-  return yaml.load(content);
+  return loadPolicyWithWarnings(policyPath).policy;
+}
+
+function loadPolicyWithWarnings(policyPath: string) {
+  const parsed = parsePolicyFile({ policyPath });
+  if (!parsed.ok) {
+    const message = parsed.errors.join('; ') || 'failed to parse policy';
+    const err: any = new Error(message);
+    if (message.startsWith('policy file not found:')) {
+      err.code = 'ENOENT';
+    }
+    throw err;
+  }
+  return { policy: parsed.policy, warnings: parsed.warnings };
+}
+
+function reportPolicyWarnings(warnings: string[]) {
+  if (warnings.length === 0) {
+    return;
+  }
+  console.warn('Policy parse warnings:');
+  for (const warning of warnings) {
+    console.warn('  - ' + warning);
+  }
 }
 
 function extractRegex(source: string) {
@@ -920,9 +942,12 @@ function main(argv: string[] = process.argv.slice(2)) {
   const failOnPermissive = hasFailOnPermissiveFlag(argv);
   const strictOriginAuth = hasStrictOriginAuthFlag(argv);
   let policy;
+  let policyWarnings: string[] = [];
 
   try {
-    policy = loadPolicy(policyPath);
+    const parsed = loadPolicyWithWarnings(policyPath);
+    policy = parsed.policy;
+    policyWarnings = parsed.warnings;
   } catch (e: any) {
     if (e.code === 'ENOENT') {
       console.error('Error: policy file not found:', policyPath);
@@ -931,6 +956,7 @@ function main(argv: string[] = process.argv.slice(2)) {
     console.error('Error: failed to parse policy YAML:', e.message);
     process.exit(1);
   }
+  reportPolicyWarnings(policyWarnings);
 
   // Surface permissive-profile warning before wasting build time.
   const permissive = warnIfPermissive(policy, { failOnPermissive });

--- a/src/scripts/policy-lint.ts
+++ b/src/scripts/policy-lint.ts
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parsePolicyFile } = require('../parser');
 const Ajv = require('ajv');
 const { validateAuthGates, parsePathPatterns } = require('./lib/compile-core');
 
@@ -21,10 +21,6 @@ type AjvError = import('ajv').ErrorObject;
 
 function loadJson(filePath: string): any {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
-
-function loadYaml(filePath: string): any {
-  return yaml.load(fs.readFileSync(filePath, 'utf8'));
 }
 
 function formatAjvErrors(errors: AjvError[]): string[] {
@@ -50,13 +46,36 @@ function validateCorsCredentials(policy: any): string[] {
   ];
 }
 
+function loadPolicyFileWithWarnings(policyPath: string) {
+  const parsed = parsePolicyFile({ policyPath });
+  if (!parsed.ok) {
+    const message = parsed.errors.join('; ') || 'failed to parse policy';
+    const e: any = new Error(message);
+    if (message.startsWith('policy file not found:')) {
+      e.code = 'ENOENT';
+    }
+    throw e;
+  }
+  return parsed;
+}
+
+function reportPolicyWarnings(policyPath: string, warnings: string[]) {
+  if (warnings.length === 0) return;
+  console.warn('Policy parse warnings:', policyPath);
+  for (const warning of warnings) {
+    console.warn('  - ' + warning);
+  }
+}
+
 function main(): void {
   const policyPath = process.argv[2] || defaultPolicyPath;
   const errors: string[] = [];
 
   let policy;
   try {
-    policy = loadYaml(policyPath);
+    const parsed = loadPolicyFileWithWarnings(policyPath);
+    policy = parsed.policy;
+    reportPolicyWarnings(String(policyPath), parsed.warnings);
   } catch (e: any) {
     if (e.code === 'ENOENT') {
       console.error('Error: policy file not found:', policyPath);

--- a/src/scripts/schema-lint-tests.ts
+++ b/src/scripts/schema-lint-tests.ts
@@ -68,6 +68,63 @@ test('lint accepts in-range request.limits', () => {
   }
 });
 
+test('lint accepts policy inherited via extends', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-lint-'));
+  const basePath = path.join(dir, 'base.yml');
+  const childPath = path.join(dir, 'prod.yml');
+  fs.writeFileSync(basePath, basePolicy({}), 'utf8');
+  fs.writeFileSync(
+    childPath,
+    `
+extends: ./base.yml
+defaults:
+  mode: enforce
+`,
+    'utf8'
+  );
+  try {
+    const result: any = runLint(childPath);
+    assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('lint accepts transitive inheritance', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-lint-'));
+  const basePath = path.join(dir, 'base.yml');
+  const midPath = path.join(dir, 'mid.yml');
+  const childPath = path.join(dir, 'prod.yml');
+  fs.writeFileSync(basePath, basePolicy({}), 'utf8');
+  fs.writeFileSync(
+    midPath,
+    `
+extends: ./base.yml
+project: schema-lint-test
+request:
+  limits:
+    max_query_params: 40
+`,
+    'utf8'
+  );
+  fs.writeFileSync(
+    childPath,
+    `
+extends: ./mid.yml
+request:
+  limits:
+    max_uri_length: 4096
+`,
+    'utf8'
+  );
+  try {
+    const result: any = runLint(childPath);
+    assert.strictEqual(result.status, 0, `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('lint rejects max_query_length below minimum', () => {
   const { dir, file } = writeTempPolicy(basePolicy({ max_query_length: 0 }));
   try {

--- a/src/types/policy.d.ts
+++ b/src/types/policy.d.ts
@@ -10,6 +10,10 @@
  */
 export interface CDNSecurityFrameworkPolicy {
   version: 1;
+  /**
+   * Optional base policy path to extend. Path is resolved relative to the current policy file.
+   */
+  extends?: string;
   project?: string;
   /**
    * Optional profile / policy metadata. `risk_level` hints the intended security posture — `permissive` triggers a build-time warning so operators do not accidentally ship a loose policy to production.


### PR DESCRIPTION
## 問題 (Issue #167)
- README で示されている運用要件（共通ベースやマルチテナント運用）があるにもかかわらず、`policy.yml` の再利用ができずコピー運用になっていた。
- 環境固有の差分（例: staging は monitor、本番は enforce）を別ファイルで重複管理し、差分管理コストが高くなっていた。

## 変更内容
- `policy/schema.json`: `extends` を top-level の string フィールドとして追加。
- `src/parser/index.ts`: `extends` を再帰的に解決するパーサを実装し、親子関係の解決、循環リスクの回避、マージ結果の構築を追加。
  - マージ規則: オブジェクトは deep merge（子優先）、配列は親→子の append、スカラーは既存 subtree を上書き。
  - transitive chain (`child -> parent -> grandparent`) に対応。
- コンパイル系: `src/scripts/lib/compile-core.ts`, `src/scripts/compile-infra.ts`, `src/scripts/compile-cloudflare.ts`, `src/scripts/compile-cloudflare-waf.ts`, `src/scripts/policy-lint.ts`
  - `js-yaml` 直接ロードを廃止し、`parsePolicyFile` を経由する構成に変更。
  - parse 警告（到達不能キー含む）を出力に反映。
- `src/lib/lint.ts`: parse warnings を `LintReport` に保持。
- テスト拡張: `src/scripts/compiler-phase-unit-tests.ts`, `src/scripts/schema-lint-tests.ts`
  - transitive 継承、配列 append、ネスト object merge、scalar overwrite 警告の回帰テストを追加。
- ドキュメント: `docs/cli.md`, `docs/cli.ja.md`, `policy/README.md`, `policy/README.ja.md`
  - `build`/継承・overlay 仕様と merge セマンティクスを追記。

## 挙動の変化
- `build` / `lint` / `policy-lint` が `extends` を解決して継承ポリシーを扱えるようになった。
- 既存ポリシーを基底として、環境やサービス別の override を安全な merge で適用可能。
- `extends` の到達不能キーや scalar 上書き時に warning が確認できる。

## 実行した検証
- `npm install`
- `npm run build:ts`
- `node scripts/compiler-phase-unit-tests.js`
- `node scripts/schema-lint-tests.js`

## 残リスク / フォローアップ
- エラーメッセージ（欠落ファイルや循環参照）でのガイダンス改善は次イテレーションで追加可能。
- 他プロジェクトからの移行時に既存運用との差分レビューが必要。

Closes #167
