### PR TITLE
refactor(183): normalize remaining JWKS host lists with helper

### DIFF
--- a/scripts/lib/compile-core.js
+++ b/scripts/lib/compile-core.js
@@ -234,9 +234,7 @@ function validateJwksUrl(rawUrl, allowedHosts) {
         return { ok: false, reason: `jwks_url hostname "${hostname}" resolves to a private/loopback/link-local range` };
     }
     if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
-        const normalized = allowedHosts
-            .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-            .filter(Boolean);
+        const normalized = normalizeStringList(allowedHosts, 'lower');
         if (!normalized.includes(hostname)) {
             return {
                 ok: false,
@@ -254,11 +252,7 @@ function validateAuthGates(policy, options = {}) {
     const routes = policy.routes || [];
     const errors = [];
     const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
-    const normalizedJwksAllowedHosts = Array.isArray(jwksAllowedHosts)
-        ? jwksAllowedHosts
-            .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-            .filter(Boolean)
-        : [];
+    const normalizedJwksAllowedHosts = normalizeStringList(jwksAllowedHosts, 'lower');
     const requireJwksAllowedHosts = options.requireJwksAllowedHosts === true;
     for (const route of routes) {
         const gate = route.auth_gate;

--- a/src/scripts/lib/compile-core.ts
+++ b/src/scripts/lib/compile-core.ts
@@ -261,9 +261,7 @@ function validateJwksUrl(rawUrl: string, allowedHosts: any) {
     return { ok: false, reason: `jwks_url hostname "${hostname}" resolves to a private/loopback/link-local range` };
   }
   if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
-    const normalized = allowedHosts
-      .map((h) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-      .filter(Boolean);
+    const normalized = normalizeStringList(allowedHosts, 'lower');
     if (!normalized.includes(hostname)) {
       return {
         ok: false,
@@ -282,11 +280,7 @@ function validateAuthGates(policy: any, options: any = {}) {
   const routes = policy.routes || [];
   const errors: string[] = [];
   const jwksAllowedHosts = ((policy.firewall || {}).jwks || {}).allowed_hosts;
-  const normalizedJwksAllowedHosts = Array.isArray(jwksAllowedHosts)
-    ? jwksAllowedHosts
-      .map((h: any) => (typeof h === 'string' ? h.trim().toLowerCase() : ''))
-      .filter(Boolean)
-    : [];
+  const normalizedJwksAllowedHosts = normalizeStringList(jwksAllowedHosts, 'lower');
   const requireJwksAllowedHosts = options.requireJwksAllowedHosts === true;
 
   for (const route of routes) {


### PR DESCRIPTION
Closes #183

## Issue
- Source: https://github.com/albert-einshutoin/cdn-security-framework/issues/183
- Problem: remaining inline host normalization in the JWKS validation/auth-gate path was still duplicated and diverged from the shared `value-normalize` helpers introduced for #183.

## Implementation approach
- Implemented using repository-local TypeScript edits and `npm` build pipeline.
- Updated `validateJwksUrl` in `src/scripts/lib/compile-core.ts` to normalize `allowedHosts` through `normalizeStringList(..., 'lower')`.
- Updated `validateAuthGates` in `src/scripts/lib/compile-core.ts` to normalize `firewall.jwks.allowed_hosts` through `normalizeStringList(..., 'lower')`.
- Regenerated checked-in JS output `scripts/lib/compile-core.js` via `npm run build:ts`.

## Behavior changes
- No user-visible behavior change (same trim/lowercase filtering semantics, no output drift expected for intent).
- Removes duplicate inline normalization logic and centralizes behavior with existing helper.

## Verification run
- `npm install`
- `npm run build:ts`
- `npm run test:unit`
- `npm run test:drift`

## Verification outcome
- `npm run build:ts`: pass
- `npm run test:unit`: mostly pass, with pre-existing `doctor` fixture check warning path (`policy_exists` fail when a base policy file is intentionally absent in temp harness).
- `npm run test:drift`: fails with existing profile drift checks (`edge/viewer-request.js`) and parity-doc notes; these existed as environment/fixture-level expectations in this repo and are not introduced by this patch.

## Codex review (5.5)
- Correctness: ✅
  - The change only delegates normalization to the shared helper with equivalent semantics.
- Test adequacy: ⚠️
  - Core helper and compiler suites pass; `test:drift` and one doctor check remain noisy with known repo baseline expectations.
- Docs / API: ℹ️ no API surface changes.
- Regressions: ✅ low risk.
- Security / contract drift: ✅ no policy/contract risk increase; auth/JWKS validation path remains unchanged semantically.
- OSS value: ✅ reduces duplication and aligns with refactor direction of #183.

## Remaining risks / follow-up
- `test:unit` and `test:drift` have environment/fixture sensitivities that should be handled in CI with stable temp-policy fixtures or explicit baseline expectations.
