### PR TITLE
ci: Commander 15の非互換更新を保留する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    # Commander 15 requires Node >=22.12 while this package supports >=20.17.
     # c8 12 requires Node >=20.19 while this package supports >=20.17.
     # TypeScript 7 removes compiler options still required by this project.
     ignore:
+      - dependency-name: "commander"
+        versions: [">=15.0.0"]
       - dependency-name: "c8"
         versions: [">=12.0.0"]
       - dependency-name: "typescript"


### PR DESCRIPTION
## 背景

Dependabot PR #261 がCommander 14.0.3から15.0.0への更新を提案しましたが、Commander 15はNode >=22.12.0かつESM-onlyです。本パッケージはNode >=20.17.0を公開サポートし、20.17.0をCIマトリクスでも検証しています。

engine-strictが無効なnpm installが成功しても、Node 20利用者へ対応外依存を配布するため採用できません。Commander 14は2027年5月までsecurity maintenance対象なので、Node最小要件を計画的に引き上げるまでは14系を維持します。

## 変更

- Dependabotでcommander >=15.0.0を無視
- 既存のc8 12 / TypeScript 7保留条件は維持

## 検証

- Ruby YAML parserで.github/dependabot.ymlの構文確認
- git diff --check成功

Follow-up to #261