### PR TITLE
fix(cli): avoid duplicate visualize class directive

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -223,12 +223,6 @@ function renderPolicyVisualization(policyPath, target, options) {
     lines.push('  classDef unsupported fill:#fee2e2,stroke:#dc2626,color:#7f1d1d');
     lines.push('  classDef target_specific fill:#fef9c3,stroke:#ca8a04,color:#713f12');
     lines.push(`  class policy,edge,waf,origin,response enforce`);
-    if (controls.length === 0) {
-        lines.push('  class policy,edge,waf,origin,response enforce');
-    }
-    else {
-        lines.push('  class policy,edge,waf,origin,response enforce');
-    }
     lines.push(`  %% target: ${requestedTargets.join(', ')}`);
     const mermaid = lines.join('\n') + '\n';
     if (options?.format === 'html') {

--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -944,6 +944,9 @@ test('CLI authoring DX: visualize emits mermaid with control coverage', () => {
         assert.ok(result.stdout.includes('request.graphql_guard'));
         assert.ok(result.stdout.includes('response_dlp'));
         assert.ok(result.stdout.includes('(monitor)'));
+        const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
+        const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
+        assert.strictEqual(baseClassDirectiveCount, 1);
     }
     finally {
         ctx.cleanup();

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -480,11 +480,6 @@ function renderPolicyVisualization(policyPath: string, target: CapabilityDeployT
   lines.push('  classDef target_specific fill:#fef9c3,stroke:#ca8a04,color:#713f12');
 
   lines.push(`  class policy,edge,waf,origin,response enforce`);
-  if (controls.length === 0) {
-    lines.push('  class policy,edge,waf,origin,response enforce');
-  } else {
-    lines.push('  class policy,edge,waf,origin,response enforce');
-  }
   lines.push(`  %% target: ${requestedTargets.join(', ')}`);
 
   const mermaid = lines.join('\n') + '\n';

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -986,6 +986,9 @@ test('CLI authoring DX: visualize emits mermaid with control coverage', () => {
     assert.ok(result.stdout.includes('request.graphql_guard'));
     assert.ok(result.stdout.includes('response_dlp'));
     assert.ok(result.stdout.includes('(monitor)'));
+    const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
+    const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
+    assert.strictEqual(baseClassDirectiveCount, 1);
   } finally {
     ctx.cleanup();
   }


### PR DESCRIPTION
## Problem

`cdn-security visualize` emitted the same Mermaid base class directive twice from `renderPolicyVisualization`. Issue #181 reported this as a dead `if/else` branch that made the generated Mermaid noisier and made the code harder to reason about.

Closes #181.

## Changes

- Removed the duplicate `class policy,edge,waf,origin,response enforce` emission from `src/bin/cli.ts`.
- Added a focused CLI regression assertion in `programmatic-api-unit-tests` that the base Mermaid class directive appears exactly once.
- Regenerated the committed JS outputs with `npm run build:ts`.

## Behavior after this PR

`cdn-security visualize` still emits the same Mermaid graph structure, class definitions, and target metadata, but the base `class policy,edge,waf,origin,response enforce` directive is present once instead of twice.

Manual check:

```text
$ node bin/cli.js visualize --policy policy/base.yml --target aws | awk 'index($0,"class policy,edge,waf,origin,response enforce") { count++ } END { print "class directive count=" count }'\nclass directive count=1\n```\n\n## Verification\n\n- RED before fix: `node scripts/programmatic-api-unit-tests.js` failed with `2 !== 1` for the new visualize class directive assertion.\n- `npm run build:ts`\n- `node scripts/programmatic-api-unit-tests.js`\n- `node bin/cli.js visualize --policy policy/base.yml --target aws` class directive count = 1\n- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run test:ci`\n\n## Risks / follow-up\n\nLow risk. This intentionally does not add new styling behavior or restore any speculative controls-based style branch; that remains out of scope for #181.