### PR TITLE
Fix: [Refactor P0-4] Fix injectTemplateCode corrupting output when injected config contains $-replacement sequences

### DIFF
--- a/src/scripts/lib/template-inject.ts
+++ b/src/scripts/lib/template-inject.ts
@@ -34,7 +34,9 @@ function injectTemplateCode(template: string, marker: string, code: string): str
   if (count !== 1) {
     throw new Error(`Template marker ${marker} must appear exactly once, found ${count}`);
   }
-  return template.replace(marker, code);
+  // Use function replacement to avoid String.prototype.replace expanding $-replacement sequences
+  // that can corrupt injected JS when `code` contains $&/$`/$' and similar patterns.
+  return template.replace(marker, () => code);
 }
 
 function parseForConstInspection(code: string, loader: 'js' | 'ts') {


### PR DESCRIPTION
Resolves #180.

Summary:
Fix conservador en injectTemplateCode para evitar corrupción cuando el código inyectado contiene secuencias de reemplazo especiales ($& $` $' $$ $1..).

Tests:
- Not run by cloud worker.

Risks:
- No se pudo agregar un test de regresión porque no fueron provistos archivos de tests/unit existentes (p.ej. compile-unit-tests.ts). Aun así, el cambio es mínimo y de bajo riesgo: afecta solo la forma de reemplazo manteniendo la semántica del texto inyectado.

Generated by Investor Agent on branch investor-agent/issue-180.