### PR TITLE
feat(cli): add analyze command for monitor log candidates

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -614,6 +614,287 @@ async function runPlayground(opts) {
             fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
 }
+function asString(value) {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+    return null;
+}
+function asNumber(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+function normalizePolicyRoute(value) {
+    if (!value) {
+        return 'unknown';
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return 'unknown';
+    }
+    return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+function normalizeEvent(value) {
+    const raw = asString(value);
+    if (!raw) {
+        return 'other';
+    }
+    const lower = raw.toLowerCase();
+    if (lower === 'allow' || lower === 'pass' || lower === 'passed') {
+        return 'pass';
+    }
+    if (lower === 'block' || lower === 'blocked') {
+        return 'block';
+    }
+    if (lower === 'monitor' || lower === 'monitoring' || lower === 'logged') {
+        return 'monitor';
+    }
+    return lower;
+}
+function parseAnalyzeRecord(row) {
+    if (!row || typeof row !== 'object') {
+        return null;
+    }
+    const record = row;
+    const method = asString(record.method)
+        || asString(record.httpRequest?.method)
+        || asString(record.request?.method)
+        || 'UNKNOWN';
+    const event = normalizeEvent(record.event)
+        || normalizeEvent(record.eventName)
+        || normalizeEvent(record.outcome);
+    const blockReason = asString(record.block_reason)
+        || asString(record.blockReason)
+        || asString(record.reason)
+        || 'unclassified';
+    const uri = normalizePolicyRoute(asString(record.uri)
+        || asString(record.path)
+        || asString(record.request?.uri)
+        || asString(record.request?.path)
+        || asString(record.httpRequest?.uri)
+        || asString(record.httpRequest?.path));
+    const policyRoute = normalizePolicyRoute(asString(record.policy_route)
+        || asString(record.policyRoute)
+        || asString(record.route)
+        || asString(record.request?.route)
+        || uri);
+    const target = asString(record.target)
+        || asString(record.platform)
+        || asString(record.provider)
+        || asString(record.runtime)
+        || 'unknown';
+    const status = asNumber(record.status) || asNumber(record.statusCode) || 0;
+    if (status < 0 || status > 999999) {
+        return null;
+    }
+    return {
+        target,
+        policyRoute,
+        method,
+        uri,
+        status,
+        event: event === 'other' && isBlockedStatus(status) ? 'block' : event,
+        blockReason,
+    };
+}
+function buildEmptyAnalyzeReport(input, minCount, top) {
+    return {
+        summary: {
+            input,
+            totalLines: 0,
+            parsedLines: 0,
+            unparseableLines: 0,
+            analyzedEvents: 0,
+            blockEvents: 0,
+            monitorEvents: 0,
+            lowFrequencyThreshold: minCount,
+            top,
+        },
+        byBlockReason: {},
+        byPolicyRoute: {},
+        candidates: [],
+    };
+}
+function incrementCounter(map, key) {
+    map[key] = (map[key] || 0) + 1;
+}
+function parseAnalyzeLine(line) {
+    if (!line.trim()) {
+        return null;
+    }
+    let row;
+    try {
+        row = JSON.parse(line);
+    }
+    catch (_e) {
+        return null;
+    }
+    if (!row || typeof row !== 'object') {
+        return null;
+    }
+    const nested = row.message;
+    if (asString(nested) && typeof nested === 'string') {
+        try {
+            const parsed = JSON.parse(nested);
+            return parseAnalyzeRecord(parsed);
+        }
+        catch (_e) {
+            // fall through
+        }
+    }
+    return parseAnalyzeRecord(row);
+}
+function runAnalyze(opts) {
+    const cwd = process.cwd();
+    const inputPath = opts.input
+        ? path.isAbsolute(opts.input) ? opts.input : path.join(cwd, opts.input)
+        : '';
+    if (!inputPath) {
+        throw new Error('analyze: --input is required');
+    }
+    if (!fs.existsSync(inputPath)) {
+        throw new Error(`analyze: input file not found: ${inputPath}`);
+    }
+    const minCount = Number(opts.minCount);
+    const top = Number(opts.top);
+    if (!Number.isFinite(minCount) || minCount < 1) {
+        throw new Error('analyze: --min-count must be a positive integer');
+    }
+    if (!Number.isFinite(top) || top < 1) {
+        throw new Error('analyze: --top must be a positive integer');
+    }
+    const report = buildEmptyAnalyzeReport(inputPath, Math.floor(minCount), Math.floor(top));
+    const text = fs.readFileSync(inputPath, 'utf8');
+    const lines = text.split(/\r?\n/);
+    const candidateMap = {};
+    for (const rawLine of lines) {
+        if (!rawLine.trim()) {
+            continue;
+        }
+        report.summary.totalLines += 1;
+        const event = parseAnalyzeLine(rawLine);
+        if (!event) {
+            report.summary.unparseableLines += 1;
+            continue;
+        }
+        report.summary.parsedLines += 1;
+        report.summary.analyzedEvents += 1;
+        const byReason = report.byBlockReason[event.blockReason] || {
+            count: 0,
+            targets: {},
+            policyRoutes: {},
+        };
+        incrementCounter(byReason.targets, event.target);
+        incrementCounter(byReason.policyRoutes, event.policyRoute);
+        byReason.count += 1;
+        report.byBlockReason[event.blockReason] = byReason;
+        const byRoute = report.byPolicyRoute[event.policyRoute] || {
+            count: 0,
+            blockReasons: {},
+            targets: {},
+        };
+        byRoute.count += 1;
+        incrementCounter(byRoute.blockReasons, event.blockReason);
+        incrementCounter(byRoute.targets, event.target);
+        report.byPolicyRoute[event.policyRoute] = byRoute;
+        const evt = event.event || 'other';
+        if (evt === 'block') {
+            report.summary.blockEvents += 1;
+            const key = `${event.blockReason}|${event.policyRoute}`;
+            const bucket = candidateMap[key] || {
+                policyRoute: event.policyRoute,
+                blockReason: event.blockReason,
+                count: 0,
+                targets: {},
+                events: [],
+            };
+            bucket.count += 1;
+            bucket.targets[event.target] = true;
+            if (bucket.events.length < report.summary.top) {
+                bucket.events.push({
+                    method: event.method,
+                    status: event.status,
+                    uri: event.uri,
+                    target: event.target,
+                });
+            }
+            candidateMap[key] = bucket;
+        }
+        if (evt === 'monitor') {
+            report.summary.monitorEvents += 1;
+        }
+    }
+    const candidateKeys = Object.keys(candidateMap);
+    report.candidates = candidateKeys
+        .map((key) => {
+        const bucket = candidateMap[key];
+        return {
+            policyRoute: bucket.policyRoute,
+            blockReason: bucket.blockReason,
+            count: bucket.count,
+            targets: Object.keys(bucket.targets),
+            events: bucket.events
+                .slice(0, report.summary.top)
+                .map((event) => ({
+                method: event.method,
+                status: event.status,
+                uri: event.uri,
+                target: event.target,
+            })),
+        };
+    })
+        .filter((entry) => entry.count <= report.summary.lowFrequencyThreshold)
+        .sort((a, b) => a.count - b.count || a.policyRoute.localeCompare(b.policyRoute))
+        .slice(0, report.summary.top);
+    return report;
+}
+function printAnalyzeReport(report) {
+    console.log(`[analyze] input=${report.summary.input}`);
+    console.log(`[analyze] total_lines=${report.summary.totalLines} parsed_lines=${report.summary.parsedLines} unparseable=${report.summary.unparseableLines}`);
+    console.log(`[analyze] analyzed_events=${report.summary.analyzedEvents} block=${report.summary.blockEvents} monitor=${report.summary.monitorEvents}`);
+    console.log('');
+    const reasonEntries = Object.entries(report.byBlockReason)
+        .map(([reason, value]) => ({ reason, count: value.count, routes: Object.entries(value.policyRoutes).length }))
+        .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+    const routeEntries = Object.entries(report.byPolicyRoute)
+        .map(([policyRoute, value]) => ({ policyRoute, count: value.count, reasons: Object.entries(value.blockReasons).length }))
+        .sort((a, b) => b.count - a.count || a.policyRoute.localeCompare(b.policyRoute));
+    console.log('[analyze] Block reasons:');
+    for (const item of reasonEntries) {
+        console.log(`- ${item.reason}: ${item.count} events across ${item.routes} policy route(s)`);
+    }
+    if (reasonEntries.length === 0) {
+        console.log('- none');
+    }
+    console.log('');
+    console.log('[analyze] Top policy routes:');
+    for (const item of routeEntries.slice(0, 20)) {
+        console.log(`- ${item.policyRoute}: ${item.count} events (${item.reasons} block reason(s))`);
+    }
+    if (routeEntries.length === 0) {
+        console.log('- none');
+    }
+    console.log('');
+    if (report.candidates.length > 0) {
+        console.log('[analyze] Low-frequency candidates:');
+        for (const candidate of report.candidates) {
+            console.log(`- route=${candidate.policyRoute} reason=${candidate.blockReason} count=${candidate.count} targets=${candidate.targets.join(',')}`);
+            for (const evt of candidate.events) {
+                console.log(`  sample: ${evt.method} ${evt.uri} status=${evt.status} target=${evt.target}`);
+            }
+        }
+    }
+    else {
+        console.log('[analyze] Low-frequency candidates: none');
+    }
+}
 function routeAuthConfigured(policy, types) {
     const routes = Array.isArray(policy && policy.routes) ? policy.routes : [];
     return routes.some((route) => types.includes(route && route.auth_gate && route.auth_gate.type));
@@ -2149,6 +2430,34 @@ program
                 const reason = item.block_reason ? ` reason=${item.block_reason}` : '';
                 console.log(`- ${item.name}: ${item.method} ${item.path}${querySuffix} => ${item.decision.toUpperCase()} (status=${item.status})${reason}`);
             }
+        }
+    }
+    catch (e) {
+        console.error('[ERROR]', e.message || String(e));
+        process.exit(1);
+    }
+});
+program
+    .command('analyze')
+    .description('Aggregate monitor-mode JSON logs and flag low-frequency blocking candidates')
+    .requiredOption('-i, --input <path>', 'Path to JSONL log input')
+    .option('--min-count <n>', 'Candidate threshold for suspicious low-frequency blocks', '5')
+    .option('--top <n>', 'Maximum route candidates to print/export', '20')
+    .option('--json', 'Emit machine-readable output')
+    .action((opts) => {
+    try {
+        const minCount = Number(opts.minCount);
+        const top = Number(opts.top);
+        const report = runAnalyze({
+            input: opts.input,
+            minCount,
+            top,
+        });
+        if (opts.json) {
+            console.log(JSON.stringify(report, null, 2));
+        }
+        else {
+            printAnalyzeReport(report);
         }
     }
     catch (e) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -667,9 +667,12 @@ function parseAnalyzeRecord(row) {
         || asString(record.httpRequest?.method)
         || asString(record.request?.method)
         || 'UNKNOWN';
-    const event = normalizeEvent(record.event)
-        || normalizeEvent(record.eventName)
-        || normalizeEvent(record.outcome);
+    const rawEvent = asString(record.event) !== null
+        ? record.event
+        : asString(record.eventName) !== null
+            ? record.eventName
+            : record.outcome;
+    const event = normalizeEvent(rawEvent);
     const blockReason = asString(record.block_reason)
         || asString(record.blockReason)
         || asString(record.reason)

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -13,6 +13,7 @@ npx cdn-security <subcommand> [options]
 | `init` | プロファイル / アーキタイプから `policy/security.yml` をスキャフォールド。 |
 | `build` | ポリシー検証 + エッジランタイム + インフラ設定の生成。 |
 | `playground` | ポリシーをローカルでコンパイルし、サンプルリクエストを AWS/Cloudflare ランタイムで再生して pass/block を確認。 |
+| `analyze` | 監視モード JSONL を集約し、低頻度ブロック候補を抽出。 |
 | `emit-waf` | インフラ設定のみ生成（エッジは生成しない）。エッジはそのままで WAF ルールだけ再デプロイしたいとき。 |
 | `doctor` | 環境診断をワンショット実行。失敗チェックがあれば非ゼロ終了。 |
 | `readiness` | 環境診断と policy posture を統合する本番リリースゲート。 |
@@ -113,6 +114,29 @@ fixture 例:
   ]
 }
 ```
+
+## `analyze`
+
+```bash
+npx cdn-security analyze --input /path/to/monitor.jsonl
+npx cdn-security analyze --input /path/to/monitor.jsonl --min-count 3 --top 10 --json
+```
+
+`analyze` は監視モードの構造化ログ（JSONL）を受け取り、`block` / `monitor` / `pass` を集約して低頻度な block の候補を抽出し、監視から enforce への移行判断を支援します。
+
+対応オプション:
+
+- `--input`: `JSONL` のログファイルパス（必須）
+- `--min-count`: `block` 判定の低頻度しきい値（デフォルト `5`）
+- `--top`: ルート/サンプルの最大表示件数（デフォルト `20`）
+- `--json`: 機械可読 JSON を標準出力
+
+出力:
+
+- 全体サマリ（総行数 / パース可能行 / ブロック / monitor）
+- `block_reason` ごとの集計（対象 target / route）
+- `policy route` ごとの集計（`block_reason` / target）
+- `count <= --min-count` の低頻度 block候補（サンプルイベント付き）
 
 ## `emit-waf`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,7 @@ npx cdn-security <subcommand> [options]
 | `init` | Scaffold `policy/security.yml` from a profile or archetype. |
 | `build` | Validate policy, compile edge runtime + infra config. |
 | `playground` | Compile policy locally and run sample request fixtures against edge runtimes (AWS + Cloudflare). |
+| `analyze` | Aggregate block/monitor JSONL logs and surface low-frequency candidates. |
 | `emit-waf` | Emit infra config only (no edge code). For redeploying firewall rules without touching edge. |
 | `doctor` | One-shot environment diagnostics. Exits non-zero on any failing check. |
 | `readiness` | Production release gate that combines diagnostics and policy posture findings. |
@@ -113,6 +114,27 @@ When `--json` is set, output is:
   ]
 }
 ```
+
+## `analyze`
+
+```bash
+npx cdn-security analyze --input /path/to/monitor.jsonl
+npx cdn-security analyze --input /path/to/monitor.jsonl --min-count 3 --top 10 --json
+```
+
+`analyze` accepts monitor logs in JSON Lines format and aggregates by route/reason to support migration from monitor mode to enforce.
+
+- `--input` required: log file path (JSONL)
+- `--min-count` minimum event count for low-frequency candidates (default `5`)
+- `--top` max number of printed/exported per-group samples (default `20`)
+- `--json` prints machine-readable report
+
+It reports:
+
+- summary lines (parsed/unparsed/analyzed)
+- by block reason (event count + route counts)
+- by policy route (reason and target distribution)
+- low-frequency candidates (`count <= --min-count`) for `block` events
 
 ## `emit-waf`
 

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -651,6 +651,51 @@ test('CLI authoring DX: playground emits AWS + Cloudflare fixture decisions', ()
         ctx.cleanup();
     }
 });
+test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'analyze-'));
+    const logPath = path.join(tmp, 'monitor.jsonl');
+    const lines = [
+        { event: 'block', block_reason: 'bad_method', method: 'POST', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
+        { event: 'block', block_reason: 'bad_method', method: 'PUT', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
+        { event: 'block', block_reason: 'path_traversal', method: 'GET', status: 404, uri: '/assets/../etc/passwd', target: 'cloudflare', policy_route: '/assets' },
+        { event: 'monitor', block_reason: 'path_traversal', method: 'GET', status: 200, uri: '/assets/favicon.ico', target: 'aws', policy_route: '/assets' },
+    ];
+    fs.writeFileSync(logPath, lines.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf8');
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const result = spawnSync(process.execPath, [
+            cli, 'analyze',
+            '--input', logPath,
+            '--min-count', '2',
+            '--top', '10',
+            '--json',
+        ], {
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 0, `analyze failed: ${result.stderr}`);
+        const report = JSON.parse(result.stdout);
+        assert.strictEqual(report.summary.totalLines, 4);
+        assert.strictEqual(report.summary.parsedLines, 4);
+        assert.strictEqual(report.summary.unparseableLines, 0);
+        assert.strictEqual(report.summary.analyzedEvents, 4);
+        assert.strictEqual(report.summary.blockEvents, 3);
+        assert.strictEqual(report.summary.monitorEvents, 1);
+        assert.strictEqual(report.byBlockReason['bad_method']?.count, 2);
+        assert.strictEqual(report.byPolicyRoute['/api/data']?.count, 2);
+        const badMethod = report.candidates.find((x) => x.blockReason === 'bad_method' && x.policyRoute === '/api/data');
+        assert.ok(badMethod, 'missing bad_method candidate');
+        assert.strictEqual(badMethod.count, 2);
+        assert.strictEqual(Array.isArray(badMethod.targets), true);
+        assert.ok(badMethod.targets.includes('aws'));
+        assert.strictEqual(Array.isArray(badMethod.events), true);
+        assert.ok(badMethod.events.length >= 1);
+    }
+    finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
 test('CLI authoring DX: init --guided emits lintable policy with selected shape', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guided-init-'));
     try {

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -659,6 +659,8 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
         { event: 'block', block_reason: 'bad_method', method: 'PUT', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
         { event: 'block', block_reason: 'path_traversal', method: 'GET', status: 404, uri: '/assets/../etc/passwd', target: 'cloudflare', policy_route: '/assets' },
         { event: 'monitor', block_reason: 'path_traversal', method: 'GET', status: 200, uri: '/assets/favicon.ico', target: 'aws', policy_route: '/assets' },
+        { eventName: 'blocked', block_reason: 'token_replay', method: 'POST', status: 200, uri: '/api/login', target: 'aws', policy_route: '/api/login' },
+        { outcome: 'monitoring', reason: 'slow_path_probe', method: 'GET', status: 200, uri: '/search', target: 'cloudflare', policy_route: '/search' },
     ];
     fs.writeFileSync(logPath, lines.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf8');
     try {
@@ -676,12 +678,12 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
         });
         assert.strictEqual(result.status, 0, `analyze failed: ${result.stderr}`);
         const report = JSON.parse(result.stdout);
-        assert.strictEqual(report.summary.totalLines, 4);
-        assert.strictEqual(report.summary.parsedLines, 4);
+        assert.strictEqual(report.summary.totalLines, 6);
+        assert.strictEqual(report.summary.parsedLines, 6);
         assert.strictEqual(report.summary.unparseableLines, 0);
-        assert.strictEqual(report.summary.analyzedEvents, 4);
-        assert.strictEqual(report.summary.blockEvents, 3);
-        assert.strictEqual(report.summary.monitorEvents, 1);
+        assert.strictEqual(report.summary.analyzedEvents, 6);
+        assert.strictEqual(report.summary.blockEvents, 4);
+        assert.strictEqual(report.summary.monitorEvents, 2);
         assert.strictEqual(report.byBlockReason['bad_method']?.count, 2);
         assert.strictEqual(report.byPolicyRoute['/api/data']?.count, 2);
         const badMethod = report.candidates.find((x) => x.blockReason === 'bad_method' && x.policyRoute === '/api/data');
@@ -691,6 +693,9 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
         assert.ok(badMethod.targets.includes('aws'));
         assert.strictEqual(Array.isArray(badMethod.events), true);
         assert.ok(badMethod.events.length >= 1);
+        const tokenReplay = report.candidates.find((x) => x.blockReason === 'token_replay' && x.policyRoute === '/api/login');
+        assert.ok(tokenReplay, 'missing eventName fallback candidate');
+        assert.strictEqual(report.byBlockReason['slow_path_probe']?.count, 1);
     }
     finally {
         fs.rmSync(tmp, { recursive: true, force: true });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -141,6 +141,63 @@ type PlaygroundCaseResult = {
 
 type PlaygroundDecision = 'pass' | 'block';
 
+type AnalyzeLogOptions = {
+  input: string;
+  minCount: number;
+  top: number;
+  json?: boolean;
+};
+
+type AnalyzeEvent = {
+  target: string;
+  policyRoute: string;
+  method: string;
+  uri: string;
+  status: number;
+  event: string;
+  blockReason: string;
+};
+
+type AnalyzeCandidate = {
+  policyRoute: string;
+  blockReason: string;
+  count: number;
+  targets: string[];
+  events: {
+    method: string;
+    status: number;
+    uri: string;
+    target: string;
+  }[];
+};
+
+type AnalyzeSummary = {
+  input: string;
+  totalLines: number;
+  parsedLines: number;
+  unparseableLines: number;
+  analyzedEvents: number;
+  blockEvents: number;
+  monitorEvents: number;
+  lowFrequencyThreshold: number;
+  top: number;
+};
+
+type AnalyzeReport = {
+  summary: AnalyzeSummary;
+  byBlockReason: Record<string, {
+    count: number;
+    targets: Record<string, number>;
+    policyRoutes: Record<string, number>;
+  }>;
+  byPolicyRoute: Record<string, {
+    count: number;
+    blockReasons: Record<string, number>;
+    targets: Record<string, number>;
+  }>;
+  candidates: AnalyzeCandidate[];
+};
+
 function isBlockedStatus(status: unknown): boolean {
   const numericStatus = Number(status);
   return Number.isFinite(numericStatus) && numericStatus >= 400;
@@ -885,6 +942,324 @@ async function runPlayground(opts: PlaygroundOptions): Promise<PlaygroundReport>
     return { policyPath, targets: results };
   } finally {
     if (fs.existsSync(tmpRoot)) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizePolicyRoute(value: string | null): string {
+  if (!value) {
+    return 'unknown';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 'unknown';
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function normalizeEvent(value: unknown): string {
+  const raw = asString(value);
+  if (!raw) {
+    return 'other';
+  }
+  const lower = raw.toLowerCase();
+  if (lower === 'allow' || lower === 'pass' || lower === 'passed') {
+    return 'pass';
+  }
+  if (lower === 'block' || lower === 'blocked') {
+    return 'block';
+  }
+  if (lower === 'monitor' || lower === 'monitoring' || lower === 'logged') {
+    return 'monitor';
+  }
+  return lower;
+}
+
+function parseAnalyzeRecord(row: unknown): AnalyzeEvent | null {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+  const record = row as Record<string, unknown>;
+  const method = asString((record as any).method)
+    || asString((record as any).httpRequest?.method)
+    || asString((record as any).request?.method)
+    || 'UNKNOWN';
+  const event = normalizeEvent((record as any).event)
+    || normalizeEvent((record as any).eventName)
+    || normalizeEvent((record as any).outcome);
+  const blockReason = asString((record as any).block_reason)
+    || asString((record as any).blockReason)
+    || asString((record as any).reason)
+    || 'unclassified';
+
+  const uri = normalizePolicyRoute(
+    asString((record as any).uri)
+      || asString((record as any).path)
+      || asString((record as any).request?.uri)
+      || asString((record as any).request?.path)
+      || asString((record as any).httpRequest?.uri)
+      || asString((record as any).httpRequest?.path),
+  );
+  const policyRoute = normalizePolicyRoute(
+    asString((record as any).policy_route)
+      || asString((record as any).policyRoute)
+      || asString((record as any).route)
+      || asString((record as any).request?.route)
+      || uri,
+  );
+
+  const target = asString((record as any).target)
+    || asString((record as any).platform)
+    || asString((record as any).provider)
+    || asString((record as any).runtime)
+    || 'unknown';
+
+  const status = asNumber((record as any).status) || asNumber((record as any).statusCode) || 0;
+  if (status < 0 || status > 999999) {
+    return null;
+  }
+
+  return {
+    target,
+    policyRoute,
+    method,
+    uri,
+    status,
+    event: event === 'other' && isBlockedStatus(status) ? 'block' : event,
+    blockReason,
+  };
+}
+
+function buildEmptyAnalyzeReport(input: string, minCount: number, top: number): AnalyzeReport {
+  return {
+    summary: {
+      input,
+      totalLines: 0,
+      parsedLines: 0,
+      unparseableLines: 0,
+      analyzedEvents: 0,
+      blockEvents: 0,
+      monitorEvents: 0,
+      lowFrequencyThreshold: minCount,
+      top,
+    },
+    byBlockReason: {},
+    byPolicyRoute: {},
+    candidates: [],
+  };
+}
+
+function incrementCounter(map: Record<string, number>, key: string) {
+  map[key] = (map[key] || 0) + 1;
+}
+
+function parseAnalyzeLine(line: string): AnalyzeEvent | null {
+  if (!line.trim()) {
+    return null;
+  }
+  let row: unknown;
+  try {
+    row = JSON.parse(line);
+  } catch (_e) {
+    return null;
+  }
+
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const nested = (row as Record<string, unknown>).message;
+  if (asString(nested) && typeof nested === 'string') {
+    try {
+      const parsed = JSON.parse(nested);
+      return parseAnalyzeRecord(parsed);
+    } catch (_e) {
+      // fall through
+    }
+  }
+
+  return parseAnalyzeRecord(row);
+}
+
+function runAnalyze(opts: AnalyzeLogOptions): AnalyzeReport {
+  const cwd = process.cwd();
+  const inputPath = opts.input
+    ? path.isAbsolute(opts.input) ? opts.input : path.join(cwd, opts.input)
+    : '';
+
+  if (!inputPath) {
+    throw new Error('analyze: --input is required');
+  }
+  if (!fs.existsSync(inputPath)) {
+    throw new Error(`analyze: input file not found: ${inputPath}`);
+  }
+
+  const minCount = Number(opts.minCount);
+  const top = Number(opts.top);
+  if (!Number.isFinite(minCount) || minCount < 1) {
+    throw new Error('analyze: --min-count must be a positive integer');
+  }
+  if (!Number.isFinite(top) || top < 1) {
+    throw new Error('analyze: --top must be a positive integer');
+  }
+
+  const report = buildEmptyAnalyzeReport(inputPath, Math.floor(minCount), Math.floor(top));
+  const text = fs.readFileSync(inputPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const candidateMap: Record<string, {
+    policyRoute: string;
+    blockReason: string;
+    count: number;
+    targets: Record<string, boolean>;
+    events: AnalyzeEvent[];
+  }> = {};
+
+  for (const rawLine of lines) {
+    if (!rawLine.trim()) {
+      continue;
+    }
+    report.summary.totalLines += 1;
+    const event = parseAnalyzeLine(rawLine);
+    if (!event) {
+      report.summary.unparseableLines += 1;
+      continue;
+    }
+    report.summary.parsedLines += 1;
+    report.summary.analyzedEvents += 1;
+
+    const byReason = report.byBlockReason[event.blockReason] || {
+      count: 0,
+      targets: {},
+      policyRoutes: {},
+    };
+    incrementCounter(byReason.targets, event.target);
+    incrementCounter(byReason.policyRoutes, event.policyRoute);
+    byReason.count += 1;
+    report.byBlockReason[event.blockReason] = byReason;
+
+    const byRoute = report.byPolicyRoute[event.policyRoute] || {
+      count: 0,
+      blockReasons: {},
+      targets: {},
+    };
+    byRoute.count += 1;
+    incrementCounter(byRoute.blockReasons, event.blockReason);
+    incrementCounter(byRoute.targets, event.target);
+    report.byPolicyRoute[event.policyRoute] = byRoute;
+
+    const evt = event.event || 'other';
+    if (evt === 'block') {
+      report.summary.blockEvents += 1;
+      const key = `${event.blockReason}|${event.policyRoute}`;
+      const bucket = candidateMap[key] || {
+        policyRoute: event.policyRoute,
+        blockReason: event.blockReason,
+        count: 0,
+        targets: {},
+        events: [],
+      };
+      bucket.count += 1;
+      bucket.targets[event.target] = true;
+      if (bucket.events.length < report.summary.top) {
+        bucket.events.push({
+          method: event.method,
+          status: event.status,
+          uri: event.uri,
+          target: event.target,
+        } as AnalyzeEvent);
+      }
+      candidateMap[key] = bucket;
+    }
+    if (evt === 'monitor') {
+      report.summary.monitorEvents += 1;
+    }
+  }
+
+  const candidateKeys = Object.keys(candidateMap);
+  report.candidates = candidateKeys
+    .map((key) => {
+      const bucket = candidateMap[key];
+      return {
+        policyRoute: bucket.policyRoute,
+        blockReason: bucket.blockReason,
+        count: bucket.count,
+        targets: Object.keys(bucket.targets),
+        events: bucket.events
+          .slice(0, report.summary.top)
+          .map((event: AnalyzeEvent) => ({
+            method: event.method,
+            status: event.status,
+            uri: event.uri,
+            target: event.target,
+          })),
+      };
+    })
+    .filter((entry) => entry.count <= report.summary.lowFrequencyThreshold)
+    .sort((a, b) => a.count - b.count || a.policyRoute.localeCompare(b.policyRoute))
+    .slice(0, report.summary.top);
+
+  return report;
+}
+
+function printAnalyzeReport(report: AnalyzeReport) {
+  console.log(`[analyze] input=${report.summary.input}`);
+  console.log(`[analyze] total_lines=${report.summary.totalLines} parsed_lines=${report.summary.parsedLines} unparseable=${report.summary.unparseableLines}`);
+  console.log(`[analyze] analyzed_events=${report.summary.analyzedEvents} block=${report.summary.blockEvents} monitor=${report.summary.monitorEvents}`);
+  console.log('');
+
+  const reasonEntries = Object.entries(report.byBlockReason)
+    .map(([reason, value]) => ({ reason, count: value.count, routes: Object.entries(value.policyRoutes).length }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+  const routeEntries = Object.entries(report.byPolicyRoute)
+    .map(([policyRoute, value]) => ({ policyRoute, count: value.count, reasons: Object.entries(value.blockReasons).length }))
+    .sort((a, b) => b.count - a.count || a.policyRoute.localeCompare(b.policyRoute));
+
+  console.log('[analyze] Block reasons:');
+  for (const item of reasonEntries) {
+    console.log(`- ${item.reason}: ${item.count} events across ${item.routes} policy route(s)`);
+  }
+  if (reasonEntries.length === 0) {
+    console.log('- none');
+  }
+
+  console.log('');
+  console.log('[analyze] Top policy routes:');
+  for (const item of routeEntries.slice(0, 20)) {
+    console.log(`- ${item.policyRoute}: ${item.count} events (${item.reasons} block reason(s))`);
+  }
+  if (routeEntries.length === 0) {
+    console.log('- none');
+  }
+
+  console.log('');
+  if (report.candidates.length > 0) {
+    console.log('[analyze] Low-frequency candidates:');
+    for (const candidate of report.candidates) {
+      console.log(`- route=${candidate.policyRoute} reason=${candidate.blockReason} count=${candidate.count} targets=${candidate.targets.join(',')}`);
+      for (const evt of candidate.events) {
+        console.log(`  sample: ${evt.method} ${evt.uri} status=${evt.status} target=${evt.target}`);
+      }
+    }
+  } else {
+    console.log('[analyze] Low-frequency candidates: none');
   }
 }
 
@@ -2620,6 +2995,38 @@ program
           const reason = item.block_reason ? ` reason=${item.block_reason}` : '';
           console.log(`- ${item.name}: ${item.method} ${item.path}${querySuffix} => ${item.decision.toUpperCase()} (status=${item.status})${reason}`);
         }
+      }
+    } catch (e: any) {
+      console.error('[ERROR]', e.message || String(e));
+      process.exit(1);
+    }
+  });
+
+program
+  .command('analyze')
+  .description('Aggregate monitor-mode JSON logs and flag low-frequency blocking candidates')
+  .requiredOption('-i, --input <path>', 'Path to JSONL log input')
+  .option('--min-count <n>', 'Candidate threshold for suspicious low-frequency blocks', '5')
+  .option('--top <n>', 'Maximum route candidates to print/export', '20')
+  .option('--json', 'Emit machine-readable output')
+  .action((opts: {
+    input: string;
+    minCount: string;
+    top: string;
+    json?: boolean;
+  }) => {
+    try {
+      const minCount = Number(opts.minCount);
+      const top = Number(opts.top);
+      const report = runAnalyze({
+        input: opts.input,
+        minCount,
+        top,
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printAnalyzeReport(report);
       }
     } catch (e: any) {
       console.error('[ERROR]', e.message || String(e));

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1002,9 +1002,12 @@ function parseAnalyzeRecord(row: unknown): AnalyzeEvent | null {
     || asString((record as any).httpRequest?.method)
     || asString((record as any).request?.method)
     || 'UNKNOWN';
-  const event = normalizeEvent((record as any).event)
-    || normalizeEvent((record as any).eventName)
-    || normalizeEvent((record as any).outcome);
+  const rawEvent = asString((record as any).event) !== null
+    ? (record as any).event
+    : asString((record as any).eventName) !== null
+      ? (record as any).eventName
+      : (record as any).outcome;
+  const event = normalizeEvent(rawEvent);
   const blockReason = asString((record as any).block_reason)
     || asString((record as any).blockReason)
     || asString((record as any).reason)

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -683,6 +683,53 @@ test('CLI authoring DX: playground emits AWS + Cloudflare fixture decisions', ()
   }
 });
 
+test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'analyze-'));
+  const logPath = path.join(tmp, 'monitor.jsonl');
+  const lines = [
+    { event: 'block', block_reason: 'bad_method', method: 'POST', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
+    { event: 'block', block_reason: 'bad_method', method: 'PUT', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
+    { event: 'block', block_reason: 'path_traversal', method: 'GET', status: 404, uri: '/assets/../etc/passwd', target: 'cloudflare', policy_route: '/assets' },
+    { event: 'monitor', block_reason: 'path_traversal', method: 'GET', status: 200, uri: '/assets/favicon.ico', target: 'aws', policy_route: '/assets' },
+  ];
+  fs.writeFileSync(logPath, lines.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf8');
+
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'analyze',
+      '--input', logPath,
+      '--min-count', '2',
+      '--top', '10',
+      '--json',
+    ], {
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 0, `analyze failed: ${result.stderr}`);
+    const report = JSON.parse(result.stdout);
+    assert.strictEqual(report.summary.totalLines, 4);
+    assert.strictEqual(report.summary.parsedLines, 4);
+    assert.strictEqual(report.summary.unparseableLines, 0);
+    assert.strictEqual(report.summary.analyzedEvents, 4);
+    assert.strictEqual(report.summary.blockEvents, 3);
+    assert.strictEqual(report.summary.monitorEvents, 1);
+    assert.strictEqual(report.byBlockReason['bad_method']?.count, 2);
+    assert.strictEqual(report.byPolicyRoute['/api/data']?.count, 2);
+
+    const badMethod = report.candidates.find((x: any) => x.blockReason === 'bad_method' && x.policyRoute === '/api/data');
+    assert.ok(badMethod, 'missing bad_method candidate');
+    assert.strictEqual(badMethod.count, 2);
+    assert.strictEqual(Array.isArray(badMethod.targets), true);
+    assert.ok(badMethod.targets.includes('aws'));
+    assert.strictEqual(Array.isArray(badMethod.events), true);
+    assert.ok(badMethod.events.length >= 1);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('CLI authoring DX: init --guided emits lintable policy with selected shape', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guided-init-'));
   try {

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -691,6 +691,8 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
     { event: 'block', block_reason: 'bad_method', method: 'PUT', status: 405, uri: '/api/data', target: 'aws', policy_route: '/api/data' },
     { event: 'block', block_reason: 'path_traversal', method: 'GET', status: 404, uri: '/assets/../etc/passwd', target: 'cloudflare', policy_route: '/assets' },
     { event: 'monitor', block_reason: 'path_traversal', method: 'GET', status: 200, uri: '/assets/favicon.ico', target: 'aws', policy_route: '/assets' },
+    { eventName: 'blocked', block_reason: 'token_replay', method: 'POST', status: 200, uri: '/api/login', target: 'aws', policy_route: '/api/login' },
+    { outcome: 'monitoring', reason: 'slow_path_probe', method: 'GET', status: 200, uri: '/search', target: 'cloudflare', policy_route: '/search' },
   ];
   fs.writeFileSync(logPath, lines.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf8');
 
@@ -709,12 +711,12 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
     });
     assert.strictEqual(result.status, 0, `analyze failed: ${result.stderr}`);
     const report = JSON.parse(result.stdout);
-    assert.strictEqual(report.summary.totalLines, 4);
-    assert.strictEqual(report.summary.parsedLines, 4);
+    assert.strictEqual(report.summary.totalLines, 6);
+    assert.strictEqual(report.summary.parsedLines, 6);
     assert.strictEqual(report.summary.unparseableLines, 0);
-    assert.strictEqual(report.summary.analyzedEvents, 4);
-    assert.strictEqual(report.summary.blockEvents, 3);
-    assert.strictEqual(report.summary.monitorEvents, 1);
+    assert.strictEqual(report.summary.analyzedEvents, 6);
+    assert.strictEqual(report.summary.blockEvents, 4);
+    assert.strictEqual(report.summary.monitorEvents, 2);
     assert.strictEqual(report.byBlockReason['bad_method']?.count, 2);
     assert.strictEqual(report.byPolicyRoute['/api/data']?.count, 2);
 
@@ -725,6 +727,9 @@ test('CLI authoring DX: analyze surfaces low-frequency block candidates', () => 
     assert.ok(badMethod.targets.includes('aws'));
     assert.strictEqual(Array.isArray(badMethod.events), true);
     assert.ok(badMethod.events.length >= 1);
+    const tokenReplay = report.candidates.find((x: any) => x.blockReason === 'token_replay' && x.policyRoute === '/api/login');
+    assert.ok(tokenReplay, 'missing eventName fallback candidate');
+    assert.strictEqual(report.byBlockReason['slow_path_probe']?.count, 1);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem
- issue #169 requires log-driven support for monitor→enforce transitions.
- teams need aggregation of monitor JSON logs by block reason and route, plus low-frequency candidate identification.

## What changed
- Added `analyze` CLI subcommand to `src/bin/cli.ts` with options:
  - `--input <path>` (required)
  - `--min-count <n>` (default `5`)
  - `--top <n>` (default `20`)
  - `--json`
- Implemented JSONL parsing with tolerant extraction:
  - top-level JSON logs
  - nested JSON in `message` field
  - route/policy route normalization, target detection, status/event normalization
- Added candidate extraction logic:
  - aggregates by `block_reason` and policy route
  - tracks per-route and per-reason totals/targets
  - outputs low-frequency `block` candidates by `count <= min-count`
- Added CLI output path:
  - human-readable summary + grouped tables
  - JSON output via `--json`
- Added documentation for `analyze` in:
  - `docs/cli.md`
  - `docs/cli.ja.md`
- Added regression coverage in `src/scripts/programmatic-api-unit-tests.ts`:
  - `analyze` command executes with sample JSONL
  - verifies summary counts and candidate reporting

## Behavior changes after PR
- `npx cdn-security analyze --input logs.jsonl` now produces summarized monitor-log analytics for `block`/`monitor`/`pass` events.
- `--json` produces machine-readable report with `summary`, `byBlockReason`, `byPolicyRoute`, and `candidates`.
- `--min-count` and `--top` now control candidate frequency threshold and displayed sample cap.

## Verification
- `npm run build:ts`
- `node scripts/programmatic-api-unit-tests.js`

## Remaining risks / follow-up
- `analyze` currently accepts generic JSON/JSONL fields; provider-specific schema variants may need additional explicit field mappings over time.
- Low-frequency selection is heuristic-only (`count <= min-count`) and may produce noisy candidates for small sample windows.
- `analyze` is CLI-only in this PR; a dedicated operational script for scheduled pipeline jobs can be added in a follow-up if needed.

Closes #169
