### PR TITLE
refactor: centralize runtime policy defaults

### DIFF
--- a/scripts/compile-cloudflare.js
+++ b/scripts/compile-cloudflare.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { parsePathPatterns, regexesLiteralCode, validateAuthGates, hasAllowPlaceholderFlag, hasFailOnPermissiveFlag, hasCatastrophicBacktrackShape, compileRegexOrThrow, warnIfPermissive, warnSignedUrlReplay, buildChallengeConfig, buildGraphqlGuardConfig, buildAnomalyGuardConfig, buildObsConfig, } = require('./lib/compile-core');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
 const { clampNumber, normalizeStringList, numberOr, } = require('./lib/value-normalize');
+const { DEFAULT_ADMIN_PATH_PREFIXES, DEFAULT_ALLOW_METHODS, DEFAULT_CLEAR_SITE_DATA_TYPES, DEFAULT_CSP_ADMIN, DEFAULT_CSP_PUBLIC, DEFAULT_DROP_QUERY_KEYS, DEFAULT_REQUIRED_HEADERS, DEFAULT_SECURITY_HEADERS, DEFAULT_UA_DENY_CONTAINS, JWKS_DEFAULTS, JWT_CLOCK_SKEW, LIMITS_DEFAULTS, } = require('./lib/policy-defaults');
 const { parseArgs, loadPolicyWithWarnings, reportPolicyWarnings, reportPolicyLoadError, } = require('./lib/policy-io');
 const repoRoot = path.join(__dirname, '..');
 const argv = process.argv.slice(2);
@@ -111,7 +112,7 @@ function getWorkerAuthGates() {
         const authType = gate.type || 'static_token';
         const gateConfig = {
             name: route.name || 'unnamed',
-            protectedPrefixes: prefixes.length ? prefixes : ['/admin', '/docs', '/swagger'],
+            protectedPrefixes: prefixes.length ? prefixes : [...DEFAULT_ADMIN_PATH_PREFIXES],
             type: authType,
         };
         if (authType === 'static_token') {
@@ -132,7 +133,7 @@ function getWorkerAuthGates() {
                 ? gate.allowed_algorithms.filter((a) => typeof a === 'string' && a !== 'none' && a === algorithm)
                 : null;
             gateConfig.allowed_algorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-            gateConfig.clock_skew_sec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
+            gateConfig.clock_skew_sec = clampNumber(gate.clock_skew_sec, JWT_CLOCK_SKEW.min, JWT_CLOCK_SKEW.max, JWT_CLOCK_SKEW.defaultSec);
             gateConfig.jwks_url = gate.jwks_url || '';
             gateConfig.issuer = gate.issuer || '';
             gateConfig.audience = gate.audience || '';
@@ -154,21 +155,19 @@ function getWorkerAuthGates() {
     return gates;
 }
 const authGates = getWorkerAuthGates();
-const dropQueryKeysArray = normalize.drop_query_keys || [
-    'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid',
-];
+const dropQueryKeysArray = normalize.drop_query_keys || DEFAULT_DROP_QUERY_KEYS;
 const { contains: blockPathContains, regexSources: blockPathRegexSources } = parsePathPatterns(block.path_patterns);
-const allowMethods = request.allow_methods || ['GET', 'HEAD', 'POST'];
+const allowMethods = request.allow_methods || DEFAULT_ALLOW_METHODS;
 const pathNormalize = normalize.path || {};
-const requiredHeaders = block.header_missing || ['user-agent'];
+const requiredHeaders = block.header_missing || DEFAULT_REQUIRED_HEADERS;
 const resHeaders = policy.response_headers || {};
 const corsConfig = resHeaders.cors || null;
 const originAuth = (policy.origin || {}).auth || null;
 const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
 const trustForwardedFor = request.trust_forwarded_for === true;
 const jwksGlobal = (policy.firewall || {}).jwks || {};
-const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
-const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
+const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, JWKS_DEFAULTS.staleMax, JWKS_DEFAULTS.staleIfErrorSec);
+const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, JWKS_DEFAULTS.negativeMax, JWKS_DEFAULTS.negativeCacheSec);
 const fwGeo = (policy.firewall || {}).geo || {};
 // Keep String() coercion here; policy authors sometimes provide numeric country-like values.
 const geoBlockCountries = Array.isArray(fwGeo.block_countries)
@@ -181,13 +180,13 @@ const challengeConfig = buildChallengeConfig(policy);
 const cfgCode = renderConstObject('CFG', {
     mode: defaults.mode || 'enforce',
     allowMethods: runtimeCode(`new Set(${JSON.stringify(allowMethods)})`),
-    maxQueryLength: numberOr(limits.max_query_length, 1024),
-    maxQueryParams: numberOr(limits.max_query_params, 30),
-    maxUriLength: numberOr(limits.max_uri_length, 2048),
-    maxHeaderSize: numberOr(limits.max_header_size, 0),
-    maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
+    maxQueryLength: numberOr(limits.max_query_length, LIMITS_DEFAULTS.maxQueryLength),
+    maxQueryParams: numberOr(limits.max_query_params, LIMITS_DEFAULTS.maxQueryParams),
+    maxUriLength: numberOr(limits.max_uri_length, LIMITS_DEFAULTS.maxUriLength),
+    maxHeaderSize: numberOr(limits.max_header_size, LIMITS_DEFAULTS.maxHeaderSize),
+    maxHeaderCount: clampNumber(limits.max_header_count, LIMITS_DEFAULTS.headerCountMin, LIMITS_DEFAULTS.headerCountMax, LIMITS_DEFAULTS.maxHeaderCount),
     dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
-    uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
+    uaDenyContains: block.ua_contains || DEFAULT_UA_DENY_CONTAINS,
     blockPathContains,
     blockPathRegexes: runtimeCode(regexesLiteralCode(blockPathRegexSources)),
     normalizePath: {
@@ -209,7 +208,7 @@ const cfgCode = renderConstObject('CFG', {
     anomalyGuards: buildAnomalyGuardConfig(policy),
     obs: buildObsConfig(policy),
 });
-let adminPathPrefixes = ['/admin', '/docs', '/swagger'];
+let adminPathPrefixes = [...DEFAULT_ADMIN_PATH_PREFIXES];
 let adminCacheControl = 'no-store';
 for (const route of routes) {
     const match = route.match || {};
@@ -227,13 +226,13 @@ const forceVaryAuth = resHeaders.force_vary_auth !== false;
 const responseDlp = normalizeResponseDlp(policy);
 const responseCfgCode = renderConstObject('RESPONSE_CFG', {
     headers: {
-        'strict-transport-security': resHeaders.hsts || 'max-age=31536000; includeSubDomains; preload',
-        'x-content-type-options': resHeaders.x_content_type_options || 'nosniff',
-        'referrer-policy': resHeaders.referrer_policy || 'strict-origin-when-cross-origin',
-        'permissions-policy': resHeaders.permissions_policy || 'camera=(), microphone=(), geolocation=()',
+        'strict-transport-security': resHeaders.hsts || DEFAULT_SECURITY_HEADERS['strict-transport-security'],
+        'x-content-type-options': resHeaders.x_content_type_options || DEFAULT_SECURITY_HEADERS['x-content-type-options'],
+        'referrer-policy': resHeaders.referrer_policy || DEFAULT_SECURITY_HEADERS['referrer-policy'],
+        'permissions-policy': resHeaders.permissions_policy || DEFAULT_SECURITY_HEADERS['permissions-policy'],
     },
-    csp_public: resHeaders.csp_public || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
-    csp_admin: resHeaders.csp_admin || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+    csp_public: resHeaders.csp_public || DEFAULT_CSP_PUBLIC,
+    csp_admin: resHeaders.csp_admin || DEFAULT_CSP_ADMIN,
     csp_report_only: resHeaders.csp_report_only || '',
     csp_report_uri: resHeaders.csp_report_uri || '',
     csp_nonce: resHeaders.csp_nonce === true,
@@ -248,7 +247,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
     clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
         ? resHeaders.clear_site_data_types
-        : ['cache', 'cookies', 'storage'],
+        : DEFAULT_CLEAR_SITE_DATA_TYPES,
     cors: corsConfig,
     cookie_attributes: resHeaders.cookie_attributes || null,
     responseDlp: responseDlp.config,

--- a/scripts/compile-unit-tests.js
+++ b/scripts/compile-unit-tests.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { DEFAULT_CONTAINS, parsePathPatterns, hasCatastrophicBacktrackShape, regexesLiteralCode, getAuthGates, validateAuthGates, validateJwksUrl, build, PLACEHOLDER_TOKEN, hasFailOnPermissiveFlag, warnIfPermissive, warnWeakAwsCspNonce, warnUnsupportedAwsResponseDlp, warnSignedUrlReplay, buildChallengeConfig, warnUnsupportedAwsChallenge, buildGraphqlGuardConfig, buildAnomalyGuardConfig, warnUnsupportedGraphqlGuard, validateOriginAuth, } = require('./lib/compile-core');
+const { DEFAULT_ADMIN_PATH_PREFIXES, DEFAULT_ALLOW_METHODS, DEFAULT_CLEAR_SITE_DATA_TYPES, DEFAULT_CSP_ADMIN, DEFAULT_CSP_PUBLIC, DEFAULT_DROP_QUERY_KEYS, DEFAULT_REQUIRED_HEADERS, DEFAULT_SECURITY_HEADERS, DEFAULT_UA_DENY_CONTAINS, JWKS_DEFAULTS, JWT_CLOCK_SKEW, LIMITS_DEFAULTS, } = require('./lib/policy-defaults');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./lib/template-inject');
 function test(name, fn) {
     try {
@@ -38,6 +39,49 @@ function withEnv(key, value, fn) {
         }
     }
 }
+test('policy-defaults exposes immutable runtime defaults shared by compiler targets', () => {
+    assert.deepStrictEqual(DEFAULT_UA_DENY_CONTAINS, ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests']);
+    assert.deepStrictEqual(DEFAULT_DROP_QUERY_KEYS, [
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+        'gclid',
+        'fbclid',
+    ]);
+    assert.deepStrictEqual(DEFAULT_ADMIN_PATH_PREFIXES, ['/admin', '/docs', '/swagger']);
+    assert.deepStrictEqual(DEFAULT_ALLOW_METHODS, ['GET', 'HEAD', 'POST']);
+    assert.deepStrictEqual(DEFAULT_REQUIRED_HEADERS, ['user-agent']);
+    assert.strictEqual(DEFAULT_CSP_PUBLIC, "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';");
+    assert.strictEqual(DEFAULT_CSP_ADMIN, "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';");
+    assert.deepStrictEqual(DEFAULT_SECURITY_HEADERS, {
+        'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
+        'x-content-type-options': 'nosniff',
+        'referrer-policy': 'strict-origin-when-cross-origin',
+        'permissions-policy': 'camera=(), microphone=(), geolocation=()',
+    });
+    assert.deepStrictEqual(LIMITS_DEFAULTS, {
+        maxQueryLength: 1024,
+        maxQueryParams: 30,
+        maxUriLength: 2048,
+        maxHeaderSize: 0,
+        maxHeaderCount: 64,
+        headerCountMin: 1,
+        headerCountMax: 500,
+    });
+    assert.deepStrictEqual(JWKS_DEFAULTS, {
+        staleIfErrorSec: 3600,
+        staleMax: 86400,
+        negativeCacheSec: 60,
+        negativeMax: 600,
+    });
+    assert.deepStrictEqual(JWT_CLOCK_SKEW, { defaultSec: 30, min: 0, max: 600 });
+    assert.deepStrictEqual(DEFAULT_CLEAR_SITE_DATA_TYPES, ['cache', 'cookies', 'storage']);
+    assert.ok(Object.isFrozen(DEFAULT_UA_DENY_CONTAINS));
+    assert.ok(Object.isFrozen(DEFAULT_SECURITY_HEADERS));
+    assert.ok(Object.isFrozen(LIMITS_DEFAULTS));
+});
 test('template-inject renders structured config with runtime literals', () => {
     const code = renderConstObject('CFG', {
         mode: 'enforce',

--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { assertInjectedConstDeclarations, injectTemplateCode, renderConstObject, runtimeCode, } = require('./template-inject');
 const { clampNumber, normalizeStringList, numberOr, } = require('./value-normalize');
+const { DEFAULT_ADMIN_PATH_PREFIXES, DEFAULT_ALLOW_METHODS, DEFAULT_CLEAR_SITE_DATA_TYPES, DEFAULT_CSP_ADMIN, DEFAULT_CSP_PUBLIC, DEFAULT_DROP_QUERY_KEYS, DEFAULT_REQUIRED_HEADERS, DEFAULT_SECURITY_HEADERS, DEFAULT_UA_DENY_CONTAINS, JWKS_DEFAULTS, JWT_CLOCK_SKEW, LIMITS_DEFAULTS, } = require('./policy-defaults');
 const { parseArgs: parseArgsIo, hasFlag, loadPolicy: loadPolicyIo, loadPolicyWithWarnings, reportPolicyWarnings, reportPolicyLoadError, } = require('./policy-io');
 const repoRoot = path.join(__dirname, '..', '..');
 const DEFAULT_CONTAINS = ['/../', '%2e%2e', '%2f..', '..%2f', '%5c'];
@@ -345,7 +346,7 @@ function getAuthGates(policy, options = {}) {
         const authType = gate.type || 'static_token';
         const gateConfig = {
             name: route.name || 'unnamed',
-            protectedPrefixes: prefixes.length ? prefixes : ['/admin', '/docs', '/swagger'],
+            protectedPrefixes: prefixes.length ? prefixes : [...DEFAULT_ADMIN_PATH_PREFIXES],
             type: authType,
         };
         if (authType === 'static_token') {
@@ -630,12 +631,10 @@ function build(policy, options = {}) {
     const block = request.block || {};
     const normalize = request.normalize || {};
     const authGates = getAuthGates(policy, { env, allowPlaceholderToken });
-    const dropQueryKeysArray = normalize.drop_query_keys || [
-        'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid',
-    ];
+    const dropQueryKeysArray = normalize.drop_query_keys || DEFAULT_DROP_QUERY_KEYS;
     const { contains: blockPathContains, regexSources: blockPathRegexSources } = parsePathPatterns(block.path_patterns);
     const pathNormalize = normalize.path || {};
-    const requiredHeaders = block.header_missing || ['user-agent'];
+    const requiredHeaders = block.header_missing || DEFAULT_REQUIRED_HEADERS;
     const corsConfig = (policy.response_headers || {}).cors || null;
     // Host allowlist: lowercase entries so we can compare against the lowercase
     // Host header value without per-request normalization.
@@ -644,13 +643,13 @@ function build(policy, options = {}) {
     const obsCfg = buildObsConfig(policy);
     const cfgCode = renderConstObject('CFG', {
         mode: defaults.mode || 'enforce',
-        allowMethods: request.allow_methods || ['GET', 'HEAD', 'POST'],
-        maxQueryLength: numberOr(limits.max_query_length, 1024),
-        maxQueryParams: numberOr(limits.max_query_params, 30),
-        maxUriLength: numberOr(limits.max_uri_length, 2048),
-        maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
+        allowMethods: request.allow_methods || DEFAULT_ALLOW_METHODS,
+        maxQueryLength: numberOr(limits.max_query_length, LIMITS_DEFAULTS.maxQueryLength),
+        maxQueryParams: numberOr(limits.max_query_params, LIMITS_DEFAULTS.maxQueryParams),
+        maxUriLength: numberOr(limits.max_uri_length, LIMITS_DEFAULTS.maxUriLength),
+        maxHeaderCount: clampNumber(limits.max_header_count, LIMITS_DEFAULTS.headerCountMin, LIMITS_DEFAULTS.headerCountMax, LIMITS_DEFAULTS.maxHeaderCount),
         dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
-        uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
+        uaDenyContains: block.ua_contains || DEFAULT_UA_DENY_CONTAINS,
         blockPathContains,
         blockPathRegexes: runtimeCode(regexesLiteralCode(blockPathRegexSources)),
         normalizePath: {
@@ -689,20 +688,20 @@ function build(policy, options = {}) {
         }
     }
     if (adminPathPrefixes.length === 0)
-        adminPathPrefixes = ['/admin', '/docs', '/swagger'];
+        adminPathPrefixes = [...DEFAULT_ADMIN_PATH_PREFIXES];
     // Union of every auth-gate protected prefix — used to force no-store +
     // Vary: Authorization regardless of which gate type applies. Issue #8.
     const authProtectedPrefixes = Array.from(new Set((authGates || []).flatMap((g) => Array.isArray(g.protectedPrefixes) ? g.protectedPrefixes : [])));
     const forceVaryAuth = resHeaders.force_vary_auth !== false; // default on
     const responseCfgCode = renderConstObject('RESPONSE_CFG', {
         headers: {
-            'strict-transport-security': resHeaders.hsts || 'max-age=31536000; includeSubDomains; preload',
-            'x-content-type-options': resHeaders.x_content_type_options || 'nosniff',
-            'referrer-policy': resHeaders.referrer_policy || 'strict-origin-when-cross-origin',
-            'permissions-policy': resHeaders.permissions_policy || 'camera=(), microphone=(), geolocation=()',
+            'strict-transport-security': resHeaders.hsts || DEFAULT_SECURITY_HEADERS['strict-transport-security'],
+            'x-content-type-options': resHeaders.x_content_type_options || DEFAULT_SECURITY_HEADERS['x-content-type-options'],
+            'referrer-policy': resHeaders.referrer_policy || DEFAULT_SECURITY_HEADERS['referrer-policy'],
+            'permissions-policy': resHeaders.permissions_policy || DEFAULT_SECURITY_HEADERS['permissions-policy'],
         },
-        csp_public: resHeaders.csp_public || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
-        csp_admin: resHeaders.csp_admin || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+        csp_public: resHeaders.csp_public || DEFAULT_CSP_PUBLIC,
+        csp_admin: resHeaders.csp_admin || DEFAULT_CSP_ADMIN,
         csp_report_only: resHeaders.csp_report_only || '',
         csp_report_uri: resHeaders.csp_report_uri || '',
         csp_nonce: resHeaders.csp_nonce === true,
@@ -717,7 +716,7 @@ function build(policy, options = {}) {
         clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
         clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
             ? resHeaders.clear_site_data_types
-            : ['cache', 'cookies', 'storage'],
+            : DEFAULT_CLEAR_SITE_DATA_TYPES,
         cors: resHeaders.cors || null,
         cookie_attributes: resHeaders.cookie_attributes || null,
     });
@@ -740,7 +739,7 @@ function build(policy, options = {}) {
             ? gate.allowed_algorithms.filter((a) => typeof a === 'string' && a !== 'none' && a === algorithm)
             : null;
         const allowedAlgorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-        const clockSkewSec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
+        const clockSkewSec = clampNumber(gate.clock_skew_sec, JWT_CLOCK_SKEW.min, JWT_CLOCK_SKEW.max, JWT_CLOCK_SKEW.defaultSec);
         return {
             name: g.name,
             protectedPrefixes: g.protectedPrefixes,
@@ -773,13 +772,13 @@ function build(policy, options = {}) {
     });
     const originAuth = (policy.origin || {}).auth || null;
     const jwksGlobal = (policy.firewall || {}).jwks || {};
-    const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
-    const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
+    const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, JWKS_DEFAULTS.staleMax, JWKS_DEFAULTS.staleIfErrorSec);
+    const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, JWKS_DEFAULTS.negativeMax, JWKS_DEFAULTS.negativeCacheSec);
     const obsCfgOrigin = buildObsConfig(policy);
     const originCfgCode = renderConstObject('CFG', {
         project: policy.project || 'cdn-security',
         mode: defaults.mode || 'enforce',
-        maxHeaderSize: numberOr(limits.max_header_size, 0),
+        maxHeaderSize: numberOr(limits.max_header_size, LIMITS_DEFAULTS.maxHeaderSize),
         trustForwardedFor,
         jwtGates,
         signedUrlGates,

--- a/scripts/lib/policy-defaults.d.ts
+++ b/scripts/lib/policy-defaults.d.ts
@@ -1,0 +1,34 @@
+export declare const DEFAULT_UA_DENY_CONTAINS: readonly ["sqlmap", "nikto", "acunetix", "masscan", "python-requests"];
+export declare const DEFAULT_DROP_QUERY_KEYS: readonly ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid", "fbclid"];
+export declare const DEFAULT_ADMIN_PATH_PREFIXES: readonly ["/admin", "/docs", "/swagger"];
+export declare const DEFAULT_ALLOW_METHODS: readonly ["GET", "HEAD", "POST"];
+export declare const DEFAULT_REQUIRED_HEADERS: readonly ["user-agent"];
+export declare const DEFAULT_CSP_PUBLIC = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';";
+export declare const DEFAULT_CSP_ADMIN = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
+export declare const DEFAULT_SECURITY_HEADERS: Readonly<{
+    readonly 'strict-transport-security': "max-age=31536000; includeSubDomains; preload";
+    readonly 'x-content-type-options': "nosniff";
+    readonly 'referrer-policy': "strict-origin-when-cross-origin";
+    readonly 'permissions-policy': "camera=(), microphone=(), geolocation=()";
+}>;
+export declare const LIMITS_DEFAULTS: Readonly<{
+    readonly maxQueryLength: 1024;
+    readonly maxQueryParams: 30;
+    readonly maxUriLength: 2048;
+    readonly maxHeaderSize: 0;
+    readonly maxHeaderCount: 64;
+    readonly headerCountMin: 1;
+    readonly headerCountMax: 500;
+}>;
+export declare const JWKS_DEFAULTS: Readonly<{
+    readonly staleIfErrorSec: 3600;
+    readonly staleMax: 86400;
+    readonly negativeCacheSec: 60;
+    readonly negativeMax: 600;
+}>;
+export declare const JWT_CLOCK_SKEW: Readonly<{
+    readonly defaultSec: 30;
+    readonly min: 0;
+    readonly max: 600;
+}>;
+export declare const DEFAULT_CLEAR_SITE_DATA_TYPES: readonly ["cache", "cookies", "storage"];

--- a/scripts/lib/policy-defaults.js
+++ b/scripts/lib/policy-defaults.js
@@ -1,0 +1,53 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_CLEAR_SITE_DATA_TYPES = exports.JWT_CLOCK_SKEW = exports.JWKS_DEFAULTS = exports.LIMITS_DEFAULTS = exports.DEFAULT_SECURITY_HEADERS = exports.DEFAULT_CSP_ADMIN = exports.DEFAULT_CSP_PUBLIC = exports.DEFAULT_REQUIRED_HEADERS = exports.DEFAULT_ALLOW_METHODS = exports.DEFAULT_ADMIN_PATH_PREFIXES = exports.DEFAULT_DROP_QUERY_KEYS = exports.DEFAULT_UA_DENY_CONTAINS = void 0;
+// Runtime compiler defaults only. The guided CLI init template stays separate
+// until maintainers decide whether sample policies should mirror these values.
+exports.DEFAULT_UA_DENY_CONTAINS = Object.freeze([
+    'sqlmap',
+    'nikto',
+    'acunetix',
+    'masscan',
+    'python-requests',
+]);
+exports.DEFAULT_DROP_QUERY_KEYS = Object.freeze([
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'gclid',
+    'fbclid',
+]);
+exports.DEFAULT_ADMIN_PATH_PREFIXES = Object.freeze(['/admin', '/docs', '/swagger']);
+exports.DEFAULT_ALLOW_METHODS = Object.freeze(['GET', 'HEAD', 'POST']);
+exports.DEFAULT_REQUIRED_HEADERS = Object.freeze(['user-agent']);
+exports.DEFAULT_CSP_PUBLIC = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';";
+exports.DEFAULT_CSP_ADMIN = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
+exports.DEFAULT_SECURITY_HEADERS = Object.freeze({
+    'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
+    'x-content-type-options': 'nosniff',
+    'referrer-policy': 'strict-origin-when-cross-origin',
+    'permissions-policy': 'camera=(), microphone=(), geolocation=()',
+});
+exports.LIMITS_DEFAULTS = Object.freeze({
+    maxQueryLength: 1024,
+    maxQueryParams: 30,
+    maxUriLength: 2048,
+    maxHeaderSize: 0,
+    maxHeaderCount: 64,
+    headerCountMin: 1,
+    headerCountMax: 500,
+});
+exports.JWKS_DEFAULTS = Object.freeze({
+    staleIfErrorSec: 3600,
+    staleMax: 86400,
+    negativeCacheSec: 60,
+    negativeMax: 600,
+});
+exports.JWT_CLOCK_SKEW = Object.freeze({
+    defaultSec: 30,
+    min: 0,
+    max: 600,
+});
+exports.DEFAULT_CLEAR_SITE_DATA_TYPES = Object.freeze(['cache', 'cookies', 'storage']);

--- a/src/scripts/compile-cloudflare.ts
+++ b/src/scripts/compile-cloudflare.ts
@@ -33,6 +33,20 @@ const {
   numberOr,
 } = require('./lib/value-normalize');
 const {
+  DEFAULT_ADMIN_PATH_PREFIXES,
+  DEFAULT_ALLOW_METHODS,
+  DEFAULT_CLEAR_SITE_DATA_TYPES,
+  DEFAULT_CSP_ADMIN,
+  DEFAULT_CSP_PUBLIC,
+  DEFAULT_DROP_QUERY_KEYS,
+  DEFAULT_REQUIRED_HEADERS,
+  DEFAULT_SECURITY_HEADERS,
+  DEFAULT_UA_DENY_CONTAINS,
+  JWKS_DEFAULTS,
+  JWT_CLOCK_SKEW,
+  LIMITS_DEFAULTS,
+} = require('./lib/policy-defaults');
+const {
   parseArgs,
   loadPolicyWithWarnings,
   reportPolicyWarnings,
@@ -147,7 +161,7 @@ function getWorkerAuthGates(): any[] {
 
     const gateConfig: any = {
       name: route.name || 'unnamed',
-      protectedPrefixes: prefixes.length ? prefixes : ['/admin', '/docs', '/swagger'],
+      protectedPrefixes: prefixes.length ? prefixes : [...DEFAULT_ADMIN_PATH_PREFIXES],
       type: authType,
     };
 
@@ -167,7 +181,12 @@ function getWorkerAuthGates(): any[] {
         ? gate.allowed_algorithms.filter((a: unknown) => typeof a === 'string' && a !== 'none' && a === algorithm)
         : null;
       gateConfig.allowed_algorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-      gateConfig.clock_skew_sec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
+      gateConfig.clock_skew_sec = clampNumber(
+        gate.clock_skew_sec,
+        JWT_CLOCK_SKEW.min,
+        JWT_CLOCK_SKEW.max,
+        JWT_CLOCK_SKEW.defaultSec,
+      );
       gateConfig.jwks_url = gate.jwks_url || '';
       gateConfig.issuer = gate.issuer || '';
       gateConfig.audience = gate.audience || '';
@@ -190,21 +209,29 @@ function getWorkerAuthGates(): any[] {
 }
 const authGates = getWorkerAuthGates();
 
-const dropQueryKeysArray = normalize.drop_query_keys || [
-  'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid',
-];
+const dropQueryKeysArray = normalize.drop_query_keys || DEFAULT_DROP_QUERY_KEYS;
 const { contains: blockPathContains, regexSources: blockPathRegexSources } = parsePathPatterns(block.path_patterns);
-const allowMethods = request.allow_methods || ['GET', 'HEAD', 'POST'];
+const allowMethods = request.allow_methods || DEFAULT_ALLOW_METHODS;
 const pathNormalize = normalize.path || {};
-const requiredHeaders = block.header_missing || ['user-agent'];
+const requiredHeaders = block.header_missing || DEFAULT_REQUIRED_HEADERS;
 const resHeaders = policy.response_headers || {};
 const corsConfig = resHeaders.cors || null;
 const originAuth = (policy.origin || {}).auth || null;
 const allowedHosts = normalizeStringList(request.allowed_hosts, 'lower');
 const trustForwardedFor = request.trust_forwarded_for === true;
 const jwksGlobal = (policy.firewall || {}).jwks || {};
-const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
-const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
+const jwksStaleIfError = clampNumber(
+  jwksGlobal.stale_if_error_sec,
+  0,
+  JWKS_DEFAULTS.staleMax,
+  JWKS_DEFAULTS.staleIfErrorSec,
+);
+const jwksNegativeCache = clampNumber(
+  jwksGlobal.negative_cache_sec,
+  0,
+  JWKS_DEFAULTS.negativeMax,
+  JWKS_DEFAULTS.negativeCacheSec,
+);
 const fwGeo = (policy.firewall || {}).geo || {};
 // Keep String() coercion here; policy authors sometimes provide numeric country-like values.
 const geoBlockCountries = Array.isArray(fwGeo.block_countries)
@@ -218,13 +245,18 @@ const challengeConfig = buildChallengeConfig(policy);
 const cfgCode = renderConstObject('CFG', {
   mode: defaults.mode || 'enforce',
   allowMethods: runtimeCode(`new Set(${JSON.stringify(allowMethods)})`),
-  maxQueryLength: numberOr(limits.max_query_length, 1024),
-  maxQueryParams: numberOr(limits.max_query_params, 30),
-  maxUriLength: numberOr(limits.max_uri_length, 2048),
-  maxHeaderSize: numberOr(limits.max_header_size, 0),
-  maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
+  maxQueryLength: numberOr(limits.max_query_length, LIMITS_DEFAULTS.maxQueryLength),
+  maxQueryParams: numberOr(limits.max_query_params, LIMITS_DEFAULTS.maxQueryParams),
+  maxUriLength: numberOr(limits.max_uri_length, LIMITS_DEFAULTS.maxUriLength),
+  maxHeaderSize: numberOr(limits.max_header_size, LIMITS_DEFAULTS.maxHeaderSize),
+  maxHeaderCount: clampNumber(
+    limits.max_header_count,
+    LIMITS_DEFAULTS.headerCountMin,
+    LIMITS_DEFAULTS.headerCountMax,
+    LIMITS_DEFAULTS.maxHeaderCount,
+  ),
   dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
-  uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
+  uaDenyContains: block.ua_contains || DEFAULT_UA_DENY_CONTAINS,
   blockPathContains,
   blockPathRegexes: runtimeCode(regexesLiteralCode(blockPathRegexSources)),
   normalizePath: {
@@ -247,7 +279,7 @@ const cfgCode = renderConstObject('CFG', {
   obs: buildObsConfig(policy),
 });
 
-let adminPathPrefixes = ['/admin', '/docs', '/swagger'];
+let adminPathPrefixes = [...DEFAULT_ADMIN_PATH_PREFIXES];
 let adminCacheControl = 'no-store';
 for (const route of routes) {
   const match = route.match || {};
@@ -268,13 +300,13 @@ const responseDlp = normalizeResponseDlp(policy);
 
 const responseCfgCode = renderConstObject('RESPONSE_CFG', {
   headers: {
-    'strict-transport-security': resHeaders.hsts || 'max-age=31536000; includeSubDomains; preload',
-    'x-content-type-options': resHeaders.x_content_type_options || 'nosniff',
-    'referrer-policy': resHeaders.referrer_policy || 'strict-origin-when-cross-origin',
-    'permissions-policy': resHeaders.permissions_policy || 'camera=(), microphone=(), geolocation=()',
+    'strict-transport-security': resHeaders.hsts || DEFAULT_SECURITY_HEADERS['strict-transport-security'],
+    'x-content-type-options': resHeaders.x_content_type_options || DEFAULT_SECURITY_HEADERS['x-content-type-options'],
+    'referrer-policy': resHeaders.referrer_policy || DEFAULT_SECURITY_HEADERS['referrer-policy'],
+    'permissions-policy': resHeaders.permissions_policy || DEFAULT_SECURITY_HEADERS['permissions-policy'],
   },
-  csp_public: resHeaders.csp_public || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
-  csp_admin: resHeaders.csp_admin || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+  csp_public: resHeaders.csp_public || DEFAULT_CSP_PUBLIC,
+  csp_admin: resHeaders.csp_admin || DEFAULT_CSP_ADMIN,
   csp_report_only: resHeaders.csp_report_only || '',
   csp_report_uri: resHeaders.csp_report_uri || '',
   csp_nonce: resHeaders.csp_nonce === true,
@@ -289,7 +321,7 @@ const responseCfgCode = renderConstObject('RESPONSE_CFG', {
   clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
   clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
     ? resHeaders.clear_site_data_types
-    : ['cache', 'cookies', 'storage'],
+    : DEFAULT_CLEAR_SITE_DATA_TYPES,
   cors: corsConfig,
   cookie_attributes: resHeaders.cookie_attributes || null,
   responseDlp: responseDlp.config,

--- a/src/scripts/compile-unit-tests.ts
+++ b/src/scripts/compile-unit-tests.ts
@@ -27,6 +27,20 @@ const {
   validateOriginAuth,
 } = require('./lib/compile-core');
 const {
+  DEFAULT_ADMIN_PATH_PREFIXES,
+  DEFAULT_ALLOW_METHODS,
+  DEFAULT_CLEAR_SITE_DATA_TYPES,
+  DEFAULT_CSP_ADMIN,
+  DEFAULT_CSP_PUBLIC,
+  DEFAULT_DROP_QUERY_KEYS,
+  DEFAULT_REQUIRED_HEADERS,
+  DEFAULT_SECURITY_HEADERS,
+  DEFAULT_UA_DENY_CONTAINS,
+  JWKS_DEFAULTS,
+  JWT_CLOCK_SKEW,
+  LIMITS_DEFAULTS,
+} = require('./lib/policy-defaults');
+const {
   assertInjectedConstDeclarations,
   injectTemplateCode,
   renderConstObject,
@@ -62,6 +76,50 @@ function withEnv(key: string, value: string | undefined, fn: () => void) {
     }
   }
 }
+
+test('policy-defaults exposes immutable runtime defaults shared by compiler targets', () => {
+  assert.deepStrictEqual(DEFAULT_UA_DENY_CONTAINS, ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests']);
+  assert.deepStrictEqual(DEFAULT_DROP_QUERY_KEYS, [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'gclid',
+    'fbclid',
+  ]);
+  assert.deepStrictEqual(DEFAULT_ADMIN_PATH_PREFIXES, ['/admin', '/docs', '/swagger']);
+  assert.deepStrictEqual(DEFAULT_ALLOW_METHODS, ['GET', 'HEAD', 'POST']);
+  assert.deepStrictEqual(DEFAULT_REQUIRED_HEADERS, ['user-agent']);
+  assert.strictEqual(DEFAULT_CSP_PUBLIC, "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';");
+  assert.strictEqual(DEFAULT_CSP_ADMIN, "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';");
+  assert.deepStrictEqual(DEFAULT_SECURITY_HEADERS, {
+    'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
+    'x-content-type-options': 'nosniff',
+    'referrer-policy': 'strict-origin-when-cross-origin',
+    'permissions-policy': 'camera=(), microphone=(), geolocation=()',
+  });
+  assert.deepStrictEqual(LIMITS_DEFAULTS, {
+    maxQueryLength: 1024,
+    maxQueryParams: 30,
+    maxUriLength: 2048,
+    maxHeaderSize: 0,
+    maxHeaderCount: 64,
+    headerCountMin: 1,
+    headerCountMax: 500,
+  });
+  assert.deepStrictEqual(JWKS_DEFAULTS, {
+    staleIfErrorSec: 3600,
+    staleMax: 86400,
+    negativeCacheSec: 60,
+    negativeMax: 600,
+  });
+  assert.deepStrictEqual(JWT_CLOCK_SKEW, { defaultSec: 30, min: 0, max: 600 });
+  assert.deepStrictEqual(DEFAULT_CLEAR_SITE_DATA_TYPES, ['cache', 'cookies', 'storage']);
+  assert.ok(Object.isFrozen(DEFAULT_UA_DENY_CONTAINS));
+  assert.ok(Object.isFrozen(DEFAULT_SECURITY_HEADERS));
+  assert.ok(Object.isFrozen(LIMITS_DEFAULTS));
+});
 
 test('template-inject renders structured config with runtime literals', () => {
   const code = renderConstObject('CFG', {

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -12,6 +12,20 @@ const {
   numberOr,
 } = require('./value-normalize');
 const {
+  DEFAULT_ADMIN_PATH_PREFIXES,
+  DEFAULT_ALLOW_METHODS,
+  DEFAULT_CLEAR_SITE_DATA_TYPES,
+  DEFAULT_CSP_ADMIN,
+  DEFAULT_CSP_PUBLIC,
+  DEFAULT_DROP_QUERY_KEYS,
+  DEFAULT_REQUIRED_HEADERS,
+  DEFAULT_SECURITY_HEADERS,
+  DEFAULT_UA_DENY_CONTAINS,
+  JWKS_DEFAULTS,
+  JWT_CLOCK_SKEW,
+  LIMITS_DEFAULTS,
+} = require('./policy-defaults');
+const {
   parseArgs: parseArgsIo,
   hasFlag,
   loadPolicy: loadPolicyIo,
@@ -373,7 +387,7 @@ function getAuthGates(policy: any, options: any = {}) {
 
     const gateConfig: any = {
       name: route.name || 'unnamed',
-      protectedPrefixes: prefixes.length ? prefixes : ['/admin', '/docs', '/swagger'],
+      protectedPrefixes: prefixes.length ? prefixes : [...DEFAULT_ADMIN_PATH_PREFIXES],
       type: authType,
     };
 
@@ -691,12 +705,10 @@ function build(policy: any, options: any = {}) {
 
   const authGates = getAuthGates(policy, { env, allowPlaceholderToken });
 
-  const dropQueryKeysArray = normalize.drop_query_keys || [
-    'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid',
-  ];
+  const dropQueryKeysArray = normalize.drop_query_keys || DEFAULT_DROP_QUERY_KEYS;
   const { contains: blockPathContains, regexSources: blockPathRegexSources } = parsePathPatterns(block.path_patterns);
   const pathNormalize = normalize.path || {};
-  const requiredHeaders = block.header_missing || ['user-agent'];
+  const requiredHeaders = block.header_missing || DEFAULT_REQUIRED_HEADERS;
   const corsConfig = (policy.response_headers || {}).cors || null;
   // Host allowlist: lowercase entries so we can compare against the lowercase
   // Host header value without per-request normalization.
@@ -707,13 +719,18 @@ function build(policy: any, options: any = {}) {
 
   const cfgCode = renderConstObject('CFG', {
     mode: defaults.mode || 'enforce',
-    allowMethods: request.allow_methods || ['GET', 'HEAD', 'POST'],
-    maxQueryLength: numberOr(limits.max_query_length, 1024),
-    maxQueryParams: numberOr(limits.max_query_params, 30),
-    maxUriLength: numberOr(limits.max_uri_length, 2048),
-    maxHeaderCount: clampNumber(limits.max_header_count, 1, 500, 64),
+    allowMethods: request.allow_methods || DEFAULT_ALLOW_METHODS,
+    maxQueryLength: numberOr(limits.max_query_length, LIMITS_DEFAULTS.maxQueryLength),
+    maxQueryParams: numberOr(limits.max_query_params, LIMITS_DEFAULTS.maxQueryParams),
+    maxUriLength: numberOr(limits.max_uri_length, LIMITS_DEFAULTS.maxUriLength),
+    maxHeaderCount: clampNumber(
+      limits.max_header_count,
+      LIMITS_DEFAULTS.headerCountMin,
+      LIMITS_DEFAULTS.headerCountMax,
+      LIMITS_DEFAULTS.maxHeaderCount,
+    ),
     dropQueryKeys: runtimeCode(`new Set(${JSON.stringify(dropQueryKeysArray)})`),
-    uaDenyContains: block.ua_contains || ['sqlmap', 'nikto', 'acunetix', 'masscan', 'python-requests'],
+    uaDenyContains: block.ua_contains || DEFAULT_UA_DENY_CONTAINS,
     blockPathContains,
     blockPathRegexes: runtimeCode(regexesLiteralCode(blockPathRegexSources)),
     normalizePath: {
@@ -753,7 +770,7 @@ function build(policy: any, options: any = {}) {
       break;
     }
   }
-  if (adminPathPrefixes.length === 0) adminPathPrefixes = ['/admin', '/docs', '/swagger'];
+  if (adminPathPrefixes.length === 0) adminPathPrefixes = [...DEFAULT_ADMIN_PATH_PREFIXES];
 
   // Union of every auth-gate protected prefix — used to force no-store +
   // Vary: Authorization regardless of which gate type applies. Issue #8.
@@ -764,13 +781,13 @@ function build(policy: any, options: any = {}) {
 
   const responseCfgCode = renderConstObject('RESPONSE_CFG', {
     headers: {
-      'strict-transport-security': resHeaders.hsts || 'max-age=31536000; includeSubDomains; preload',
-      'x-content-type-options': resHeaders.x_content_type_options || 'nosniff',
-      'referrer-policy': resHeaders.referrer_policy || 'strict-origin-when-cross-origin',
-      'permissions-policy': resHeaders.permissions_policy || 'camera=(), microphone=(), geolocation=()',
+      'strict-transport-security': resHeaders.hsts || DEFAULT_SECURITY_HEADERS['strict-transport-security'],
+      'x-content-type-options': resHeaders.x_content_type_options || DEFAULT_SECURITY_HEADERS['x-content-type-options'],
+      'referrer-policy': resHeaders.referrer_policy || DEFAULT_SECURITY_HEADERS['referrer-policy'],
+      'permissions-policy': resHeaders.permissions_policy || DEFAULT_SECURITY_HEADERS['permissions-policy'],
     },
-    csp_public: resHeaders.csp_public || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';",
-    csp_admin: resHeaders.csp_admin || "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+    csp_public: resHeaders.csp_public || DEFAULT_CSP_PUBLIC,
+    csp_admin: resHeaders.csp_admin || DEFAULT_CSP_ADMIN,
     csp_report_only: resHeaders.csp_report_only || '',
     csp_report_uri: resHeaders.csp_report_uri || '',
     csp_nonce: resHeaders.csp_nonce === true,
@@ -785,7 +802,7 @@ function build(policy: any, options: any = {}) {
     clearSiteDataPaths: normalizeStringList(resHeaders.clear_site_data_paths, 'preserve', { trim: false }),
     clearSiteDataTypes: Array.isArray(resHeaders.clear_site_data_types) && resHeaders.clear_site_data_types.length > 0
       ? resHeaders.clear_site_data_types
-      : ['cache', 'cookies', 'storage'],
+      : DEFAULT_CLEAR_SITE_DATA_TYPES,
     cors: resHeaders.cors || null,
     cookie_attributes: resHeaders.cookie_attributes || null,
   });
@@ -810,7 +827,12 @@ function build(policy: any, options: any = {}) {
       ? gate.allowed_algorithms.filter((a: any) => typeof a === 'string' && a !== 'none' && a === algorithm)
       : null;
     const allowedAlgorithms = userAllowed && userAllowed.length > 0 ? userAllowed : [algorithm];
-    const clockSkewSec = clampNumber(gate.clock_skew_sec, 0, 600, 30);
+    const clockSkewSec = clampNumber(
+      gate.clock_skew_sec,
+      JWT_CLOCK_SKEW.min,
+      JWT_CLOCK_SKEW.max,
+      JWT_CLOCK_SKEW.defaultSec,
+    );
     return {
       name: g.name,
       protectedPrefixes: g.protectedPrefixes,
@@ -845,15 +867,25 @@ function build(policy: any, options: any = {}) {
 
   const originAuth = (policy.origin || {}).auth || null;
   const jwksGlobal = (policy.firewall || {}).jwks || {};
-  const jwksStaleIfError = clampNumber(jwksGlobal.stale_if_error_sec, 0, 86400, 3600);
-  const jwksNegativeCache = clampNumber(jwksGlobal.negative_cache_sec, 0, 600, 60);
+  const jwksStaleIfError = clampNumber(
+    jwksGlobal.stale_if_error_sec,
+    0,
+    JWKS_DEFAULTS.staleMax,
+    JWKS_DEFAULTS.staleIfErrorSec,
+  );
+  const jwksNegativeCache = clampNumber(
+    jwksGlobal.negative_cache_sec,
+    0,
+    JWKS_DEFAULTS.negativeMax,
+    JWKS_DEFAULTS.negativeCacheSec,
+  );
 
   const obsCfgOrigin = buildObsConfig(policy);
 
   const originCfgCode = renderConstObject('CFG', {
     project: policy.project || 'cdn-security',
     mode: defaults.mode || 'enforce',
-    maxHeaderSize: numberOr(limits.max_header_size, 0),
+    maxHeaderSize: numberOr(limits.max_header_size, LIMITS_DEFAULTS.maxHeaderSize),
     trustForwardedFor,
     jwtGates,
     signedUrlGates,

--- a/src/scripts/lib/policy-defaults.ts
+++ b/src/scripts/lib/policy-defaults.ts
@@ -1,0 +1,58 @@
+// Runtime compiler defaults only. The guided CLI init template stays separate
+// until maintainers decide whether sample policies should mirror these values.
+export const DEFAULT_UA_DENY_CONTAINS = Object.freeze([
+  'sqlmap',
+  'nikto',
+  'acunetix',
+  'masscan',
+  'python-requests',
+] as const);
+
+export const DEFAULT_DROP_QUERY_KEYS = Object.freeze([
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'gclid',
+  'fbclid',
+] as const);
+
+export const DEFAULT_ADMIN_PATH_PREFIXES = Object.freeze(['/admin', '/docs', '/swagger'] as const);
+export const DEFAULT_ALLOW_METHODS = Object.freeze(['GET', 'HEAD', 'POST'] as const);
+export const DEFAULT_REQUIRED_HEADERS = Object.freeze(['user-agent'] as const);
+
+export const DEFAULT_CSP_PUBLIC = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self';";
+export const DEFAULT_CSP_ADMIN = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
+
+export const DEFAULT_SECURITY_HEADERS = Object.freeze({
+  'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options': 'nosniff',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'permissions-policy': 'camera=(), microphone=(), geolocation=()',
+} as const);
+
+export const LIMITS_DEFAULTS = Object.freeze({
+  maxQueryLength: 1024,
+  maxQueryParams: 30,
+  maxUriLength: 2048,
+  maxHeaderSize: 0,
+  maxHeaderCount: 64,
+  headerCountMin: 1,
+  headerCountMax: 500,
+} as const);
+
+export const JWKS_DEFAULTS = Object.freeze({
+  staleIfErrorSec: 3600,
+  staleMax: 86400,
+  negativeCacheSec: 60,
+  negativeMax: 600,
+} as const);
+
+export const JWT_CLOCK_SKEW = Object.freeze({
+  defaultSec: 30,
+  min: 0,
+  max: 600,
+} as const);
+
+export const DEFAULT_CLEAR_SITE_DATA_TYPES = Object.freeze(['cache', 'cookies', 'storage'] as const);


### PR DESCRIPTION
Closes #184.

## Problem

The AWS and Cloudflare compiler paths carried the same runtime policy defaults in multiple places: user-agent deny strings, dropped query keys, default methods/headers, response security headers, CSP fallbacks, JWT clock skew, JWKS cache bounds, admin path prefixes, and Clear-Site-Data defaults. That made drift between targets easy to introduce during future security maintenance.

## Implementation

Implementation skill used: `gemini-rescue` with `gemini-3.1-pro-preview` was invoked for this run. The first Gemini task failed because the Gemini CLI did not trust the workspace; after enabling the headless trust setting, Gemini reviewed the current write-capable implementation and reported no required changes. `opencode-rescue` was present in local files but was not exposed as a callable sub-agent role in this Codex session.

Code changes:

- Added `src/scripts/lib/policy-defaults.ts` as the single runtime-default module with frozen `as const` arrays/objects.
- Updated `src/scripts/lib/compile-core.ts` and `src/scripts/compile-cloudflare.ts` to read shared defaults instead of duplicating literals.
- Preserved generated runtime output behavior; default arrays that may be exposed to mutable downstream code are spread before assignment.
- Added focused unit coverage asserting the default values and immutability contract.
- Regenerated checked-in JS and `.d.ts` artifacts with `npm run build:ts`.

## Behavior Change

No generated runtime behavior should change. `npm run test:drift` passed with no drift across base, profiles, archetypes, and parity docs.

## Verification

- `npm ci`
- `npm run build:ts`
- `node scripts/compile-unit-tests.js`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:drift`
- `npm run test:unit`
- `npm run typecheck`
- `EDGE_ADMIN_TOKEN=ci-build-token-not-for-deploy ORIGIN_SECRET=ci-origin-secret-not-for-deploy npm run test:ci`
- `git diff --check`

## Codex Review Result

Reviewed the full diff for correctness, generated-artifact sync, test adequacy, behavior drift, security regressions, API/contract drift, and maintainability. Result: no blocking findings. The refactor keeps public behavior stable and improves OSS maintainability by making target-wide security defaults auditable in one module.

## Remaining Risk / Follow-up

The guided CLI init template still intentionally remains separate from runtime defaults. I added an issue comment asking whether sample policies should mirror runtime defaults exactly or stay opinionated as starter templates.
