### PR TITLE
test: guard visualize no-control class directive regression for #181

### DIFF
--- a/scripts/programmatic-api-unit-tests.js
+++ b/scripts/programmatic-api-unit-tests.js
@@ -242,6 +242,10 @@ firewall:
     managed_rules:
       - AWSManagedRulesCommonRuleSet
 `;
+const VISUALIZE_NO_CONTROL_POLICY = `
+version: 1
+project: visualize-no-control-test
+`;
 const POLICY_YAML_SCHEMA_HINT_SECURITY = '# yaml-language-server: $schema=./schema.json';
 const POLICY_YAML_SCHEMA_HINT_PROFILE = '# yaml-language-server: $schema=../schema.json';
 function assertPolicySchemaHint(raw, expectedHint) {
@@ -966,6 +970,32 @@ test('CLI authoring DX: visualize emits mermaid with control coverage', () => {
         assert.ok(result.stdout.includes('request.graphql_guard'));
         assert.ok(result.stdout.includes('response_dlp'));
         assert.ok(result.stdout.includes('(monitor)'));
+        const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
+        const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
+        assert.strictEqual(baseClassDirectiveCount, 1);
+    }
+    finally {
+        ctx.cleanup();
+    }
+});
+test('CLI authoring DX: visualize emits single base class directive without controls', () => {
+    const ctx = tmpProject(VISUALIZE_NO_CONTROL_POLICY);
+    try {
+        const { spawnSync } = require('child_process');
+        const cli = path.join(repoRoot, 'bin', 'cli.js');
+        const result = spawnSync(process.execPath, [
+            cli, 'visualize',
+            '--policy', ctx.policyPath,
+            '--target', 'aws',
+        ], {
+            cwd: ctx.tmp,
+            encoding: 'utf8',
+            env: process.env,
+        });
+        assert.strictEqual(result.status, 0, `visualize failed: ${result.stderr}`);
+        assert.ok(result.stdout.includes('%% target: aws'));
+        assert.ok(result.stdout.includes('note_no_controls'));
+        assert.ok(result.stdout.includes('No configured control blocks were detected'));
         const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
         const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
         assert.strictEqual(baseClassDirectiveCount, 1);

--- a/src/scripts/programmatic-api-unit-tests.ts
+++ b/src/scripts/programmatic-api-unit-tests.ts
@@ -253,6 +253,11 @@ firewall:
       - AWSManagedRulesCommonRuleSet
 `;
 
+const VISUALIZE_NO_CONTROL_POLICY = `
+version: 1
+project: visualize-no-control-test
+`;
+
 const POLICY_YAML_SCHEMA_HINT_SECURITY = '# yaml-language-server: $schema=./schema.json';
 const POLICY_YAML_SCHEMA_HINT_PROFILE = '# yaml-language-server: $schema=../schema.json';
 
@@ -1014,6 +1019,32 @@ test('CLI authoring DX: visualize emits mermaid with control coverage', () => {
     assert.ok(result.stdout.includes('request.graphql_guard'));
     assert.ok(result.stdout.includes('response_dlp'));
     assert.ok(result.stdout.includes('(monitor)'));
+    const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
+    const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
+    assert.strictEqual(baseClassDirectiveCount, 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('CLI authoring DX: visualize emits single base class directive without controls', () => {
+  const ctx = tmpProject(VISUALIZE_NO_CONTROL_POLICY);
+  try {
+    const { spawnSync } = require('child_process');
+    const cli = path.join(repoRoot, 'bin', 'cli.js');
+    const result: any = spawnSync(process.execPath, [
+      cli, 'visualize',
+      '--policy', ctx.policyPath,
+      '--target', 'aws',
+    ], {
+      cwd: ctx.tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+    assert.strictEqual(result.status, 0, `visualize failed: ${result.stderr}`);
+    assert.ok(result.stdout.includes('%% target: aws'));
+    assert.ok(result.stdout.includes('note_no_controls'));
+    assert.ok(result.stdout.includes('No configured control blocks were detected'));
     const baseClassDirective = 'class policy,edge,waf,origin,response enforce';
     const baseClassDirectiveCount = result.stdout.split(baseClassDirective).length - 1;
     assert.strictEqual(baseClassDirectiveCount, 1);


### PR DESCRIPTION
## Problem reported
- Issue #181 reports duplicate Mermaid class directive output in `renderPolicyVisualization` (dead `if/else`).
- Existing behavior already had the duplicate removed in code, but there was no focused regression coverage for the no-controls branch.

## Implementation summary
- Code changes are in `src/scripts/programmatic-api-unit-tests.ts` and generated `scripts/programmatic-api-unit-tests.js`.
- Added a new fixture `VISUALIZE_NO_CONTROL_POLICY` and new test:
  - `CLI authoring DX: visualize emits single base class directive without controls`
- Added assertions that output includes:
  - `%% target: aws`
  - `note_no_controls` marker
  - exactly one `class policy,edge,waf,origin,response enforce` occurrence.

## Behavior after PR
- `cdn-security visualize --policy <minimal policy> --target aws` is now explicitly guarded against class-directive regressions in the controls-none path.
- Existing control-path test coverage remains unchanged.

## Implementation workflow / skills
- Requested implementation skilling (opencode-rescue/gemini-rescue) was not available in this execution environment, so this was implemented directly in-repo.

## Verification
- `npm install`
- `npm run build:ts`
- `node scripts/programmatic-api-unit-tests.js`

## Codex 5.5 xhigh review
- Correctness: high (test directly exercises the specific regression path).
- Test adequacy: improved via explicit no-controls coverage.
- Docs: unchanged (already covered in existing tests and command output references).
- Regressions: low risk; no runtime behavior code paths changed.
- Security/contract: unchanged.
- Maintainability/OSS value: stronger CI-level regression gate for a known fragility.

## Follow-up / risks
- `doctor` checks include a pre-existing environment-dependent fail (`policy_exists`) in `test:unit` output in this environment.
- If maintainers want strict linkage of every issue narrative to changed code, they may prefer to also close Issue #181 since code path fix is already present.
