### PR TITLE
[#243] decision matrix に Cloudflare Workers JS challenge を追加する

### DIFF
--- a/docs/decision-matrix.ja.md
+++ b/docs/decision-matrix.ja.md
@@ -32,6 +32,7 @@
 | セキュリティヘッダー付与 | ✓ | — | Edge: レスポンス書き換え。 |
 | OWASP CRS / ボディの SQLi, XSS | — | ✓ | WAF マネージドルール。 |
 | CAPTCHA / チャレンジ | — | ✓ | WAF / Bot Management。 |
+| 軽量 JS challenge / PoW | ✓（Cloudflare Workers のみ） | — | `firewall.challenge` による Edge 専用。CAPTCHA や Bot Management とは別物。AWS CloudFront Functions / Lambda@Edge: unsupported warning。詳細は [edge-js-challenge](./edge-js-challenge.ja.md)。 |
 | Geo / ASN ブロック | 任意（Workers） | ✓ | WAF の方が容易なことが多い。 |
 | DDoS 対策 | — | ✓ | CDN + Shield / WAF。 |
 

--- a/docs/decision-matrix.md
+++ b/docs/decision-matrix.md
@@ -32,6 +32,7 @@ Use this matrix to decide whether a control belongs in **Edge** (CloudFront Func
 | Security header injection | ✓ | — | Edge: response rewrite. |
 | OWASP CRS / SQLi, XSS in body | — | ✓ | WAF managed rules. |
 | CAPTCHA / challenge | — | ✓ | WAF / Bot Management. |
+| Lightweight JS challenge / PoW | ✓ (Cloudflare Workers only) | — | Edge-only via `firewall.challenge`; not CAPTCHA or Bot Management. AWS CloudFront Functions / Lambda@Edge: unsupported warning. See [edge-js-challenge](./edge-js-challenge.md). |
 | Geo / ASN block | Optional (Workers) | ✓ | WAF often easier. |
 | DDoS mitigation | — | ✓ | CDN + Shield / WAF. |
 

--- a/docs/edge-js-challenge.ja.md
+++ b/docs/edge-js-challenge.ja.md
@@ -2,6 +2,8 @@
 
 `firewall.challenge` は、Cloudflare Workers 専用の opt-in experimental JavaScript challenge / lightweight proof-of-work 機能です。疑わしいブラウザ風トラフィックに軽い摩擦を与えるためのもので、CAPTCHA や本格的な bot management の代替ではありません。
 
+Edge と WAF の切り分けは [判断マトリクス](./decision-matrix.ja.md) を参照してください。
+
 ```yaml
 firewall:
   challenge:

--- a/docs/edge-js-challenge.md
+++ b/docs/edge-js-challenge.md
@@ -2,6 +2,8 @@
 
 `firewall.challenge` is an opt-in, experimental Cloudflare Workers-only JavaScript challenge with a lightweight proof-of-work check. It is intended as low-cost friction for suspicious browser-shaped traffic, not as a CAPTCHA replacement or a bot-management product.
 
+For Edge vs WAF placement, see [Decision matrix](./decision-matrix.md).
+
 ```yaml
 firewall:
   challenge:


### PR DESCRIPTION
## Summary

<!-- takt-product-issue -->

## 背景
v1.4.0 で `firewall.challenge` が追加されていますが、`docs/decision-matrix.md` / `docs/decision-matrix.ja.md` は bot / automation 検知を WAF 側のみとしており、Cloudflare Workers 限定の軽量 JS challenge / PoW の位置づけが抜けています。

## Acceptance Criteria
- decision matrix に `Lightweight JS challenge / PoW` 相当の行を追加する。
- Edge 側は Cloudflare Workers only、WAF 側は CAPTCHA / Bot Management とは別物であることを明記する。
- `docs/edge-js-challenge.md` と `docs/edge-js-challenge.ja.md` へ相互参照を追加する。
- AWS CloudFront Functions / Lambda@Edge では unsupported warning 対象であることと整合させる。

## Verification Commands
```bash
npm run typecheck
npm run test:unit
rg -n "challenge|PoW|firewall.challenge|edge-js-challenge" docs/decision-matrix.md docs/decision-matrix.ja.md docs/edge-js-challenge.md docs/edge-js-challenge.ja.md
```

## Execution Report

Workflow `.takt/workflows/subscription-devloop.yaml` completed successfully.

Closes #243