### PR TITLE
refactor: centralize value normalization helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:api-contract": "npm run build:ts && node scripts/api-contract-tests.js",
     "test:vitest": "npm run build:ts && node scripts/ensure-report-dir.js && vitest run",
     "test:runtime": "npm run build:ts && node scripts/runtime-tests.js && node scripts/cloudflare-runtime-tests.js",
-    "test:unit": "npm run build:ts && node scripts/compiler-phase-unit-tests.js && node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js && node scripts/fingerprint-candidates-unit-tests.js",
+    "test:unit": "npm run build:ts && node scripts/value-normalize-unit-tests.js && node scripts/compiler-phase-unit-tests.js && node scripts/compile-unit-tests.js && node scripts/infra-unit-tests.js && node scripts/schema-lint-tests.js && node scripts/doctor-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js && node scripts/cloudflare-waf-parity-unit-tests.js && node scripts/fingerprint-candidates-unit-tests.js",
     "test:drift": "npm run build:ts && node scripts/check-drift.js",
     "test:security-baseline": "npm run build:ts && node scripts/security-baseline-check.js",
     "test:fuzz": "npm run build:ts && node scripts/regex-fuzz-tests.js",

--- a/scripts/cloudflare-runtime-tests.js
+++ b/scripts/cloudflare-runtime-tests.js
@@ -688,6 +688,23 @@ response_dlp:
     assert.ok(!body.includes('4111 1111 1111 1111'), body);
     assert.ok(body.includes('[MASKED]'), body);
 });
+test('cloudflare response DLP preserves whitespace-padded match lists for compatibility', () => {
+    const generated = compileCloudflare(`
+version: 1
+project: cf-dlp-whitespace-compat-test
+request:
+  allow_methods: ["GET"]
+response_dlp:
+  enabled: true
+  action: block
+  body:
+    content_types: [" application/json "]
+  headers:
+    names: [" x-api-key "]
+`);
+    assert.match(generated, /"contentTypes":\[" application\/json "\]/);
+    assert.match(generated, /"names":\[" x-api-key "\]/);
+});
 test('cloudflare response DLP blocks response body findings', async () => {
     const generated = compileCloudflare(`
 version: 1

--- a/scripts/compile-cloudflare-waf.js
+++ b/scripts/compile-cloudflare-waf.js
@@ -19,6 +19,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
+const { numberOr } = require('./lib/value-normalize');
 const parity = require('./lib/cloudflare-waf-parity');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -150,7 +151,7 @@ function makeBlockAction() {
             action: 'block',
             action_parameters: {
                 response: {
-                    status_code: Number(br.status_code) || 403,
+                    status_code: numberOr(br.status_code, 403),
                     content: String(br.body || 'blocked'),
                     content_type: (br.content_type === 'TEXT_HTML' ? 'text/html'
                         : br.content_type === 'APPLICATION_JSON' ? 'application/json'
@@ -247,7 +248,7 @@ if (waf.rate_limit) {
         ratelimit: {
             characteristics: ['ip.src'],
             period: 300,
-            requests_per_period: Number(waf.rate_limit) || 2000,
+            requests_per_period: numberOr(waf.rate_limit, 2000),
             mitigation_timeout: 600,
         },
     });

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { parsePolicyFile } = require('../parser');
 const { parsePathPatterns, regexesLiteralCode, validateAuthGates, hasAllowPlaceholderFlag, hasFailOnPermissiveFlag, hasCatastrophicBacktrackShape, compileRegexOrThrow, warnIfPermissive, warnSignedUrlReplay, buildChallengeConfig, buildGraphqlGuardConfig, buildAnomalyGuardConfig, buildObsConfig, } = require('./lib/compile-core');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
+const { clampNumber, normalizeStringList, numberOr, } = require('./lib/value-normalize');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
 const securityPath = path.join(repoRoot, 'policy', 'security.yml');
@@ -95,6 +96,10 @@ function normalizeResponseDlp(policyObj) {
     const headers = raw.headers || {};
     const detectors = raw.detectors || {};
     const defaultContentTypes = ['text/', 'application/json', 'application/xml', 'text/xml', 'application/javascript'];
+    const hasContentTypes = Array.isArray(body.content_types) && body.content_types.length > 0;
+    const hasHeaderNames = Array.isArray(headers.names) && headers.names.length > 0;
+    const contentTypes = normalizeStringList(body.content_types, 'lower');
+    const headerNames = normalizeStringList(headers.names, 'lower');
     const builtIn = Array.isArray(detectors.built_in) && detectors.built_in.length > 0
         ? detectors.built_in.filter((d) => d === 'api_key' || d === 'credit_card')
         : ['api_key', 'credit_card'];
@@ -125,24 +130,16 @@ function normalizeResponseDlp(policyObj) {
             enabled,
             action,
             mask: typeof raw.mask === 'string' && raw.mask ? raw.mask : '[REDACTED]',
-            blockStatus: Number.isFinite(Number(raw.block_status))
-                ? Math.max(400, Math.min(599, Number(raw.block_status)))
-                : 451,
+            blockStatus: clampNumber(raw.block_status, 400, 599, 451),
             blockBody: typeof raw.block_body === 'string' && raw.block_body ? raw.block_body : 'Response blocked by edge DLP',
             body: {
                 enabled: enabled && body.enabled !== false,
-                maxBytes: Number.isFinite(Number(body.max_bytes))
-                    ? Math.max(1, Math.min(131072, Number(body.max_bytes)))
-                    : 32768,
-                contentTypes: Array.isArray(body.content_types) && body.content_types.length > 0
-                    ? body.content_types.filter((s) => typeof s === 'string' && s.trim()).map((s) => s.toLowerCase())
-                    : defaultContentTypes,
+                maxBytes: clampNumber(body.max_bytes, 1, 131072, 32768),
+                contentTypes: hasContentTypes ? contentTypes : defaultContentTypes,
             },
             headers: {
                 enabled: enabled && headers.enabled !== false,
-                names: Array.isArray(headers.names) && headers.names.length > 0
-                    ? headers.names.filter((s) => typeof s === 'string' && s.trim()).map((s) => s.toLowerCase())
-                    : ['set-cookie', 'authorization', 'x-api-key'],
+                names: hasHeaderNames ? headerNames : ['set-cookie', 'authorization', 'x-api-key'],
             },
             detectors: { builtIn, customRegexNames },
         },
@@ -181,14 +178,12 @@ function getWorkerAuthGates() {
                 ? gate.allowed_algorithms.filter((a) => typeof a === 'string' && a !== 'none' && a === algorithm)
                 : null;
             gateConfig.allowed_algorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-            gateConfig.clock_skew_sec = Number.isFinite(Number(gate.clock_skew_sec))
-                ? Math.max(0, Math.min(600, Number(gate.clock_skew_sec)))
-                : 30;
+            gateConfig.clock_skew_sec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
             gateConfig.jwks_url = gate.jwks_url || '';
             gateConfig.issuer = gate.issuer || '';
             gateConfig.audience = gate.audience || '';
             gateConfig.secret_env = gate.secret_env || '';
-            gateConfig.cache_ttl_sec = Number(gate.cache_ttl_sec) || 3600;
+            gateConfig.cache_ttl_sec = numberOr(gate.cache_ttl_sec, 3600);
         }
         else if (authType === 'signed_url') {
             gateConfig.algorithm = gate.algorithm || 'HMAC-SHA256';
@@ -215,19 +210,13 @@ const requiredHeaders = block.header_missing || ['user-agent'];
 const resHeaders = policy.response_headers || {};
 const corsConfig = resHeaders.cors || null;
 const originAuth = (policy.origin || {}).auth || null;
-const rawAllowedHosts = Array.isArray(request.allowed_hosts) ? request.allowed_hosts : [];
-const allowedHosts = rawAllowedHosts
-    .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-    .filter(Boolean);
+const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
 const trustForwardedFor = request.trust_forwarded_for === true;
 const jwksGlobal = (policy.firewall || {}).jwks || {};
-const jwksStaleIfError = Number.isFinite(Number(jwksGlobal.stale_if_error_sec))
-    ? Math.max(0, Math.min(86400, Number(jwksGlobal.stale_if_error_sec)))
-    : 3600;
-const jwksNegativeCache = Number.isFinite(Number(jwksGlobal.negative_cache_sec))
-    ? Math.max(0, Math.min(600, Number(jwksGlobal.negative_cache_sec)))
-    : 60;
+const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
+const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
 const fwGeo = (policy.firewall || {}).geo || {};
+// Keep String() coercion here; policy authors sometimes provide numeric country-like values.
 const geoBlockCountries = Array.isArray(fwGeo.block_countries)
     ? fwGeo.block_countries.map((c) => String(c || '').trim().toUpperCase()).filter(Boolean)
     : [];
@@ -238,13 +227,11 @@ const challengeConfig = buildChallengeConfig(policy);
 const cfgCode = renderConstObject('CFG', {
     mode: defaults.mode || 'enforce',
     allowMethods: runtimeCode(`new Set(${JSON.stringify(allowMethods)})`),
-    maxQueryLength: Number(limits.max_query_length) || 1024,
-    maxQueryParams: Number(limits.max_query_params) || 30,
-    maxUriLength: Number(limits.max_uri_length) || 2048,
-    maxHeaderSize: Number(limits.max_header_size) || 0,
-    maxHeaderCount: Number.isFinite(Number(limits.max_header_count))
-        ? Math.max(1, Math.min(500, Number(limits.max_header_count)))
-        : 64,
+    maxQueryLength: numberOr(limits.max_query_length, 1024),
+    maxQueryParams: numberOr(limits.max_query_params, 30),
+    maxUriLength: numberOr(limits.max_uri_length, 2048),
+    maxHeaderSize: numberOr(limits.max_header_size, 0),
+    maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
     dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
     uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
     blockPathContains,
@@ -304,9 +291,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
     adminCacheControl,
     authProtectedPrefixes: authProtectedPrefixesForResp,
     forceVaryAuth,
-    clearSiteDataPaths: Array.isArray(resHeaders.clear_site_data_paths)
-        ? resHeaders.clear_site_data_paths.filter((s) => typeof s === 'string' && s.trim())
-        : [],
+    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
         ? resHeaders.clear_site_data_types
         : ['cache', 'cookies', 'storage'],

--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -98,8 +98,8 @@ function normalizeResponseDlp(policyObj) {
     const defaultContentTypes = ['text/', 'application/json', 'application/xml', 'text/xml', 'application/javascript'];
     const hasContentTypes = Array.isArray(body.content_types) && body.content_types.length > 0;
     const hasHeaderNames = Array.isArray(headers.names) && headers.names.length > 0;
-    const contentTypes = normalizeStringList(body.content_types, 'lower');
-    const headerNames = normalizeStringList(headers.names, 'lower');
+    const contentTypes = normalizeStringList(body.content_types, 'lower', { trim: false });
+    const headerNames = normalizeStringList(headers.names, 'lower', { trim: false });
     const builtIn = Array.isArray(detectors.built_in) && detectors.built_in.length > 0
         ? detectors.built_in.filter((d) => d === 'api_key' || d === 'credit_card')
         : ['api_key', 'credit_card'];
@@ -291,7 +291,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
     adminCacheControl,
     authProtectedPrefixes: authProtectedPrefixesForResp,
     forceVaryAuth,
-    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
+    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
         ? resHeaders.clear_site_data_types
         : ['cache', 'cookies', 'storage'],

--- a/scripts/compile-infra.js
+++ b/scripts/compile-infra.js
@@ -14,6 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
+const { numberOr } = require('./lib/value-normalize');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
 const securityPath = path.join(repoRoot, 'policy', 'security.yml');
@@ -105,7 +106,7 @@ function blockAction() {
         return {
             block: {
                 custom_response: {
-                    response_code: Number(blockResponse.status_code) || 403,
+                    response_code: numberOr(blockResponse.status_code, 403),
                     custom_response_body_key: blockResponseKey,
                 },
             },
@@ -128,7 +129,7 @@ if (waf.rate_limit) {
         action: blockAction(),
         statement: {
             rate_based_statement: {
-                limit: Number(waf.rate_limit) || 2000,
+                limit: numberOr(waf.rate_limit, 2000),
                 aggregate_key_type: 'IP',
             },
         },
@@ -155,9 +156,10 @@ if (Array.isArray(waf.rate_limit_rules)) {
         if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
             rateStmt.scope_down_statement = rule.scope_down_statement;
         }
+        const rulePriority = numberOr(rule.priority, 0) || priority++;
         wafRules.push({
             name: rule.name,
-            priority: Number(rule.priority) || priority++,
+            priority: rulePriority,
             action: actionFor(rule.action),
             statement: { rate_based_statement: rateStmt },
             visibility_config: {

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -1338,12 +1338,12 @@ test('response_headers.clear_site_data_paths emits directive + no-store on 2xx',
             version: 1,
             request: { allow_methods: ['GET'] },
             response_headers: {
-                clear_site_data_paths: ['/logout', '/session/end'],
+                clear_site_data_paths: [' /logout ', '/session/end'],
             },
             routes: [],
         }, { outDir: tmpDir, allowPlaceholderToken: true });
         const resp = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
-        assert.match(resp, /clearSiteDataPaths: \["\/logout","\/session\/end"\]/);
+        assert.match(resp, /clearSiteDataPaths: \[" \/logout ","\/session\/end"\]/);
         assert.match(resp, /clearSiteDataTypes: \["cache","cookies","storage"\]/);
         assert.match(resp, /Clear-Site-Data/);
     }

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../../parser');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./template-inject');
+const { clampNumber, normalizeStringList, numberOr, } = require('./value-normalize');
 const repoRoot = path.join(__dirname, '..', '..');
 const DEFAULT_CONTAINS = ['/../', '%2e%2e', '%2f..', '..%2f', '%5c'];
 const LEGACY_KNOWN_MAP = {
@@ -557,23 +558,15 @@ function buildChallengeConfig(policy) {
     const raw = policy && policy.firewall && policy.firewall.challenge;
     if (!raw || raw.enabled !== true)
         return null;
-    const pathPrefixes = Array.isArray(raw.path_prefixes)
-        ? raw.path_prefixes.map((p) => (typeof p === 'string' ? p.trim() : '')).filter(Boolean)
-        : [];
-    const uaContains = Array.isArray(raw.ua_contains)
-        ? raw.ua_contains.map((s) => (typeof s === 'string' ? s.trim().toLowerCase() : '')).filter(Boolean)
-        : [];
+    const pathPrefixes = normalizeStringList(raw.path_prefixes);
+    const uaContains = normalizeStringList(raw.ua_contains, 'lower');
     return {
         enabled: true,
         mode: raw.mode === 'report' || raw.mode === 'block' || raw.mode === 'challenge' ? raw.mode : 'challenge',
         pathPrefixes,
         uaContains,
-        difficulty: Number.isFinite(Number(raw.difficulty))
-            ? Math.max(1, Math.min(6, Number(raw.difficulty)))
-            : 3,
-        ttlSec: Number.isFinite(Number(raw.ttl_sec))
-            ? Math.max(60, Math.min(86400, Number(raw.ttl_sec)))
-            : 900,
+        difficulty: clampNumber(raw.difficulty, 1, 6, 3),
+        ttlSec: clampNumber(raw.ttl_sec, 60, 86400, 900),
         secretEnv: typeof raw.secret_env === 'string' && raw.secret_env.trim()
             ? raw.secret_env.trim()
             : 'CHALLENGE_SECRET',
@@ -597,24 +590,14 @@ function buildGraphqlGuardConfig(policy) {
     if (!guard || typeof guard !== 'object')
         return null;
     const endpointPaths = Array.isArray(guard.endpoint_paths)
-        ? guard.endpoint_paths
-            .map((p) => (typeof p === 'string' ? p.trim() : ''))
-            .filter(Boolean)
+        ? normalizeStringList(guard.endpoint_paths)
         : ['/graphql'];
     return {
         endpointPaths: endpointPaths.length > 0 ? endpointPaths : ['/graphql'],
-        maxDepth: Number.isFinite(Number(guard.max_depth))
-            ? Math.max(1, Math.min(64, Number(guard.max_depth)))
-            : 10,
-        maxAliases: Number.isFinite(Number(guard.max_aliases))
-            ? Math.max(0, Math.min(10000, Number(guard.max_aliases)))
-            : 20,
-        maxFields: Number.isFinite(Number(guard.max_fields))
-            ? Math.max(1, Math.min(50000, Number(guard.max_fields)))
-            : 200,
-        maxBodyBytes: Number.isFinite(Number(guard.max_body_bytes))
-            ? Math.max(1, Math.min(1048576, Number(guard.max_body_bytes)))
-            : 65536,
+        maxDepth: clampNumber(guard.max_depth, 1, 64, 10),
+        maxAliases: clampNumber(guard.max_aliases, 0, 10000, 20),
+        maxFields: clampNumber(guard.max_fields, 1, 50000, 200),
+        maxBodyBytes: clampNumber(guard.max_body_bytes, 1, 1048576, 65536),
         mode: guard.mode === 'report' ? 'report' : 'block',
     };
 }
@@ -635,12 +618,8 @@ function buildAnomalyGuardConfig(policy) {
         crlf: raw.crlf !== false,
         malformedCookie: raw.malformed_cookie !== false,
         doubleEncodedTraversal: raw.double_encoded_traversal !== false,
-        maxCookieBytes: Number.isFinite(Number(raw.max_cookie_bytes))
-            ? Math.max(1, Math.min(65536, Number(raw.max_cookie_bytes)))
-            : 4096,
-        maxCookiePairs: Number.isFinite(Number(raw.max_cookie_pairs))
-            ? Math.max(1, Math.min(1000, Number(raw.max_cookie_pairs)))
-            : 80,
+        maxCookieBytes: clampNumber(raw.max_cookie_bytes, 1, 65536, 4096),
+        maxCookiePairs: clampNumber(raw.max_cookie_pairs, 1, 1000, 80),
     };
 }
 function warnUnsupportedGraphqlGuard(policy, target, options = {}) {
@@ -696,21 +675,16 @@ function build(policy, options = {}) {
     const corsConfig = (policy.response_headers || {}).cors || null;
     // Host allowlist: lowercase entries so we can compare against the lowercase
     // Host header value without per-request normalization.
-    const rawAllowedHosts = Array.isArray(request.allowed_hosts) ? request.allowed_hosts : [];
-    const allowedHosts = rawAllowedHosts
-        .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-        .filter(Boolean);
+    const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
     const trustForwardedFor = request.trust_forwarded_for === true;
     const obsCfg = buildObsConfig(policy);
     const cfgCode = renderConstObject('CFG', {
         mode: defaults.mode || 'enforce',
         allowMethods: request.allow_methods || ['GET', 'HEAD', 'POST'],
-        maxQueryLength: Number(limits.max_query_length) || 1024,
-        maxQueryParams: Number(limits.max_query_params) || 30,
-        maxUriLength: Number(limits.max_uri_length) || 2048,
-        maxHeaderCount: Number.isFinite(Number(limits.max_header_count))
-            ? Math.max(1, Math.min(500, Number(limits.max_header_count)))
-            : 64,
+        maxQueryLength: numberOr(limits.max_query_length, 1024),
+        maxQueryParams: numberOr(limits.max_query_params, 30),
+        maxUriLength: numberOr(limits.max_uri_length, 2048),
+        maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
         dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
         uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
         blockPathContains,
@@ -776,9 +750,7 @@ function build(policy, options = {}) {
         adminCacheControl,
         authProtectedPrefixes,
         forceVaryAuth,
-        clearSiteDataPaths: Array.isArray(resHeaders.clear_site_data_paths)
-            ? resHeaders.clear_site_data_paths.filter((s) => typeof s === 'string' && s.trim())
-            : [],
+        clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
         clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
             ? resHeaders.clear_site_data_types
             : ['cache', 'cookies', 'storage'],
@@ -804,9 +776,7 @@ function build(policy, options = {}) {
             ? gate.allowed_algorithms.filter((a) => typeof a === 'string' && a !== 'none' && a === algorithm)
             : null;
         const allowedAlgorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-        const clockSkewSec = Number.isFinite(Number(gate.clock_skew_sec))
-            ? Math.max(0, Math.min(600, Number(gate.clock_skew_sec)))
-            : 30;
+        const clockSkewSec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
         return {
             name: g.name,
             protectedPrefixes: g.protectedPrefixes,
@@ -839,17 +809,13 @@ function build(policy, options = {}) {
     });
     const originAuth = (policy.origin || {}).auth || null;
     const jwksGlobal = (policy.firewall || {}).jwks || {};
-    const jwksStaleIfError = Number.isFinite(Number(jwksGlobal.stale_if_error_sec))
-        ? Math.max(0, Math.min(86400, Number(jwksGlobal.stale_if_error_sec)))
-        : 3600;
-    const jwksNegativeCache = Number.isFinite(Number(jwksGlobal.negative_cache_sec))
-        ? Math.max(0, Math.min(600, Number(jwksGlobal.negative_cache_sec)))
-        : 60;
+    const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
+    const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
     const obsCfgOrigin = buildObsConfig(policy);
     const originCfgCode = renderConstObject('CFG', {
         project: policy.project || 'cdn-security',
         mode: defaults.mode || 'enforce',
-        maxHeaderSize: Number(limits.max_header_size) || 0,
+        maxHeaderSize: numberOr(limits.max_header_size, 0),
         trustForwardedFor,
         jwtGates,
         signedUrlGates,

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -750,7 +750,7 @@ function build(policy, options = {}) {
         adminCacheControl,
         authProtectedPrefixes,
         forceVaryAuth,
-        clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
+        clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
         clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
             ? resHeaders.clear_site_data_types
             : ['cache', 'cookies', 'storage'],

--- a/scripts/lib/value-normalize.d.ts
+++ b/scripts/lib/value-normalize.d.ts
@@ -1,0 +1,4 @@
+export type StringCase = 'lower' | 'upper' | 'preserve';
+export declare function clampNumber(raw: unknown, min: number, max: number, fallback: number): number;
+export declare function numberOr(raw: unknown, fallback: number): number;
+export declare function normalizeStringList(raw: unknown, casing?: StringCase): string[];

--- a/scripts/lib/value-normalize.d.ts
+++ b/scripts/lib/value-normalize.d.ts
@@ -1,4 +1,7 @@
 export type StringCase = 'lower' | 'upper' | 'preserve';
 export declare function clampNumber(raw: unknown, min: number, max: number, fallback: number): number;
 export declare function numberOr(raw: unknown, fallback: number): number;
-export declare function normalizeStringList(raw: unknown, casing?: StringCase): string[];
+export interface NormalizeStringListOptions {
+    trim?: boolean;
+}
+export declare function normalizeStringList(raw: unknown, casing?: StringCase, options?: NormalizeStringListOptions): string[];

--- a/scripts/lib/value-normalize.js
+++ b/scripts/lib/value-normalize.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.clampNumber = clampNumber;
+exports.numberOr = numberOr;
+exports.normalizeStringList = normalizeStringList;
+function applyStringCase(value, casing) {
+    if (casing === 'lower')
+        return value.toLowerCase();
+    if (casing === 'upper')
+        return value.toUpperCase();
+    return value;
+}
+function toFiniteNumber(raw) {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+}
+function clampNumber(raw, min, max, fallback) {
+    const n = toFiniteNumber(raw);
+    return n === null ? fallback : Math.max(min, Math.min(max, n));
+}
+function numberOr(raw, fallback) {
+    return Number(raw) || fallback;
+}
+function normalizeStringList(raw, casing = 'preserve') {
+    if (!Array.isArray(raw))
+        return [];
+    return raw
+        .map((s) => (typeof s === 'string' ? s.trim() : ''))
+        .map((s) => applyStringCase(s, casing))
+        .filter(Boolean);
+}

--- a/scripts/lib/value-normalize.js
+++ b/scripts/lib/value-normalize.js
@@ -21,11 +21,13 @@ function clampNumber(raw, min, max, fallback) {
 function numberOr(raw, fallback) {
     return Number(raw) || fallback;
 }
-function normalizeStringList(raw, casing = 'preserve') {
+function normalizeStringList(raw, casing = 'preserve', options = {}) {
     if (!Array.isArray(raw))
         return [];
+    const trimOutput = options.trim !== false;
     return raw
-        .map((s) => (typeof s === 'string' ? s.trim() : ''))
+        .filter((s) => typeof s === 'string' && !!s.trim())
+        .map((s) => (trimOutput ? s.trim() : s))
         .map((s) => applyStringCase(s, casing))
         .filter(Boolean);
 }

--- a/scripts/value-normalize-unit-tests.d.ts
+++ b/scripts/value-normalize-unit-tests.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/scripts/value-normalize-unit-tests.js
+++ b/scripts/value-normalize-unit-tests.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert = require('assert');
+const { clampNumber, normalizeStringList, numberOr, } = require('./lib/value-normalize');
+function test(name, fn) {
+    try {
+        fn();
+        console.log('OK:', name);
+    }
+    catch (e) {
+        console.error('FAIL:', name);
+        console.error(e && e.stack ? e.stack : e);
+        process.exitCode = 1;
+    }
+}
+test('clampNumber preserves legacy Number() coercion and fallback behavior', () => {
+    assert.strictEqual(clampNumber(undefined, 1, 10, 5), 5);
+    assert.strictEqual(clampNumber(null, 1, 10, 5), 1);
+    assert.strictEqual(clampNumber('', 1, 10, 5), 1);
+    assert.strictEqual(clampNumber('  ', 1, 10, 5), 1);
+    assert.strictEqual(clampNumber('5', 1, 10, 3), 5);
+    assert.strictEqual(clampNumber(Number.NaN, 1, 10, 5), 5);
+    assert.strictEqual(clampNumber(Infinity, 1, 10, 5), 5);
+    assert.strictEqual(clampNumber(true, 1, 10, 5), 1);
+    assert.strictEqual(clampNumber(-10, 1, 10, 5), 1);
+    assert.strictEqual(clampNumber(99, 1, 10, 5), 10);
+});
+test('numberOr preserves legacy Number(x) || fallback behavior', () => {
+    assert.strictEqual(numberOr(0, 10), 10);
+    assert.strictEqual(numberOr('0', 10), 10);
+    assert.strictEqual(numberOr('', 10), 10);
+    assert.strictEqual(numberOr(Number.NaN, 10), 10);
+    assert.strictEqual(numberOr(7, 10), 7);
+    assert.strictEqual(numberOr('7', 10), 7);
+});
+test('normalizeStringList trims strings, drops non-strings and empties, and applies casing', () => {
+    assert.deepStrictEqual(normalizeStringList('GET'), []);
+    assert.deepStrictEqual(normalizeStringList([' GET ', 7, '', 'Post'], 'lower'), ['get', 'post']);
+    assert.deepStrictEqual(normalizeStringList([' us ', 'Jp', false], 'upper'), ['US', 'JP']);
+    assert.deepStrictEqual(normalizeStringList([' /Admin ', 'Docs ']), ['/Admin', 'Docs']);
+});

--- a/scripts/value-normalize-unit-tests.js
+++ b/scripts/value-normalize-unit-tests.js
@@ -40,3 +40,7 @@ test('normalizeStringList trims strings, drops non-strings and empties, and appl
     assert.deepStrictEqual(normalizeStringList([' us ', 'Jp', false], 'upper'), ['US', 'JP']);
     assert.deepStrictEqual(normalizeStringList([' /Admin ', 'Docs ']), ['/Admin', 'Docs']);
 });
+test('normalizeStringList can preserve legacy emitted whitespace while filtering by trim', () => {
+    assert.deepStrictEqual(normalizeStringList([' Text/HTML ', '   ', 'APPLICATION/JSON '], 'lower', { trim: false }), [' text/html ', 'application/json ']);
+    assert.deepStrictEqual(normalizeStringList([' /logout ', '', ' /admin'], 'preserve', { trim: false }), [' /logout ', ' /admin']);
+});

--- a/src/scripts/cloudflare-runtime-tests.ts
+++ b/src/scripts/cloudflare-runtime-tests.ts
@@ -772,6 +772,25 @@ response_dlp:
   assert.ok(body.includes('[MASKED]'), body);
 });
 
+test('cloudflare response DLP preserves whitespace-padded match lists for compatibility', () => {
+  const generated = compileCloudflare(`
+version: 1
+project: cf-dlp-whitespace-compat-test
+request:
+  allow_methods: ["GET"]
+response_dlp:
+  enabled: true
+  action: block
+  body:
+    content_types: [" application/json "]
+  headers:
+    names: [" x-api-key "]
+`);
+
+  assert.match(generated, /"contentTypes":\[" application\/json "\]/);
+  assert.match(generated, /"names":\[" x-api-key "\]/);
+});
+
 test('cloudflare response DLP blocks response body findings', async () => {
   const generated = compileCloudflare(`
 version: 1

--- a/src/scripts/compile-cloudflare-waf.ts
+++ b/src/scripts/compile-cloudflare-waf.ts
@@ -18,6 +18,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
+const { numberOr } = require('./lib/value-normalize');
 
 const parity = require('./lib/cloudflare-waf-parity');
 
@@ -147,7 +148,7 @@ function makeBlockAction() {
       action: 'block',
       action_parameters: {
         response: {
-          status_code: Number(br.status_code) || 403,
+          status_code: numberOr(br.status_code, 403),
           content: String(br.body || 'blocked'),
           content_type: (br.content_type === 'TEXT_HTML' ? 'text/html'
             : br.content_type === 'APPLICATION_JSON' ? 'application/json'
@@ -250,7 +251,7 @@ if (waf.rate_limit) {
     ratelimit: {
       characteristics: ['ip.src'],
       period: 300,
-      requests_per_period: Number(waf.rate_limit) || 2000,
+      requests_per_period: numberOr(waf.rate_limit, 2000),
       mitigation_timeout: 600,
     },
   });

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -28,6 +28,11 @@ const {
   renderConstObject,
   runtimeCode,
 } = require('./lib/template-inject');
+const {
+  clampNumber,
+  normalizeStringList,
+  numberOr,
+} = require('./lib/value-normalize');
 
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -108,6 +113,10 @@ function normalizeResponseDlp(policyObj: any) {
   const headers = raw.headers || {};
   const detectors = raw.detectors || {};
   const defaultContentTypes = ['text/', 'application/json', 'application/xml', 'text/xml', 'application/javascript'];
+  const hasContentTypes = Array.isArray(body.content_types) && body.content_types.length > 0;
+  const hasHeaderNames = Array.isArray(headers.names) && headers.names.length > 0;
+  const contentTypes = normalizeStringList(body.content_types, 'lower');
+  const headerNames = normalizeStringList(headers.names, 'lower');
   const builtIn = Array.isArray(detectors.built_in) && detectors.built_in.length > 0
     ? detectors.built_in.filter((d: unknown) => d === 'api_key' || d === 'credit_card')
     : ['api_key', 'credit_card'];
@@ -139,24 +148,16 @@ function normalizeResponseDlp(policyObj: any) {
       enabled,
       action,
       mask: typeof raw.mask === 'string' && raw.mask ? raw.mask : '[REDACTED]',
-      blockStatus: Number.isFinite(Number(raw.block_status))
-        ? Math.max(400, Math.min(599, Number(raw.block_status)))
-        : 451,
+      blockStatus: clampNumber(raw.block_status, 400, 599, 451),
       blockBody: typeof raw.block_body === 'string' && raw.block_body ? raw.block_body : 'Response blocked by edge DLP',
       body: {
         enabled: enabled && body.enabled !== false,
-        maxBytes: Number.isFinite(Number(body.max_bytes))
-          ? Math.max(1, Math.min(131072, Number(body.max_bytes)))
-          : 32768,
-        contentTypes: Array.isArray(body.content_types) && body.content_types.length > 0
-          ? body.content_types.filter((s: unknown) => typeof s === 'string' && s.trim()).map((s: string) => s.toLowerCase())
-          : defaultContentTypes,
+        maxBytes: clampNumber(body.max_bytes, 1, 131072, 32768),
+        contentTypes: hasContentTypes ? contentTypes : defaultContentTypes,
       },
       headers: {
         enabled: enabled && headers.enabled !== false,
-        names: Array.isArray(headers.names) && headers.names.length > 0
-          ? headers.names.filter((s: unknown) => typeof s === 'string' && s.trim()).map((s: string) => s.toLowerCase())
-          : ['set-cookie', 'authorization', 'x-api-key'],
+        names: hasHeaderNames ? headerNames : ['set-cookie', 'authorization', 'x-api-key'],
       },
       detectors: { builtIn, customRegexNames },
     },
@@ -196,14 +197,12 @@ function getWorkerAuthGates(): any[] {
         ? gate.allowed_algorithms.filter((a: unknown) => typeof a === 'string' && a !== 'none' && a === algorithm)
         : null;
       gateConfig.allowed_algorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-      gateConfig.clock_skew_sec = Number.isFinite(Number(gate.clock_skew_sec))
-        ? Math.max(0, Math.min(600, Number(gate.clock_skew_sec)))
-        : 30;
+      gateConfig.clock_skew_sec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
       gateConfig.jwks_url = gate.jwks_url || '';
       gateConfig.issuer = gate.issuer || '';
       gateConfig.audience = gate.audience || '';
       gateConfig.secret_env = gate.secret_env || '';
-      gateConfig.cache_ttl_sec = Number(gate.cache_ttl_sec) || 3600;
+      gateConfig.cache_ttl_sec = numberOr(gate.cache_ttl_sec, 3600);
     } else if (authType === 'signed_url') {
       gateConfig.algorithm = gate.algorithm || 'HMAC-SHA256';
       gateConfig.secret_env = gate.secret_env || 'URL_SIGNING_SECRET';
@@ -231,19 +230,13 @@ const requiredHeaders = block.header_missing || ['user-agent'];
 const resHeaders = policy.response_headers || {};
 const corsConfig = resHeaders.cors || null;
 const originAuth = (policy.origin || {}).auth || null;
-const rawAllowedHosts = Array.isArray(request.allowed_hosts) ? request.allowed_hosts : [];
-const allowedHosts = rawAllowedHosts
-  .map((h: unknown) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-  .filter(Boolean);
+const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
 const trustForwardedFor = request.trust_forwarded_for === true;
 const jwksGlobal = (policy.firewall || {}).jwks || {};
-const jwksStaleIfError = Number.isFinite(Number(jwksGlobal.stale_if_error_sec))
-  ? Math.max(0, Math.min(86400, Number(jwksGlobal.stale_if_error_sec)))
-  : 3600;
-const jwksNegativeCache = Number.isFinite(Number(jwksGlobal.negative_cache_sec))
-  ? Math.max(0, Math.min(600, Number(jwksGlobal.negative_cache_sec)))
-  : 60;
+const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
+const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
 const fwGeo = (policy.firewall || {}).geo || {};
+// Keep String() coercion here; policy authors sometimes provide numeric country-like values.
 const geoBlockCountries = Array.isArray(fwGeo.block_countries)
   ? fwGeo.block_countries.map((c: unknown) => String(c || '').trim().toUpperCase()).filter(Boolean)
   : [];
@@ -255,13 +248,11 @@ const challengeConfig = buildChallengeConfig(policy);
 const cfgCode = renderConstObject('CFG', {
   mode: defaults.mode || 'enforce',
   allowMethods: runtimeCode(`new Set(${JSON.stringify(allowMethods)})`),
-  maxQueryLength: Number(limits.max_query_length) || 1024,
-  maxQueryParams: Number(limits.max_query_params) || 30,
-  maxUriLength: Number(limits.max_uri_length) || 2048,
-  maxHeaderSize: Number(limits.max_header_size) || 0,
-  maxHeaderCount: Number.isFinite(Number(limits.max_header_count))
-    ? Math.max(1, Math.min(500, Number(limits.max_header_count)))
-    : 64,
+  maxQueryLength: numberOr(limits.max_query_length, 1024),
+  maxQueryParams: numberOr(limits.max_query_params, 30),
+  maxUriLength: numberOr(limits.max_uri_length, 2048),
+  maxHeaderSize: numberOr(limits.max_header_size, 0),
+  maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
   dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
   uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
   blockPathContains,
@@ -325,9 +316,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
   adminCacheControl,
   authProtectedPrefixes: authProtectedPrefixesForResp,
   forceVaryAuth,
-  clearSiteDataPaths: Array.isArray(resHeaders.clear_site_data_paths)
-    ? resHeaders.clear_site_data_paths.filter((s: unknown) => typeof s === 'string' && s.trim())
-    : [],
+  clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
   clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
     ? resHeaders.clear_site_data_types
     : ['cache', 'cookies', 'storage'],

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -115,8 +115,8 @@ function normalizeResponseDlp(policyObj: any) {
   const defaultContentTypes = ['text/', 'application/json', 'application/xml', 'text/xml', 'application/javascript'];
   const hasContentTypes = Array.isArray(body.content_types) && body.content_types.length > 0;
   const hasHeaderNames = Array.isArray(headers.names) && headers.names.length > 0;
-  const contentTypes = normalizeStringList(body.content_types, 'lower');
-  const headerNames = normalizeStringList(headers.names, 'lower');
+  const contentTypes = normalizeStringList(body.content_types, 'lower', { trim: false });
+  const headerNames = normalizeStringList(headers.names, 'lower', { trim: false });
   const builtIn = Array.isArray(detectors.built_in) && detectors.built_in.length > 0
     ? detectors.built_in.filter((d: unknown) => d === 'api_key' || d === 'credit_card')
     : ['api_key', 'credit_card'];
@@ -316,7 +316,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
   adminCacheControl,
   authProtectedPrefixes: authProtectedPrefixesForResp,
   forceVaryAuth,
-  clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
+  clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
   clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
     ? resHeaders.clear_site_data_types
     : ['cache', 'cookies', 'storage'],

--- a/src/scripts/compile-infra.ts
+++ b/src/scripts/compile-infra.ts
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
+const { numberOr } = require('./lib/value-normalize');
 
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -96,7 +97,7 @@ function blockAction() {
     return {
       block: {
         custom_response: {
-          response_code: Number(blockResponse.status_code) || 403,
+          response_code: numberOr(blockResponse.status_code, 403),
           custom_response_body_key: blockResponseKey,
         },
       },
@@ -119,7 +120,7 @@ if (waf.rate_limit) {
     action: blockAction(),
     statement: {
       rate_based_statement: {
-        limit: Number(waf.rate_limit) || 2000,
+        limit: numberOr(waf.rate_limit, 2000),
         aggregate_key_type: 'IP',
       },
     },
@@ -146,9 +147,10 @@ if (Array.isArray(waf.rate_limit_rules)) {
     if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
       rateStmt.scope_down_statement = rule.scope_down_statement;
     }
+    const rulePriority = numberOr(rule.priority, 0) || priority++;
     wafRules.push({
       name: rule.name,
-      priority: Number(rule.priority) || priority++,
+      priority: rulePriority,
       action: actionFor(rule.action),
       statement: { rate_based_statement: rateStmt },
       visibility_config: {

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -1536,12 +1536,12 @@ test('response_headers.clear_site_data_paths emits directive + no-store on 2xx',
       version: 1,
       request: { allow_methods: ['GET'] },
       response_headers: {
-        clear_site_data_paths: ['/logout', '/session/end'],
+        clear_site_data_paths: [' /logout ', '/session/end'],
       },
       routes: [],
     }, { outDir: tmpDir, allowPlaceholderToken: true });
     const resp = fs.readFileSync(path.join(tmpDir, 'edge', 'viewer-response.js'), 'utf8');
-    assert.match(resp, /clearSiteDataPaths: \["\/logout","\/session\/end"\]/);
+    assert.match(resp, /clearSiteDataPaths: \[" \/logout ","\/session\/end"\]/);
     assert.match(resp, /clearSiteDataTypes: \["cache","cookies","storage"\]/);
     assert.match(resp, /Clear-Site-Data/);
   } finally {

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -7,6 +7,11 @@ const {
   renderConstObject,
   runtimeCode,
 } = require('./template-inject');
+const {
+  clampNumber,
+  normalizeStringList,
+  numberOr,
+} = require('./value-normalize');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const DEFAULT_CONTAINS = ['/../', '%2e%2e', '%2f..', '..%2f', '%5c'];
@@ -599,24 +604,16 @@ function buildChallengeConfig(policy: any) {
   const raw = policy && policy.firewall && policy.firewall.challenge;
   if (!raw || raw.enabled !== true) return null;
 
-  const pathPrefixes = Array.isArray(raw.path_prefixes)
-    ? raw.path_prefixes.map((p: any) => (typeof p === 'string' ? p.trim() : '')).filter(Boolean)
-    : [];
-  const uaContains = Array.isArray(raw.ua_contains)
-    ? raw.ua_contains.map((s: any) => (typeof s === 'string' ? s.trim().toLowerCase() : '')).filter(Boolean)
-    : [];
+  const pathPrefixes = normalizeStringList(raw.path_prefixes);
+  const uaContains = normalizeStringList(raw.ua_contains, 'lower');
 
   return {
     enabled: true,
     mode: raw.mode === 'report' || raw.mode === 'block' || raw.mode === 'challenge' ? raw.mode : 'challenge',
     pathPrefixes,
     uaContains,
-    difficulty: Number.isFinite(Number(raw.difficulty))
-      ? Math.max(1, Math.min(6, Number(raw.difficulty)))
-      : 3,
-    ttlSec: Number.isFinite(Number(raw.ttl_sec))
-      ? Math.max(60, Math.min(86400, Number(raw.ttl_sec)))
-      : 900,
+    difficulty: clampNumber(raw.difficulty, 1, 6, 3),
+    ttlSec: clampNumber(raw.ttl_sec, 60, 86400, 900),
     secretEnv: typeof raw.secret_env === 'string' && raw.secret_env.trim()
       ? raw.secret_env.trim()
       : 'CHALLENGE_SECRET',
@@ -643,25 +640,15 @@ function buildGraphqlGuardConfig(policy: any) {
   if (!guard || typeof guard !== 'object') return null;
 
   const endpointPaths = Array.isArray(guard.endpoint_paths)
-    ? guard.endpoint_paths
-        .map((p: any) => (typeof p === 'string' ? p.trim() : ''))
-        .filter(Boolean)
+    ? normalizeStringList(guard.endpoint_paths)
     : ['/graphql'];
 
   return {
     endpointPaths: endpointPaths.length > 0 ? endpointPaths : ['/graphql'],
-    maxDepth: Number.isFinite(Number(guard.max_depth))
-      ? Math.max(1, Math.min(64, Number(guard.max_depth)))
-      : 10,
-    maxAliases: Number.isFinite(Number(guard.max_aliases))
-      ? Math.max(0, Math.min(10000, Number(guard.max_aliases)))
-      : 20,
-    maxFields: Number.isFinite(Number(guard.max_fields))
-      ? Math.max(1, Math.min(50000, Number(guard.max_fields)))
-      : 200,
-    maxBodyBytes: Number.isFinite(Number(guard.max_body_bytes))
-      ? Math.max(1, Math.min(1048576, Number(guard.max_body_bytes)))
-      : 65536,
+    maxDepth: clampNumber(guard.max_depth, 1, 64, 10),
+    maxAliases: clampNumber(guard.max_aliases, 0, 10000, 20),
+    maxFields: clampNumber(guard.max_fields, 1, 50000, 200),
+    maxBodyBytes: clampNumber(guard.max_body_bytes, 1, 1048576, 65536),
     mode: guard.mode === 'report' ? 'report' : 'block',
   };
 }
@@ -684,12 +671,8 @@ function buildAnomalyGuardConfig(policy: any) {
     crlf: raw.crlf !== false,
     malformedCookie: raw.malformed_cookie !== false,
     doubleEncodedTraversal: raw.double_encoded_traversal !== false,
-    maxCookieBytes: Number.isFinite(Number(raw.max_cookie_bytes))
-      ? Math.max(1, Math.min(65536, Number(raw.max_cookie_bytes)))
-      : 4096,
-    maxCookiePairs: Number.isFinite(Number(raw.max_cookie_pairs))
-      ? Math.max(1, Math.min(1000, Number(raw.max_cookie_pairs)))
-      : 80,
+    maxCookieBytes: clampNumber(raw.max_cookie_bytes, 1, 65536, 4096),
+    maxCookiePairs: clampNumber(raw.max_cookie_pairs, 1, 1000, 80),
   };
 }
 
@@ -750,10 +733,7 @@ function build(policy: any, options: any = {}) {
   const corsConfig = (policy.response_headers || {}).cors || null;
   // Host allowlist: lowercase entries so we can compare against the lowercase
   // Host header value without per-request normalization.
-  const rawAllowedHosts = Array.isArray(request.allowed_hosts) ? request.allowed_hosts : [];
-  const allowedHosts = rawAllowedHosts
-    .map((h: any) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-    .filter(Boolean);
+  const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
   const trustForwardedFor = request.trust_forwarded_for === true;
 
   const obsCfg = buildObsConfig(policy);
@@ -761,12 +741,10 @@ function build(policy: any, options: any = {}) {
   const cfgCode = renderConstObject('CFG', {
     mode: defaults.mode || 'enforce',
     allowMethods: request.allow_methods || ['GET', 'HEAD', 'POST'],
-    maxQueryLength: Number(limits.max_query_length) || 1024,
-    maxQueryParams: Number(limits.max_query_params) || 30,
-    maxUriLength: Number(limits.max_uri_length) || 2048,
-    maxHeaderCount: Number.isFinite(Number(limits.max_header_count))
-      ? Math.max(1, Math.min(500, Number(limits.max_header_count)))
-      : 64,
+    maxQueryLength: numberOr(limits.max_query_length, 1024),
+    maxQueryParams: numberOr(limits.max_query_params, 30),
+    maxUriLength: numberOr(limits.max_uri_length, 2048),
+    maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
     dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
     uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
     blockPathContains,
@@ -837,9 +815,7 @@ function build(policy: any, options: any = {}) {
     adminCacheControl,
     authProtectedPrefixes,
     forceVaryAuth,
-    clearSiteDataPaths: Array.isArray(resHeaders.clear_site_data_paths)
-      ? resHeaders.clear_site_data_paths.filter((s: any) => typeof s === 'string' && s.trim())
-      : [],
+    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
       ? resHeaders.clear_site_data_types
       : ['cache', 'cookies', 'storage'],
@@ -867,9 +843,7 @@ function build(policy: any, options: any = {}) {
       ? gate.allowed_algorithms.filter((a: any) => typeof a === 'string' && a !== 'none' && a === algorithm)
       : null;
     const allowedAlgorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-    const clockSkewSec = Number.isFinite(Number(gate.clock_skew_sec))
-      ? Math.max(0, Math.min(600, Number(gate.clock_skew_sec)))
-      : 30;
+    const clockSkewSec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
     return {
       name: g.name,
       protectedPrefixes: g.protectedPrefixes,
@@ -904,19 +878,15 @@ function build(policy: any, options: any = {}) {
 
   const originAuth = (policy.origin || {}).auth || null;
   const jwksGlobal = (policy.firewall || {}).jwks || {};
-  const jwksStaleIfError = Number.isFinite(Number(jwksGlobal.stale_if_error_sec))
-    ? Math.max(0, Math.min(86400, Number(jwksGlobal.stale_if_error_sec)))
-    : 3600;
-  const jwksNegativeCache = Number.isFinite(Number(jwksGlobal.negative_cache_sec))
-    ? Math.max(0, Math.min(600, Number(jwksGlobal.negative_cache_sec)))
-    : 60;
+  const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
+  const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
 
   const obsCfgOrigin = buildObsConfig(policy);
 
   const originCfgCode = renderConstObject('CFG', {
     project: policy.project || 'cdn-security',
     mode: defaults.mode || 'enforce',
-    maxHeaderSize: Number(limits.max_header_size) || 0,
+    maxHeaderSize: numberOr(limits.max_header_size, 0),
     trustForwardedFor,
     jwtGates,
     signedUrlGates,

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -815,7 +815,7 @@ function build(policy: any, options: any = {}) {
     adminCacheControl,
     authProtectedPrefixes,
     forceVaryAuth,
-    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths),
+    clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
       ? resHeaders.clear_site_data_types
       : ['cache', 'cookies', 'storage'],

--- a/src/scripts/lib/value-normalize.ts
+++ b/src/scripts/lib/value-normalize.ts
@@ -1,0 +1,30 @@
+export type StringCase = 'lower' | 'upper' | 'preserve';
+
+function applyStringCase(value: string, casing: StringCase): string {
+  if (casing === 'lower') return value.toLowerCase();
+  if (casing === 'upper') return value.toUpperCase();
+  return value;
+}
+
+function toFiniteNumber(raw: unknown): number | null {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function clampNumber(raw: unknown, min: number, max: number, fallback: number): number {
+  const n = toFiniteNumber(raw);
+  return n === null ? fallback : Math.max(min, Math.min(max, n));
+}
+
+export function numberOr(raw: unknown, fallback: number): number {
+  return Number(raw) || fallback;
+}
+
+export function normalizeStringList(raw: unknown, casing: StringCase = 'preserve'): string[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .map((s) => (typeof s === 'string' ? s.trim() : ''))
+    .map((s) => applyStringCase(s, casing))
+    .filter(Boolean);
+}

--- a/src/scripts/lib/value-normalize.ts
+++ b/src/scripts/lib/value-normalize.ts
@@ -20,11 +20,21 @@ export function numberOr(raw: unknown, fallback: number): number {
   return Number(raw) || fallback;
 }
 
-export function normalizeStringList(raw: unknown, casing: StringCase = 'preserve'): string[] {
+export interface NormalizeStringListOptions {
+  trim?: boolean;
+}
+
+export function normalizeStringList(
+  raw: unknown,
+  casing: StringCase = 'preserve',
+  options: NormalizeStringListOptions = {},
+): string[] {
   if (!Array.isArray(raw)) return [];
+  const trimOutput = options.trim !== false;
 
   return raw
-    .map((s) => (typeof s === 'string' ? s.trim() : ''))
+    .filter((s): s is string => typeof s === 'string' && !!s.trim())
+    .map((s) => (trimOutput ? s.trim() : s))
     .map((s) => applyStringCase(s, casing))
     .filter(Boolean);
 }

--- a/src/scripts/value-normalize-unit-tests.ts
+++ b/src/scripts/value-normalize-unit-tests.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const {
+  clampNumber,
+  normalizeStringList,
+  numberOr,
+} = require('./lib/value-normalize');
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log('OK:', name);
+  } catch (e: any) {
+    console.error('FAIL:', name);
+    console.error(e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  }
+}
+
+test('clampNumber preserves legacy Number() coercion and fallback behavior', () => {
+  assert.strictEqual(clampNumber(undefined, 1, 10, 5), 5);
+  assert.strictEqual(clampNumber(null, 1, 10, 5), 1);
+  assert.strictEqual(clampNumber('', 1, 10, 5), 1);
+  assert.strictEqual(clampNumber('  ', 1, 10, 5), 1);
+  assert.strictEqual(clampNumber('5', 1, 10, 3), 5);
+  assert.strictEqual(clampNumber(Number.NaN, 1, 10, 5), 5);
+  assert.strictEqual(clampNumber(Infinity, 1, 10, 5), 5);
+  assert.strictEqual(clampNumber(true, 1, 10, 5), 1);
+  assert.strictEqual(clampNumber(-10, 1, 10, 5), 1);
+  assert.strictEqual(clampNumber(99, 1, 10, 5), 10);
+});
+
+test('numberOr preserves legacy Number(x) || fallback behavior', () => {
+  assert.strictEqual(numberOr(0, 10), 10);
+  assert.strictEqual(numberOr('0', 10), 10);
+  assert.strictEqual(numberOr('', 10), 10);
+  assert.strictEqual(numberOr(Number.NaN, 10), 10);
+  assert.strictEqual(numberOr(7, 10), 7);
+  assert.strictEqual(numberOr('7', 10), 7);
+});
+
+test('normalizeStringList trims strings, drops non-strings and empties, and applies casing', () => {
+  assert.deepStrictEqual(normalizeStringList('GET'), []);
+  assert.deepStrictEqual(normalizeStringList([' GET ', 7, '', 'Post'], 'lower'), ['get', 'post']);
+  assert.deepStrictEqual(normalizeStringList([' us ', 'Jp', false], 'upper'), ['US', 'JP']);
+  assert.deepStrictEqual(normalizeStringList([' /Admin ', 'Docs ']), ['/Admin', 'Docs']);
+});

--- a/src/scripts/value-normalize-unit-tests.ts
+++ b/src/scripts/value-normalize-unit-tests.ts
@@ -46,3 +46,14 @@ test('normalizeStringList trims strings, drops non-strings and empties, and appl
   assert.deepStrictEqual(normalizeStringList([' us ', 'Jp', false], 'upper'), ['US', 'JP']);
   assert.deepStrictEqual(normalizeStringList([' /Admin ', 'Docs ']), ['/Admin', 'Docs']);
 });
+
+test('normalizeStringList can preserve legacy emitted whitespace while filtering by trim', () => {
+  assert.deepStrictEqual(
+    normalizeStringList([' Text/HTML ', '   ', 'APPLICATION/JSON '], 'lower', { trim: false }),
+    [' text/html ', 'application/json '],
+  );
+  assert.deepStrictEqual(
+    normalizeStringList([' /logout ', '', ' /admin'], 'preserve', { trim: false }),
+    [' /logout ', ' /admin'],
+  );
+});


### PR DESCRIPTION
Closes #183.

## Problem

Issue #183 reported repeated inline policy value normalization patterns across the compilers: finite-number clamping, `Number(x) || fallback`, and string-list trimming/casing. Those copies made it easier for targets to drift while the expected behavior must remain byte-for-byte compatible.

## Changes

- Added `src/scripts/lib/value-normalize.ts` with:
  - `clampNumber(raw, min, max, fallback)` for the existing finite `Number()` clamp idiom.
  - `numberOr(raw, fallback)` for the existing `Number(x) || fallback` behavior.
  - `normalizeStringList(raw, casing)` for string-only trim/filter/case normalization.
- Added focused unit coverage in `src/scripts/value-normalize-unit-tests.ts`, wired into `npm run test:unit`.
- Replaced matching duplication in:
  - `src/scripts/lib/compile-core.ts`
  - `src/scripts/compile-cloudflare.ts`
  - `src/scripts/compile-infra.ts`
  - `src/scripts/compile-cloudflare-waf.ts`
- Regenerated committed JS/d.ts artifacts for the changed TypeScript files.
- Left the Cloudflare geo country normalization as explicit `String()` coercion because issue #183 calls out that behavior as intentionally different from `normalizeStringList`.

## Behavior after this PR

Generated policy outputs should not change. The normalization code is centralized, but legacy coercions are intentionally preserved, including `Number(null) === 0`, `Number('') === 0`, and `Number(x) || fallback` treating `0` as fallback.

## Verification

- `npm ci`
- `npm run build:ts`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run test:drift`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy npm run test:unit`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:ci`
- `rg -n "Number\\.isFinite\\(Number\\(" src --glob '*.ts' --glob '!*tests.ts' --glob '!src/scripts/lib/value-normalize.ts'` returned no matches.

## Risks / follow-up

- This intentionally avoids broader `src/bin/cli.ts` and small standalone script cleanups; those are outside this issue's scoped compiler refactor.
- The checked-in generated JS/d.ts files are included to match the repository's current TypeScript artifact workflow.
