### PR TITLE
[#239] Document missing CLI subcommands

### DIFF
--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -248,6 +248,20 @@ npx cdn-security deploy-template --out-dir .github/workflows --force
 
 template は `EDGE_ADMIN_TOKEN`、`BASIC_AUTH_CREDS`、`URL_SIGNING_SECRET`、`JWT_SECRET`、`ORIGIN_SECRET`、`CHALLENGE_SECRET`、`CLOUDFLARE_API_TOKEN`、`CLOUDFLARE_ACCOUNT_ID` などの GitHub Secrets 名だけを参照し、secret 値は含みません。Cloudflare で policy が追加の `*_env` 名を使う場合は `CDN_SECURITY_WORKER_SECRET_NAMES` を拡張してください。既存ファイルは `--force` を付けない限り上書きしません。
 
+フラグ:
+
+- `-o, --out-dir <dir>` — workflow の出力ディレクトリ（デフォルト `.github/workflows`）
+- `-t, --target <aws|cloudflare|all>` — 生成する template（デフォルト `all`）
+- `-f, --force` — 既存 workflow ファイルを上書き
+
+出力:
+
+- `--target` が `aws` または `all` のとき `<out-dir>/cdn-security-aws.yml`
+- `--target` が `cloudflare` または `all` のとき `<out-dir>/cdn-security-cloudflare.yml`
+- 書き込んだファイルごとに `[SUCCESS] Generated <path>`
+
+成功時は exit `0` です。無効な `--target`、または `--force` なしで既存ファイルがある場合は exit `1` です。上書き拒否時は部分書き込みは行われません。
+
 ## `explain`
 
 ```bash
@@ -274,6 +288,20 @@ npx cdn-security visualize --policy policy/security.yml --target cloudflare --fo
 
 `--format mermaid` は標準出力へ Mermaid テキストを出すため、CI でブラウザランタイム不要です。`--format html` は同じ図を静的 HTML にし、ブラウザ閲覧時に mermaid を描画します。
 
+フラグ:
+
+- `-p, --policy <path>` — ポリシーパス（デフォルト `policy/security.yml` → `policy/base.yml`）
+- `-t, --target <aws|cloudflare|all>` — 制御の対象 target（デフォルト `all`）
+- `--format <mermaid|html>` — 出力形式（デフォルト `mermaid`）
+- `-o, --out <path>` — 標準出力の代わりにファイルへ書き出す
+
+出力:
+
+- `--out` なし: Mermaid または HTML を標準出力へ出力
+- `--out` あり: 指定パスへ artifact を書き出し、`[SUCCESS] Wrote visualization to <path>` を表示
+
+成功時は exit `0` です。無効な `--target` / `--format`、ポリシー未存在、描画エラーは exit `1` です。
+
 ## `diff`
 
 ```bash
@@ -298,6 +326,22 @@ npx cdn-security diff --semantic --baseline policy/security.previous.yml --polic
 ```bash
 npx cdn-security migrate              # ドライラン
 npx cdn-security migrate --to 1       # v1 の場合は no-op
+npx cdn-security migrate --policy policy/security.yml --to 1 --write
 ```
+
+ポリシーファイルのスキーマバージョンを検査または移行します。現状は v1 のみが出荷されているため、v1 → v1 は将来の migration path が登録されるまで読み取り専用の no-op です。
+
+フラグ:
+
+- `-p, --policy <path>` — 検査対象のポリシー（デフォルト `policy/security.yml`）
+- `--to <version>` — 移行先スキーマバージョン（デフォルト `1`）
+- `--write` — migration path が存在するとき、移行結果をその場で書き戻す
+
+出力:
+
+- ポリシーパスと現在/移行先スキーマバージョンを示す `[INFO]` 行
+- 移行不要時は `[OK] Already at target version — no migration needed.`
+
+移行先に既に到達している場合は exit `0` です。パースエラー、`version` 欠落、ダウングレード、その他の検証失敗は exit `1` です。この CLI に未登録の前方 migration は exit `2`（CLI のアップグレードが必要なケース用の予約コード）です。
 
 スキーマの SemVer 契約と非推奨ウィンドウについては [schema-migration.ja.md](./schema-migration.ja.md) を参照してください。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -249,6 +249,20 @@ Writes starter GitHub Actions workflows for generated edge and infra artifacts. 
 
 The templates reference GitHub Secrets such as `EDGE_ADMIN_TOKEN`, `BASIC_AUTH_CREDS`, `URL_SIGNING_SECRET`, `JWT_SECRET`, `ORIGIN_SECRET`, `CHALLENGE_SECRET`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID`; they never include secret values. For Cloudflare, extend `CDN_SECURITY_WORKER_SECRET_NAMES` when your policy uses additional `*_env` names. Existing files are not overwritten unless `--force` is provided.
 
+Flags:
+
+- `-o, --out-dir <dir>` — workflow output directory (default `.github/workflows`)
+- `-t, --target <aws|cloudflare|all>` — which templates to emit (default `all`)
+- `-f, --force` — overwrite existing workflow files
+
+Outputs:
+
+- `<out-dir>/cdn-security-aws.yml` when `--target` is `aws` or `all`
+- `<out-dir>/cdn-security-cloudflare.yml` when `--target` is `cloudflare` or `all`
+- `[SUCCESS] Generated <path>` per written file
+
+Exit code is `0` on success. Invalid `--target`, or an existing target file without `--force`, exits `1`. When overwrite is refused, no partial writes occur.
+
 ## `explain`
 
 ```bash
@@ -275,6 +289,20 @@ Generates a deterministic policy control visualization by policy section and con
 
 `--format mermaid` prints Mermaid flowchart text to stdout, which is CI-friendly because it requires no browser runtime. Use `--format html` to generate a static HTML artifact that renders the same Mermaid diagram when opened in a browser.
 
+Flags:
+
+- `-p, --policy <path>` — policy file (default `policy/security.yml` → `policy/base.yml`)
+- `-t, --target <aws|cloudflare|all>` — control behavior scope (default `all`)
+- `--format <mermaid|html>` — output format (default `mermaid`)
+- `-o, --out <path>` — write rendered output to file instead of stdout
+
+Outputs:
+
+- Without `--out`: prints Mermaid or HTML to stdout
+- With `--out`: writes the artifact to the given path and prints `[SUCCESS] Wrote visualization to <path>`
+
+Exit code is `0` on success. Invalid `--target` or `--format`, a missing policy file, or a render error exits `1`.
+
 ## `diff`
 
 ```bash
@@ -299,6 +327,22 @@ With `--semantic`, `diff` compares two policy files and reports posture changes 
 ```bash
 npx cdn-security migrate              # dry-run inspection
 npx cdn-security migrate --to 1       # no-op on v1
+npx cdn-security migrate --policy policy/security.yml --to 1 --write
 ```
+
+Inspects or migrates a policy file between schema versions. v1 is the only shipped schema today, so v1 → v1 is a read-only no-op unless a future migration path is registered.
+
+Flags:
+
+- `-p, --policy <path>` — policy file to inspect (default `policy/security.yml`)
+- `--to <version>` — target schema version (default `1`)
+- `--write` — write migrated content back in place when a migration path exists
+
+Outputs:
+
+- `[INFO]` lines with policy path and current/target schema versions
+- `[OK] Already at target version — no migration needed.` when no migration is required
+
+Exit code is `0` when the policy is already at the target version. Parse errors, missing `version`, downgrades, and other validation failures exit `1`. A forward migration to a version with no registered path in this CLI exits `2` (reserved for "upgrade CLI first").
 
 See [schema-migration.md](./schema-migration.md) for the schema SemVer contract and deprecation window.


### PR DESCRIPTION
## Summary

<!-- takt-product-issue -->

## Summary
`docs/cli.md` and `docs/cli.ja.md` list `visualize`, `deploy-template`, and `migrate` in the subcommand table, but they do not have dedicated reference sections like `build`, `doctor`, and `readiness`.

## Acceptance criteria
- Add concise per-command sections for `visualize`, `deploy-template`, and `migrate` in both English and Japanese CLI docs.
- Include purpose, common examples, key options, outputs, and expected exit-code behavior where applicable.
- Keep English text in `docs/cli.md` and Japanese text in `docs/cli.ja.md`.
- Do not change CLI behavior.

## Verification commands
```bash
npm run typecheck
npm run test:unit
```

## Execution Report

Workflow `.takt/workflows/subscription-devloop.yaml` completed successfully.

Closes #239