### PR TITLE
refactor(waf): centralize WAF rule construction

### DIFF
--- a/lib/emit-waf.js
+++ b/lib/emit-waf.js
@@ -30,20 +30,9 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { lintPolicy } = require('./lint');
+const { resolveAbsolute, listInfraArtifacts } = require('../emitter');
+const { buildWafRules } = require('../scripts/lib/waf-rule-builder');
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
-function resolveAbsolute(inputPath, cwd) {
-    return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
-}
-function listInfraArtifacts(outDir, sinceMs = 0) {
-    const infraDir = path.join(outDir, 'infra');
-    if (!fs.existsSync(infraDir))
-        return [];
-    return fs
-        .readdirSync(infraDir)
-        .filter((name) => name.endsWith('.tf.json'))
-        .map((name) => path.join(infraDir, name))
-        .filter((filePath) => sinceMs <= 0 || fs.statSync(filePath).mtimeMs >= sinceMs);
-}
 function logicalId(input) {
     const cleaned = String(input || 'Resource')
         .replace(/[^A-Za-z0-9]+/g, ' ')
@@ -143,104 +132,16 @@ function buildCloudFormation(policy, options) {
     const scope = waf.scope === 'CLOUDFRONT' ? 'CLOUDFRONT' : 'REGIONAL';
     const outputMode = options.ruleGroupOnly ? 'rule-group' : (options.outputMode || 'full');
     const resources = {};
-    const wafRules = [];
-    let priority = 1;
-    const fingerprintActionType = waf.fingerprint_action === 'count' ? 'count' : 'block';
-    const blockResponse = waf.block_response || null;
-    const blockResponseKey = blockResponse ? 'cdn_sec_block' : null;
-    const blockAction = () => blockResponseKey
-        ? { block: { custom_response: { response_code: Number(blockResponse.status_code) || 403, custom_response_body_key: blockResponseKey } } }
-        : { block: {} };
-    const actionFor = (actionName) => {
-        if (actionName === 'count')
-            return { count: {} };
-        if (actionName === 'captcha')
-            return { captcha: {} };
-        return blockAction();
-    };
-    if (waf.rate_limit) {
-        wafRules.push({
-            name: 'rate-based-rule',
-            priority: priority++,
-            action: blockAction(),
-            statement: {
-                rate_based_statement: {
-                    limit: Number(waf.rate_limit) || 2000,
-                    aggregate_key_type: 'IP',
-                },
-            },
-            visibility_config: {
-                cloudwatch_metrics_enabled: true,
-                metric_name: projectName + '-rate-limit',
-                sampled_requests_enabled: true,
-            },
-        });
-    }
-    if (Array.isArray(waf.rate_limit_rules)) {
-        for (const rule of waf.rate_limit_rules) {
-            if (!rule || !rule.name || !rule.limit)
-                continue;
-            const aggregateKeyType = rule.aggregate_key_type || 'IP';
-            const rateStmt = {
-                limit: Number(rule.limit),
-                aggregate_key_type: aggregateKeyType,
-            };
-            if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
-                rateStmt.custom_key = rule.custom_keys;
-            }
-            if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
-                rateStmt.scope_down_statement = rule.scope_down_statement;
-            }
-            wafRules.push({
-                name: rule.name,
-                priority: Number(rule.priority) || priority++,
-                action: actionFor(rule.action),
-                statement: { rate_based_statement: rateStmt },
-                visibility_config: {
-                    cloudwatch_metrics_enabled: true,
-                    metric_name: projectName + '-' + rule.name,
-                    sampled_requests_enabled: true,
-                },
-            });
-        }
-    }
-    const addFingerprintRules = (fieldName, fingerprints, rulePrefix, metricPrefix) => {
-        if (!Array.isArray(fingerprints) || fingerprints.length === 0)
-            return;
-        for (const fp of fingerprints) {
-            if (!fp)
-                continue;
-            const fpStr = String(fp);
-            const slug = fpStr.slice(0, 12).toLowerCase();
-            wafRules.push({
-                name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
-                priority: priority++,
-                action: { [fingerprintActionType]: {} },
-                statement: {
-                    byte_match_statement: {
-                        field_to_match: { [fieldName]: {} },
-                        positional_constraint: 'EXACTLY',
-                        search_string: fpStr,
-                        text_transformation: [{ priority: 0, type: 'NONE' }],
-                    },
-                },
-                visibility_config: {
-                    cloudwatch_metrics_enabled: true,
-                    metric_name: `${projectName}-${metricPrefix}-${slug}`,
-                    sampled_requests_enabled: true,
-                },
-            });
-        }
-    };
-    addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
-    addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+    const builtWafRules = buildWafRules(waf, projectName);
+    const wafRules = builtWafRules.rules;
+    const blockResponse = builtWafRules.blockResponse;
     const ruleGroupLogicalId = logicalId(projectName + '-rate-limit-rule-group');
     const ruleGroup = {
         Type: 'AWS::WAFv2::RuleGroup',
         Properties: {
             Name: projectName + '-rate-limit',
             Scope: scope,
-            Capacity: Math.max(2, wafRules.length * 2 || 2),
+            Capacity: builtWafRules.capacity,
             Rules: cfnRules(wafRules),
             VisibilityConfig: {
                 CloudWatchMetricsEnabled: true,

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -29,11 +29,8 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
-const path = require('path');
 const yaml = require('js-yaml');
-function resolveAbsolute(inputPath, cwd) {
-    return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
-}
+const { resolveAbsolute } = require('../emitter');
 function migratePolicy(opts = {}) {
     opts = opts || {};
     const cwd = opts.cwd || process.cwd();

--- a/scripts/compile-infra.js
+++ b/scripts/compile-infra.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
-const { numberOr } = require('./lib/value-normalize');
+const { buildWafRules } = require('./lib/waf-rule-builder');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
 const securityPath = path.join(repoRoot, 'policy', 'security.yml');
@@ -95,116 +95,14 @@ const scope = (waf.scope === 'CLOUDFRONT') ? 'CLOUDFRONT' : 'REGIONAL';
 const distDir = path.join(outDir, 'infra');
 fs.mkdirSync(distDir, { recursive: true });
 // 1. WAF Rules (rate limit + managed rules)
-const wafRules = [];
-let priority = 1;
-const fingerprintActionType = (waf.fingerprint_action === 'count') ? 'count' : 'block';
-// Custom block response (referenced by every block action when configured)
-const blockResponse = waf.block_response || null;
-const blockResponseKey = blockResponse ? 'cdn_sec_block' : null;
-function blockAction() {
-    if (blockResponseKey) {
-        return {
-            block: {
-                custom_response: {
-                    response_code: numberOr(blockResponse.status_code, 403),
-                    custom_response_body_key: blockResponseKey,
-                },
-            },
-        };
-    }
-    return { block: {} };
-}
-function actionFor(actionName) {
-    if (actionName === 'count')
-        return { count: {} };
-    if (actionName === 'captcha')
-        return { captcha: {} };
-    return blockAction();
-}
-// Rate limit rule (legacy single global rule)
-if (waf.rate_limit) {
-    wafRules.push({
-        name: 'rate-based-rule',
-        priority: priority++,
-        action: blockAction(),
-        statement: {
-            rate_based_statement: {
-                limit: numberOr(waf.rate_limit, 2000),
-                aggregate_key_type: 'IP',
-            },
-        },
-        visibility_config: {
-            cloudwatch_metrics_enabled: true,
-            metric_name: projectName + '-rate-limit',
-            sampled_requests_enabled: true,
-        },
-    });
-}
-// rate_limit_rules[] — fine-grained per-URI / per-key rate limits
-if (Array.isArray(waf.rate_limit_rules)) {
-    for (const rule of waf.rate_limit_rules) {
-        if (!rule || !rule.name || !rule.limit)
-            continue;
-        const aggregateKeyType = rule.aggregate_key_type || 'IP';
-        const rateStmt = {
-            limit: Number(rule.limit),
-            aggregate_key_type: aggregateKeyType,
-        };
-        if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
-            rateStmt.custom_key = rule.custom_keys;
-        }
-        if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
-            rateStmt.scope_down_statement = rule.scope_down_statement;
-        }
-        const rulePriority = numberOr(rule.priority, 0) || priority++;
-        wafRules.push({
-            name: rule.name,
-            priority: rulePriority,
-            action: actionFor(rule.action),
-            statement: { rate_based_statement: rateStmt },
-            visibility_config: {
-                cloudwatch_metrics_enabled: true,
-                metric_name: projectName + '-' + rule.name,
-                sampled_requests_enabled: true,
-            },
-        });
-    }
-}
-function addFingerprintRules(fieldName, fingerprints, rulePrefix, metricPrefix) {
-    if (!Array.isArray(fingerprints) || fingerprints.length === 0)
-        return;
-    for (const fp of fingerprints) {
-        if (!fp)
-            continue;
-        const fpStr = String(fp);
-        const slug = fpStr.slice(0, 12).toLowerCase();
-        wafRules.push({
-            name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
-            priority: priority++,
-            action: { [fingerprintActionType]: {} },
-            statement: {
-                byte_match_statement: {
-                    field_to_match: { [fieldName]: {} },
-                    positional_constraint: 'EXACTLY',
-                    search_string: fpStr,
-                    text_transformation: [{ priority: 0, type: 'NONE' }],
-                },
-            },
-            visibility_config: {
-                cloudwatch_metrics_enabled: true,
-                metric_name: `${projectName}-${metricPrefix}-${slug}`,
-                sampled_requests_enabled: true,
-            },
-        });
-    }
-}
-// JA3/JA4 fingerprint rules
-addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
-addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+const builtWafRules = buildWafRules(waf, projectName);
+const wafRules = builtWafRules.rules;
+const blockResponse = builtWafRules.blockResponse;
+const blockResponseKey = builtWafRules.blockResponseKey;
 const ruleGroupDef = {
     name: projectName + '-rate-limit',
     scope,
-    capacity: Math.max(2, wafRules.length * 2 || 2),
+    capacity: builtWafRules.capacity,
     rule: wafRules,
     visibility_config: {
         cloudwatch_metrics_enabled: true,
@@ -214,7 +112,7 @@ const ruleGroupDef = {
 };
 if (blockResponse) {
     ruleGroupDef.custom_response_body = [{
-            key: blockResponseKey,
+            key: blockResponseKey || 'cdn_sec_block',
             content: blockResponse.body || 'Forbidden',
             content_type: blockResponse.content_type || 'TEXT_PLAIN',
         }];
@@ -262,7 +160,7 @@ if (waf.managed_rules && waf.managed_rules.length > 0) {
         };
         if (blockResponse) {
             webAcl.custom_response_body = [{
-                    key: blockResponseKey,
+                    key: blockResponseKey || 'cdn_sec_block',
                     content: blockResponse.body || 'Forbidden',
                     content_type: blockResponse.content_type || 'TEXT_PLAIN',
                 }];

--- a/scripts/infra-unit-tests.js
+++ b/scripts/infra-unit-tests.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { buildWafRules } = require('./lib/waf-rule-builder');
 function test(name, fn) {
     try {
         fn();
@@ -18,6 +19,48 @@ function test(name, fn) {
     }
 }
 const repoRoot = path.join(__dirname, '..');
+test('buildWafRules centralizes rate, fingerprint, block response, and capacity decisions', () => {
+    const built = buildWafRules({
+        rate_limit: 1000,
+        rate_limit_rules: [{
+                name: 'login-tight',
+                limit: 50,
+                aggregate_key_type: 'CUSTOM_KEYS',
+                custom_keys: [{ uri_path: {} }],
+                action: 'captcha',
+                priority: 7,
+                scope_down_statement: {
+                    byte_match_statement: {
+                        field_to_match: { uri_path: {} },
+                        positional_constraint: 'STARTS_WITH',
+                        search_string: '/login',
+                        text_transformation: [{ priority: 0, type: 'NONE' }],
+                    },
+                },
+            }],
+        fingerprint_action: 'count',
+        ja3_fingerprints: ['0123456789abcdef0123456789abcdef'],
+        ja4_fingerprints: ['t13d1516h2_8daaf6152771_02713d6af862'],
+        block_response: {
+            status_code: 451,
+            body: 'blocked',
+            content_type: 'TEXT_PLAIN',
+        },
+    }, 'shared-waf');
+    assert.strictEqual(built.blockResponseKey, 'cdn_sec_block');
+    assert.strictEqual(built.capacity, 8);
+    assert.strictEqual(built.rules.length, 4);
+    assert.strictEqual(built.rules[0].name, 'rate-based-rule');
+    assert.strictEqual(built.rules[0].action.block.custom_response.response_code, 451);
+    assert.strictEqual(built.rules[1].name, 'login-tight');
+    assert.strictEqual(built.rules[1].priority, 7);
+    assert.ok(built.rules[1].action.captcha);
+    assert.deepStrictEqual(built.rules[1].statement.rate_based_statement.custom_key, [{ uri_path: {} }]);
+    assert.ok(built.rules[1].statement.rate_based_statement.scope_down_statement.byte_match_statement);
+    assert.ok(built.rules[2].action.count);
+    assert.ok(built.rules[2].statement.byte_match_statement.field_to_match.ja3_fingerprint);
+    assert.ok(built.rules[3].statement.byte_match_statement.field_to_match.ja4_fingerprint);
+});
 function runCompileInfra(policyContent, options = {}) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'infra-unit-'));
     const policyPath = path.join(tempDir, 'policy.yml');

--- a/scripts/lib/waf-rule-builder.d.ts
+++ b/scripts/lib/waf-rule-builder.d.ts
@@ -1,0 +1,9 @@
+type WafPolicy = Record<string, any>;
+export interface WafRuleBuildResult {
+    rules: any[];
+    blockResponse: any | null;
+    blockResponseKey: string | null;
+    capacity: number;
+}
+export declare function buildWafRules(waf: WafPolicy | undefined, projectName: string): WafRuleBuildResult;
+export {};

--- a/scripts/lib/waf-rule-builder.js
+++ b/scripts/lib/waf-rule-builder.js
@@ -1,0 +1,115 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildWafRules = buildWafRules;
+const value_normalize_1 = require("./value-normalize");
+const BLOCK_RESPONSE_BODY_KEY = 'cdn_sec_block';
+function buildWafRules(waf = {}, projectName) {
+    const rules = [];
+    let priority = 1;
+    const fingerprintActionType = waf.fingerprint_action === 'count' ? 'count' : 'block';
+    const blockResponse = waf.block_response || null;
+    const blockResponseKey = blockResponse ? BLOCK_RESPONSE_BODY_KEY : null;
+    function blockAction() {
+        if (blockResponseKey) {
+            return {
+                block: {
+                    custom_response: {
+                        response_code: (0, value_normalize_1.numberOr)(blockResponse.status_code, 403),
+                        custom_response_body_key: blockResponseKey,
+                    },
+                },
+            };
+        }
+        return { block: {} };
+    }
+    function actionFor(actionName) {
+        if (actionName === 'count')
+            return { count: {} };
+        if (actionName === 'captcha')
+            return { captcha: {} };
+        return blockAction();
+    }
+    if (waf.rate_limit) {
+        rules.push({
+            name: 'rate-based-rule',
+            priority: priority++,
+            action: blockAction(),
+            statement: {
+                rate_based_statement: {
+                    limit: (0, value_normalize_1.numberOr)(waf.rate_limit, 2000),
+                    aggregate_key_type: 'IP',
+                },
+            },
+            visibility_config: {
+                cloudwatch_metrics_enabled: true,
+                metric_name: projectName + '-rate-limit',
+                sampled_requests_enabled: true,
+            },
+        });
+    }
+    if (Array.isArray(waf.rate_limit_rules)) {
+        for (const rule of waf.rate_limit_rules) {
+            if (!rule || !rule.name || !rule.limit)
+                continue;
+            const aggregateKeyType = rule.aggregate_key_type || 'IP';
+            const rateStmt = {
+                limit: Number(rule.limit),
+                aggregate_key_type: aggregateKeyType,
+            };
+            if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
+                rateStmt.custom_key = rule.custom_keys;
+            }
+            if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
+                rateStmt.scope_down_statement = rule.scope_down_statement;
+            }
+            const rulePriority = (0, value_normalize_1.numberOr)(rule.priority, 0) || priority++;
+            rules.push({
+                name: rule.name,
+                priority: rulePriority,
+                action: actionFor(rule.action),
+                statement: { rate_based_statement: rateStmt },
+                visibility_config: {
+                    cloudwatch_metrics_enabled: true,
+                    metric_name: projectName + '-' + rule.name,
+                    sampled_requests_enabled: true,
+                },
+            });
+        }
+    }
+    function addFingerprintRules(fieldName, fingerprints, rulePrefix, metricPrefix) {
+        if (!Array.isArray(fingerprints) || fingerprints.length === 0)
+            return;
+        for (const fp of fingerprints) {
+            if (!fp)
+                continue;
+            const fpStr = String(fp);
+            const slug = fpStr.slice(0, 12).toLowerCase();
+            rules.push({
+                name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
+                priority: priority++,
+                action: { [fingerprintActionType]: {} },
+                statement: {
+                    byte_match_statement: {
+                        field_to_match: { [fieldName]: {} },
+                        positional_constraint: 'EXACTLY',
+                        search_string: fpStr,
+                        text_transformation: [{ priority: 0, type: 'NONE' }],
+                    },
+                },
+                visibility_config: {
+                    cloudwatch_metrics_enabled: true,
+                    metric_name: `${projectName}-${metricPrefix}-${slug}`,
+                    sampled_requests_enabled: true,
+                },
+            });
+        }
+    }
+    addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
+    addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+    return {
+        rules,
+        blockResponse,
+        blockResponseKey,
+        capacity: Math.max(2, rules.length * 2 || 2),
+    };
+}

--- a/src/lib/emit-waf.ts
+++ b/src/lib/emit-waf.ts
@@ -30,6 +30,8 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const { lintPolicy } = require('./lint');
+const { resolveAbsolute, listInfraArtifacts } = require('../emitter');
+const { buildWafRules } = require('../scripts/lib/waf-rule-builder');
 
 const DEFAULT_PKG_ROOT = path.join(__dirname, '..');
 
@@ -57,20 +59,6 @@ interface EmitWafResultBase {
   target: string;
   format: string;
   formatNotImplemented: boolean;
-}
-
-function resolveAbsolute(inputPath: string, cwd: string): string {
-  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
-}
-
-function listInfraArtifacts(outDir: string, sinceMs = 0): string[] {
-  const infraDir = path.join(outDir, 'infra');
-  if (!fs.existsSync(infraDir)) return [];
-  return fs
-    .readdirSync(infraDir)
-    .filter((name: string) => name.endsWith('.tf.json'))
-    .map((name: string) => path.join(infraDir, name))
-    .filter((filePath: string) => sinceMs <= 0 || fs.statSync(filePath).mtimeMs >= sinceMs);
 }
 
 function logicalId(input: string): string {
@@ -171,95 +159,9 @@ function buildCloudFormation(policy: any, options: { outputMode: string; ruleGro
   const outputMode = options.ruleGroupOnly ? 'rule-group' : (options.outputMode || 'full');
   const resources: any = {};
 
-  const wafRules: any[] = [];
-  let priority = 1;
-  const fingerprintActionType = waf.fingerprint_action === 'count' ? 'count' : 'block';
-  const blockResponse = waf.block_response || null;
-  const blockResponseKey = blockResponse ? 'cdn_sec_block' : null;
-  const blockAction = () => blockResponseKey
-    ? { block: { custom_response: { response_code: Number(blockResponse.status_code) || 403, custom_response_body_key: blockResponseKey } } }
-    : { block: {} };
-  const actionFor = (actionName: string) => {
-    if (actionName === 'count') return { count: {} };
-    if (actionName === 'captcha') return { captcha: {} };
-    return blockAction();
-  };
-
-  if (waf.rate_limit) {
-    wafRules.push({
-      name: 'rate-based-rule',
-      priority: priority++,
-      action: blockAction(),
-      statement: {
-        rate_based_statement: {
-          limit: Number(waf.rate_limit) || 2000,
-          aggregate_key_type: 'IP',
-        },
-      },
-      visibility_config: {
-        cloudwatch_metrics_enabled: true,
-        metric_name: projectName + '-rate-limit',
-        sampled_requests_enabled: true,
-      },
-    });
-  }
-
-  if (Array.isArray(waf.rate_limit_rules)) {
-    for (const rule of waf.rate_limit_rules) {
-      if (!rule || !rule.name || !rule.limit) continue;
-      const aggregateKeyType = rule.aggregate_key_type || 'IP';
-      const rateStmt: any = {
-        limit: Number(rule.limit),
-        aggregate_key_type: aggregateKeyType,
-      };
-      if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
-        rateStmt.custom_key = rule.custom_keys;
-      }
-      if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
-        rateStmt.scope_down_statement = rule.scope_down_statement;
-      }
-      wafRules.push({
-        name: rule.name,
-        priority: Number(rule.priority) || priority++,
-        action: actionFor(rule.action),
-        statement: { rate_based_statement: rateStmt },
-        visibility_config: {
-          cloudwatch_metrics_enabled: true,
-          metric_name: projectName + '-' + rule.name,
-          sampled_requests_enabled: true,
-        },
-      });
-    }
-  }
-
-  const addFingerprintRules = (fieldName: string, fingerprints: unknown[], rulePrefix: string, metricPrefix: string) => {
-    if (!Array.isArray(fingerprints) || fingerprints.length === 0) return;
-    for (const fp of fingerprints) {
-      if (!fp) continue;
-      const fpStr = String(fp);
-      const slug = fpStr.slice(0, 12).toLowerCase();
-      wafRules.push({
-        name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
-        priority: priority++,
-        action: { [fingerprintActionType]: {} },
-        statement: {
-          byte_match_statement: {
-            field_to_match: { [fieldName]: {} },
-            positional_constraint: 'EXACTLY',
-            search_string: fpStr,
-            text_transformation: [{ priority: 0, type: 'NONE' }],
-          },
-        },
-        visibility_config: {
-          cloudwatch_metrics_enabled: true,
-          metric_name: `${projectName}-${metricPrefix}-${slug}`,
-          sampled_requests_enabled: true,
-        },
-      });
-    }
-  };
-  addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
-  addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+  const builtWafRules = buildWafRules(waf, projectName);
+  const wafRules = builtWafRules.rules;
+  const blockResponse = builtWafRules.blockResponse;
 
   const ruleGroupLogicalId = logicalId(projectName + '-rate-limit-rule-group');
   const ruleGroup: any = {
@@ -267,7 +169,7 @@ function buildCloudFormation(policy: any, options: { outputMode: string; ruleGro
     Properties: {
       Name: projectName + '-rate-limit',
       Scope: scope,
-      Capacity: Math.max(2, wafRules.length * 2 || 2),
+      Capacity: builtWafRules.capacity,
       Rules: cfnRules(wafRules),
       VisibilityConfig: {
         CloudWatchMetricsEnabled: true,

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -28,18 +28,14 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 const yaml = require('js-yaml');
+const { resolveAbsolute } = require('../emitter');
 
 interface MigratePolicyOptions {
   policyPath?: string;
   toVersion?: number | string;
   write?: boolean;
   cwd?: string;
-}
-
-function resolveAbsolute(inputPath: string, cwd: string): string {
-  return path.isAbsolute(inputPath) ? inputPath : path.join(cwd, inputPath);
 }
 
 function migratePolicy(opts: MigratePolicyOptions = {}) {

--- a/src/scripts/compile-infra.ts
+++ b/src/scripts/compile-infra.ts
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parsePolicyFile } = require('../parser');
-const { numberOr } = require('./lib/value-normalize');
+const { buildWafRules } = require('./lib/waf-rule-builder');
 
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -85,118 +85,15 @@ const distDir = path.join(outDir, 'infra');
 fs.mkdirSync(distDir, { recursive: true });
 
 // 1. WAF Rules (rate limit + managed rules)
-const wafRules = [];
-let priority = 1;
-const fingerprintActionType = (waf.fingerprint_action === 'count') ? 'count' : 'block';
-
-// Custom block response (referenced by every block action when configured)
-const blockResponse = waf.block_response || null;
-const blockResponseKey = blockResponse ? 'cdn_sec_block' : null;
-function blockAction() {
-  if (blockResponseKey) {
-    return {
-      block: {
-        custom_response: {
-          response_code: numberOr(blockResponse.status_code, 403),
-          custom_response_body_key: blockResponseKey,
-        },
-      },
-    };
-  }
-  return { block: {} };
-}
-
-function actionFor(actionName: string) {
-  if (actionName === 'count') return { count: {} };
-  if (actionName === 'captcha') return { captcha: {} };
-  return blockAction();
-}
-
-// Rate limit rule (legacy single global rule)
-if (waf.rate_limit) {
-  wafRules.push({
-    name: 'rate-based-rule',
-    priority: priority++,
-    action: blockAction(),
-    statement: {
-      rate_based_statement: {
-        limit: numberOr(waf.rate_limit, 2000),
-        aggregate_key_type: 'IP',
-      },
-    },
-    visibility_config: {
-      cloudwatch_metrics_enabled: true,
-      metric_name: projectName + '-rate-limit',
-      sampled_requests_enabled: true,
-    },
-  });
-}
-
-// rate_limit_rules[] — fine-grained per-URI / per-key rate limits
-if (Array.isArray(waf.rate_limit_rules)) {
-  for (const rule of waf.rate_limit_rules) {
-    if (!rule || !rule.name || !rule.limit) continue;
-    const aggregateKeyType = rule.aggregate_key_type || 'IP';
-    const rateStmt: any = {
-      limit: Number(rule.limit),
-      aggregate_key_type: aggregateKeyType,
-    };
-    if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
-      rateStmt.custom_key = rule.custom_keys;
-    }
-    if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
-      rateStmt.scope_down_statement = rule.scope_down_statement;
-    }
-    const rulePriority = numberOr(rule.priority, 0) || priority++;
-    wafRules.push({
-      name: rule.name,
-      priority: rulePriority,
-      action: actionFor(rule.action),
-      statement: { rate_based_statement: rateStmt },
-      visibility_config: {
-        cloudwatch_metrics_enabled: true,
-        metric_name: projectName + '-' + rule.name,
-        sampled_requests_enabled: true,
-      },
-    });
-  }
-}
-
-function addFingerprintRules(fieldName: string, fingerprints: unknown[], rulePrefix: string, metricPrefix: string) {
-  if (!Array.isArray(fingerprints) || fingerprints.length === 0) return;
-  for (const fp of fingerprints) {
-    if (!fp) continue;
-    const fpStr = String(fp);
-    const slug = fpStr.slice(0, 12).toLowerCase();
-    wafRules.push({
-      name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
-      priority: priority++,
-      action: { [fingerprintActionType]: {} },
-      statement: {
-        byte_match_statement: {
-          field_to_match: { [fieldName]: {} },
-          positional_constraint: 'EXACTLY',
-          search_string: fpStr,
-          text_transformation: [{ priority: 0, type: 'NONE' }],
-        },
-      },
-      visibility_config: {
-        cloudwatch_metrics_enabled: true,
-        metric_name: `${projectName}-${metricPrefix}-${slug}`,
-        sampled_requests_enabled: true,
-      },
-    });
-  }
-}
-
-// JA3/JA4 fingerprint rules
-addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
-addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+const builtWafRules = buildWafRules(waf, projectName);
+const wafRules = builtWafRules.rules;
+const blockResponse = builtWafRules.blockResponse;
+const blockResponseKey = builtWafRules.blockResponseKey;
 
 const ruleGroupDef: any = {
   name: projectName + '-rate-limit',
   scope,
-  capacity: Math.max(2, wafRules.length * 2 || 2),
+  capacity: builtWafRules.capacity,
   rule: wafRules,
   visibility_config: {
     cloudwatch_metrics_enabled: true,
@@ -206,7 +103,7 @@ const ruleGroupDef: any = {
 };
 if (blockResponse) {
   ruleGroupDef.custom_response_body = [{
-    key: blockResponseKey,
+    key: blockResponseKey || 'cdn_sec_block',
     content: blockResponse.body || 'Forbidden',
     content_type: blockResponse.content_type || 'TEXT_PLAIN',
   }];
@@ -254,7 +151,7 @@ if (waf.managed_rules && waf.managed_rules.length > 0) {
     };
     if (blockResponse) {
       webAcl.custom_response_body = [{
-        key: blockResponseKey,
+        key: blockResponseKey || 'cdn_sec_block',
         content: blockResponse.body || 'Forbidden',
         content_type: blockResponse.content_type || 'TEXT_PLAIN',
       }];

--- a/src/scripts/infra-unit-tests.ts
+++ b/src/scripts/infra-unit-tests.ts
@@ -5,6 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { buildWafRules } = require('./lib/waf-rule-builder');
 
 function test(name: string, fn: () => void) {
   try {
@@ -18,6 +19,50 @@ function test(name: string, fn: () => void) {
 }
 
 const repoRoot = path.join(__dirname, '..');
+
+test('buildWafRules centralizes rate, fingerprint, block response, and capacity decisions', () => {
+  const built = buildWafRules({
+    rate_limit: 1000,
+    rate_limit_rules: [{
+      name: 'login-tight',
+      limit: 50,
+      aggregate_key_type: 'CUSTOM_KEYS',
+      custom_keys: [{ uri_path: {} }],
+      action: 'captcha',
+      priority: 7,
+      scope_down_statement: {
+        byte_match_statement: {
+          field_to_match: { uri_path: {} },
+          positional_constraint: 'STARTS_WITH',
+          search_string: '/login',
+          text_transformation: [{ priority: 0, type: 'NONE' }],
+        },
+      },
+    }],
+    fingerprint_action: 'count',
+    ja3_fingerprints: ['0123456789abcdef0123456789abcdef'],
+    ja4_fingerprints: ['t13d1516h2_8daaf6152771_02713d6af862'],
+    block_response: {
+      status_code: 451,
+      body: 'blocked',
+      content_type: 'TEXT_PLAIN',
+    },
+  }, 'shared-waf');
+
+  assert.strictEqual(built.blockResponseKey, 'cdn_sec_block');
+  assert.strictEqual(built.capacity, 8);
+  assert.strictEqual(built.rules.length, 4);
+  assert.strictEqual(built.rules[0].name, 'rate-based-rule');
+  assert.strictEqual(built.rules[0].action.block.custom_response.response_code, 451);
+  assert.strictEqual(built.rules[1].name, 'login-tight');
+  assert.strictEqual(built.rules[1].priority, 7);
+  assert.ok(built.rules[1].action.captcha);
+  assert.deepStrictEqual(built.rules[1].statement.rate_based_statement.custom_key, [{ uri_path: {} }]);
+  assert.ok(built.rules[1].statement.rate_based_statement.scope_down_statement.byte_match_statement);
+  assert.ok(built.rules[2].action.count);
+  assert.ok(built.rules[2].statement.byte_match_statement.field_to_match.ja3_fingerprint);
+  assert.ok(built.rules[3].statement.byte_match_statement.field_to_match.ja4_fingerprint);
+});
 
 function runCompileInfra(policyContent: string, options: any = {}) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'infra-unit-'));

--- a/src/scripts/lib/waf-rule-builder.ts
+++ b/src/scripts/lib/waf-rule-builder.ts
@@ -1,0 +1,125 @@
+import { numberOr } from './value-normalize';
+
+type WafPolicy = Record<string, any>;
+
+export interface WafRuleBuildResult {
+  rules: any[];
+  blockResponse: any | null;
+  blockResponseKey: string | null;
+  capacity: number;
+}
+
+const BLOCK_RESPONSE_BODY_KEY = 'cdn_sec_block';
+
+export function buildWafRules(waf: WafPolicy = {}, projectName: string): WafRuleBuildResult {
+  const rules: any[] = [];
+  let priority = 1;
+  const fingerprintActionType = waf.fingerprint_action === 'count' ? 'count' : 'block';
+  const blockResponse = waf.block_response || null;
+  const blockResponseKey = blockResponse ? BLOCK_RESPONSE_BODY_KEY : null;
+
+  function blockAction() {
+    if (blockResponseKey) {
+      return {
+        block: {
+          custom_response: {
+            response_code: numberOr(blockResponse.status_code, 403),
+            custom_response_body_key: blockResponseKey,
+          },
+        },
+      };
+    }
+    return { block: {} };
+  }
+
+  function actionFor(actionName: string) {
+    if (actionName === 'count') return { count: {} };
+    if (actionName === 'captcha') return { captcha: {} };
+    return blockAction();
+  }
+
+  if (waf.rate_limit) {
+    rules.push({
+      name: 'rate-based-rule',
+      priority: priority++,
+      action: blockAction(),
+      statement: {
+        rate_based_statement: {
+          limit: numberOr(waf.rate_limit, 2000),
+          aggregate_key_type: 'IP',
+        },
+      },
+      visibility_config: {
+        cloudwatch_metrics_enabled: true,
+        metric_name: projectName + '-rate-limit',
+        sampled_requests_enabled: true,
+      },
+    });
+  }
+
+  if (Array.isArray(waf.rate_limit_rules)) {
+    for (const rule of waf.rate_limit_rules) {
+      if (!rule || !rule.name || !rule.limit) continue;
+      const aggregateKeyType = rule.aggregate_key_type || 'IP';
+      const rateStmt: any = {
+        limit: Number(rule.limit),
+        aggregate_key_type: aggregateKeyType,
+      };
+      if (aggregateKeyType === 'CUSTOM_KEYS' && Array.isArray(rule.custom_keys)) {
+        rateStmt.custom_key = rule.custom_keys;
+      }
+      if (rule.scope_down_statement && typeof rule.scope_down_statement === 'object') {
+        rateStmt.scope_down_statement = rule.scope_down_statement;
+      }
+      const rulePriority = numberOr(rule.priority, 0) || priority++;
+      rules.push({
+        name: rule.name,
+        priority: rulePriority,
+        action: actionFor(rule.action),
+        statement: { rate_based_statement: rateStmt },
+        visibility_config: {
+          cloudwatch_metrics_enabled: true,
+          metric_name: projectName + '-' + rule.name,
+          sampled_requests_enabled: true,
+        },
+      });
+    }
+  }
+
+  function addFingerprintRules(fieldName: string, fingerprints: unknown[], rulePrefix: string, metricPrefix: string) {
+    if (!Array.isArray(fingerprints) || fingerprints.length === 0) return;
+    for (const fp of fingerprints) {
+      if (!fp) continue;
+      const fpStr = String(fp);
+      const slug = fpStr.slice(0, 12).toLowerCase();
+      rules.push({
+        name: `${rulePrefix}-${fingerprintActionType}-${slug}`,
+        priority: priority++,
+        action: { [fingerprintActionType]: {} },
+        statement: {
+          byte_match_statement: {
+            field_to_match: { [fieldName]: {} },
+            positional_constraint: 'EXACTLY',
+            search_string: fpStr,
+            text_transformation: [{ priority: 0, type: 'NONE' }],
+          },
+        },
+        visibility_config: {
+          cloudwatch_metrics_enabled: true,
+          metric_name: `${projectName}-${metricPrefix}-${slug}`,
+          sampled_requests_enabled: true,
+        },
+      });
+    }
+  }
+
+  addFingerprintRules('ja3_fingerprint', waf.ja3_fingerprints, 'ja3', 'ja3');
+  addFingerprintRules('ja4_fingerprint', waf.ja4_fingerprints, 'ja4', 'ja4');
+
+  return {
+    rules,
+    blockResponse,
+    blockResponseKey,
+    capacity: Math.max(2, rules.length * 2 || 2),
+  };
+}


### PR DESCRIPTION
## What

- Closes #186.
- Extracts shared AWS WAF rule construction into `buildWafRules` so Terraform and CloudFormation outputs use one decision path for rate limits, JA3/JA4 fingerprint rules, block responses, actions, and capacity.
- Reuses emitter helper utilities for `resolveAbsolute` and `listInfraArtifacts` from programmatic WAF/migration paths.
- Adds a focused builder characterization test covering rate limits, CUSTOM_KEYS, scope-down statements, captcha action, fingerprints, block responses, and capacity.
- Regenerates checked-in JS and d.ts artifacts from the TypeScript sources.

## Why

Issue #186 reported that `src/scripts/compile-infra.ts` and `src/lib/emit-waf.ts` duplicated the same WAF rule decisions. That made it possible for Terraform and CloudFormation output to drift when one path changed and the other did not.

## Behavior

Generated WAF behavior is intended to be unchanged. Both Terraform and CloudFormation now consume the same snake_case intermediate rule objects, while each output path still handles only its format conversion and surrounding resources.

## Verification

- `npm ci`
- `npm run build:ts`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run build:ts && node scripts/infra-unit-tests.js && node scripts/emit-waf-unit-tests.js && node scripts/programmatic-api-unit-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:drift`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:ci`

## Risks / follow-up

- This PR intentionally keeps Cloudflare WAF generation out of scope; it remains target-specific and is only verified via existing CI/drift coverage.
- The shared builder still uses the existing untyped policy object shape. Stronger WAF policy typing can follow under the later type-cleanup issues.
